### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ more about the formatting rules.
 By evaluating the value of `./go env -` within your shell, all builtin commands
 and aliases provide automatic tab completion of file, directory, and other
 arguments. If an implementation isn't available for your shell (within
-`lib/env/`), it's very easy to add one. Feel free to open an issue or, better
-yet, [send a pull request](#feedback-and-contributions)!
+`lib/internal/env/`), it's very easy to add one. Feel free to open an issue or,
+better yet, [send a pull request](#feedback-and-contributions)!
 
 To learn the API for adding tab completion to your own command scripts, run
 `./go help complete`. You can also learn by reading the scripts for the builtin

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ sometimes deploy) a software project. It is a replacement for READMEs and other
 documents that may become out-of-date, and when maintained properly, should
 provide a cohesive and discoverable interface for common project tasks.
 
+For a five-minute overview of the framework, see [Mike Bland's go-script-bash
+lightning talk at Surge 2016](https://youtu.be/WX1vrLV9mFE?t=39m48s).
+
 ### Table of contents
 
 - [Introduction](#introduction)


### PR DESCRIPTION
Adds a link to my Surge 2016 lightning talk, and fixes the path to `lib/internal/env` for adding shell tab-completion support.