### PR TITLE
Add _GO_USE_MODULES for optional modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,17 @@ Your project structure may look something like this:
 
 ```
 project/
-  go - main go script
-  scripts/ - project scripts
+  go - main ./go script
+  scripts/ - project ./go command scripts
+    lib/ - project-specific Bash library modules (see "Modules" section)
     plugins/ - (optional) third-party command scripts (see `./go help plugins`)
+      .../
+        bin/ - plugin ./go command scripts
+        lib/ - optional Bash library modules (see "Modules" section)
     go-script-bash/
       go-core.bash - top-level functions
-      lib/ - utility functions
-      libexec/ - builtin subcommands
+      lib/ - optional Bash library modules (see "Modules" section)
+      libexec/ - builtin ./go command scripts
 ```
 
 This structure implies that the first line of your `./go` script will be:
@@ -294,6 +298,8 @@ commands.
 There are a number of possible methods available for sharing code between
 command scripts. Some possibilities are:
 
+- The generally preferred method is to use `. $_GO_USE_MODULES` to source
+  optional library modules; see the [Modules](#modules) section.
 - Include common code and constants in the top-level `./go` script, after
   sourcing `go-core.bash` and before calling `@go`.
 - Source a file in the same directory that isn't executable.
@@ -325,6 +331,19 @@ exported and available to scripts in all languages.
 
 You can add third-party plugin command scripts to the `plugins` subdirectory of
 your scripts directory. Run `./go help plugins` for more information.
+
+#### Modules
+
+You can import optional Bash library code from the core framework, third-party
+plugins, or your own project's scripts directory by sourcing the
+`$_GO_USE_MODULES` script. For example, to import the core logging utilities:
+
+```bash
+. $_GO_USE_MODULES 'log'
+```
+
+See the header comment in [lib/internal/use](lib/internal/use) for more
+information.
 
 ### Feedback and contributions
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -14,8 +14,10 @@
 #   @go "$@"
 #
 # where "${0%/*}" produces the path to the project's root directory,
-# "go-core.bash" is the path to this file, and "scripts" is the path to the
-# directory holding the project's command scripts relative to the project root.
+# "/go-core.bash" is the relative path to this file, and "scripts" is the
+# relative path from the project root to the command script directory.
+#
+# See README.md for details about other available features.
 #
 # Inspired by:
 # - "In Praise of the ./go Script: Parts I and II" by Pete Hodgson
@@ -52,6 +54,21 @@ unset __go_orig_dir
 # Path to the ./go script framework's directory
 declare -r _GO_CORE_DIR="$PWD"
 cd "$_GO_ROOTDIR" || exit 1
+
+# Path to the script used to import optional library modules.
+#
+# After sourcing go-core.bash, your `./go` script, Bash command scripts, and
+# individual Bash functions can then import optional Bash library modules from
+# the core framework, from installed plugins, and from your scripts directory
+# like so:
+#
+#   . $_GO_USE_MODULES 'log'
+#
+# See the header comment from lib/internal/use for more information.
+declare -r _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
+
+# Array of modules imported via _GO_USE_MODULES
+declare _GO_IMPORTED_MODULES=()
 
 # Path to the project's script directory
 declare _GO_SCRIPTS_DIR=
@@ -208,4 +225,3 @@ elif [[ -z "$COLUMNS" ]]; then
   fi
   export COLUMNS
 fi
-

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -1,0 +1,80 @@
+#! /bin/bash
+#
+# Imports optional Bash library modules
+#
+# Usage:
+#   .  $_GO_USE_MODULES <module> [<module>...]
+#
+# Where:
+#   <module>  The name of an optional Bash library module
+#
+# After sourcing `go-core.bash`, you can source the `_GO_USE_MODULES` script to
+# import optional library code from the core framework, from plugins, or from
+# your scripts directory. You can invoke `_GO_USE_MODULES` in your `./go`
+# script, making the module code available to all your Bash command scripts, or
+# use it in specfic Bash command scripts or Bash functions.
+#
+# This aims to be a convenient, flexible, standard, and self-documenting means
+# of reusing Bash library code that incurs no overhead if such functionality
+# isn't required by a project, just like other modern programming languages. In
+# so doing, it aims to promote the development of modular, robust, and
+# well-tested core framework extensions and other plugins without bloating
+# project scripts that have no use for the extra functionality.
+#
+# For example, the core framework logging module `lib/log` is not sourced
+# automatically by `go-core.bash`, so that scripts that don't make use of it
+# will not incur the penalty of loading that code.  However, scripts that do
+# make use of it need only invoke the following command in the `./go` script
+# immediately after sourcing `go-core.bash`, and the core logging interface is
+# then available to the rest of the `./go` script and any command scripts also
+# written in Bash:
+#
+#   . $_GO_USE_MODULES 'log'
+#
+# Alternatively, specific command scripts or individual Bash functions that
+# require the functionality can use `_GO_CORE_MODULES` on an as-needed basis,
+# rather than using it in the top-level `./go` script.
+#
+# The precedence for discovering modules is (with examples from the "Directory
+# structure" example from README.md):
+#
+#   - the `lib/` directory of the framework (`scripts/go-script-bash/lib`)
+#   - the `lib/` directory of installed plugins (`scripts/plugins/*/lib`)
+#   - the `lib/` directory in your project scripts directory (`scripts/lib`)
+#
+# For modules contained in plugin directories, you must specify the path as
+# `<plugin-name>/<module-name>`. There is no need to include the `lib/`
+# component.  For example, if you have a plugin called `foo` and it contains a
+# module file `lib/bar` (installed as `scripts/plugins/foo/lib/bar` in your
+# project repository), you could import the module via:
+#
+#   . $_GO_USE_MODULES 'foo/bar'
+#
+# Module loading is idempotent, as the names of imported modules are added to
+# the `_GO_IMPORTED_MODULES` array and are not sourced again if their names are
+# already in the array.
+
+declare __go_module_name
+declare __go_loaded_module
+
+for __go_module_name in "$@"; do
+  for __go_loaded_module in "${_GO_IMPORTED_MODULES[@]}"; do
+    if [[ "$__go_module_name" == "$__go_loaded_module" ]]; then
+      continue 2
+    fi
+  done
+
+  # Prevent self- and circular importing.
+  _GO_IMPORTED_MODULES+=("$__go_module_name")
+
+  # Convert <plugin>/<module> to _GO_SCRIPTS_DIR/plugins/<plugin>/lib/<module>
+  if ! . "$_GO_CORE_DIR/lib/$__go_module_name" 2>/dev/null &&
+     ! . "$_GO_SCRIPTS_DIR/plugins/${__go_module_name/\///lib/}" 2>/dev/null &&
+     ! . "$_GO_SCRIPTS_DIR/lib/$__go_module_name" 2>/dev/null; then
+    @go.printf "ERROR: Unknown module: $__go_module_name" >&2
+    exit 1
+  fi
+done
+
+unset __go_loaded_module
+unset __go_use_module

--- a/scripts/lib/kcov
+++ b/scripts/lib/kcov
@@ -1,4 +1,12 @@
 #! /bin/bash
+#
+# Builds kcov from scratch on Ubuntu to support Bash test coverage
+#
+# Exports:
+#
+#   run_kcov
+#
+# This will eventually be extracted into a plugin library of its own.
 
 declare -r KCOV_DEV_PACKAGES=(
   'binutils-dev'

--- a/scripts/test
+++ b/scripts/test
@@ -36,7 +36,7 @@ _test_tab_completion() {
 }
 
 _test_coverage() {
-  . 'scripts/lib/kcov'
+  . $_GO_USE_MODULES 'kcov'
   run_kcov "tests/kcov" "tests/coverage" \
     'go,go-core.bash,lib/,libexec/,scripts/' \
     '/tmp,tests/bats/' \

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -4,30 +4,29 @@ load environment
 load assertions
 load script_helper
 
+TEST_MODULES=(
+  "$_GO_ROOTDIR/lib/builtin-test"
+  "$TEST_GO_SCRIPTS_DIR/plugins/test-plugin/lib/plugin-test"
+  "$TEST_GO_SCRIPTS_DIR/lib/project-test"
+)
+IMPORTS=('test-plugin/plugin-test' 'project-test' 'builtin-test')
+EXPECTED=(
+  "plugin-test loaded"
+  "project-test loaded"
+  "builtin-test loaded"
+  "modules: ${IMPORTS[*]}"
+)
+
 setup() {
   create_test_go_script \
     ". \"\$_GO_USE_MODULES\" $*" \
     'echo modules: "${_GO_IMPORTED_MODULES[*]}"'
-
-  readonly TEST_MODULES=(
-    "$_GO_ROOTDIR/lib/builtin-test"
-    "$TEST_GO_SCRIPTS_DIR/plugins/test-plugin/lib/plugin-test"
-    "$TEST_GO_SCRIPTS_DIR/lib/project-test"
-  )
 
   local module
   for module in "${TEST_MODULES[@]}"; do
     mkdir -p "${module%/*}"
     echo "echo '${module##*/}' loaded" > "$module"
   done
-
-  readonly IMPORTS=('test-plugin/plugin-test' 'project-test' 'builtin-test')
-  readonly EXPECTED=(
-    "plugin-test loaded"
-    "project-test loaded"
-    "builtin-test loaded"
-    "modules: ${IMPORTS[*]}"
-  )
 }
 
 teardown() {

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -1,0 +1,76 @@
+#! /usr/bin/env bats
+
+load environment
+load assertions
+load script_helper
+
+setup() {
+  create_test_go_script \
+    ". \"\$_GO_USE_MODULES\" $*" \
+    'echo modules: "${_GO_IMPORTED_MODULES[*]}"'
+
+  readonly TEST_MODULES=(
+    "$_GO_ROOTDIR/lib/builtin-test"
+    "$TEST_GO_SCRIPTS_DIR/plugins/test-plugin/lib/plugin-test"
+    "$TEST_GO_SCRIPTS_DIR/lib/project-test"
+  )
+
+  local module
+  for module in "${TEST_MODULES[@]}"; do
+    mkdir -p "${module%/*}"
+    echo "echo '${module##*/}' loaded" > "$module"
+  done
+
+  readonly IMPORTS=('test-plugin/plugin-test' 'project-test' 'builtin-test')
+  readonly EXPECTED=(
+    "plugin-test loaded"
+    "project-test loaded"
+    "builtin-test loaded"
+    "modules: ${IMPORTS[*]}"
+  )
+}
+
+teardown() {
+  rm -f "${TEST_MODULES[@]}"
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: no modules imported by default" {
+  create_test_go_script 'echo modules: "${_GO_IMPORTED_MODULES[*]}"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'modules: '
+}
+
+@test "$SUITE: does nothing if no modules specified" {
+  run "$TEST_GO_SCRIPT"
+  assert_success 'modules: '
+}
+
+@test "$SUITE: error if nonexistent module specified" {
+  run "$TEST_GO_SCRIPT" 'bogus-test-module'
+  assert_failure 'ERROR: Unknown module: bogus-test-module'
+}
+
+@test "$SUITE: import modules successfully" {
+  run "$TEST_GO_SCRIPT" "${IMPORTS[@]}"
+  local IFS=$'\n'
+  assert_success "${EXPECTED[*]}"
+}
+
+@test "$SUITE: import each module only once" {
+  run "$TEST_GO_SCRIPT" "${IMPORTS[@]}" "${IMPORTS[@]}" "${IMPORTS[@]}"
+  local IFS=$'\n'
+  assert_success "${EXPECTED[*]}"
+}
+
+@test "$SUITE: prevent self, circular, and multiple importing" {
+  local module
+
+  for module in "${TEST_MODULES[@]}"; do
+    echo ". \"\$_GO_USE_MODULES\" ${IMPORTS[@]}" >> "$module"
+  done
+
+  run "$TEST_GO_SCRIPT" "${IMPORTS[@]}"
+  local IFS=$'\n'
+  assert_success "${EXPECTED[*]}"
+}


### PR DESCRIPTION
The next pull request will add the `modules` built-in to help discover, document, and inspect installed and imported modules. The pull request following that will add the `log` module containing standard logging functions.
