### PR TITLE
Add public modules, minor test tweaks

### DIFF
--- a/lib/complete
+++ b/lib/complete
@@ -1,0 +1,37 @@
+#! /bin/bash
+#
+# Automatic command and argument completion utilities
+#
+# Exports:
+#
+#   @go.complete_remove_completions_already_present
+#     Removes completion values already present in an argument array
+
+# Removes completion values already present in an argument array
+#
+# NOTE: The word being completed should already be removed from the argument
+# array. Save it in a separate variable, remove it from the array, then call
+# this function.
+#
+# Arguments:
+#   $1: Name of the argument array in the caller's scope
+#   $2: Name of the completion value array in the caller's scope
+#   $3: Size of the completion value array
+@go.complete_remove_completions_already_present() {
+  local argv_reference="$1"
+  local completions_reference="$2"
+  local num_completions="$3"
+  local argv_array_reference="$argv_reference[@]"
+  local arg
+  local completion_item_reference
+  local i
+
+  for arg in "${!argv_array_reference}"; do
+    for ((i=0; i != num_completions; ++i)); do
+      completion_item_reference="$completions_reference[$i]"
+      if [[ "${!completion_item_reference}" == "$arg" ]]; then
+        unset "$completions_reference[$i]"
+      fi
+    done
+  done
+}

--- a/lib/format
+++ b/lib/format
@@ -1,0 +1,59 @@
+#! /bin/bash
+#
+# Text formatting utilities
+#
+# Exports:
+#
+#   @go.pad_items
+#     Pads each string in an array to match the length of the longest element
+#
+#   @go.zip_items
+#     Concatenates parallel elements from each input array
+
+# Pads each string in an array to match the length of the longest element
+#
+# Arguments:
+#   $1: Name of the input array in the caller's scope
+# Outputs:
+#   __go_padded_result: The caller-declared array to which results are assigned
+@go.pad_items() {
+  local items_reference=("${1}[@]")
+  local item
+  local padding=''
+  local padding_len=0
+
+  for item in "${!items_reference}"; do
+    while [[ "${#padding}" -lt "${#item}" ]]; do
+      padding+=' '
+    done
+  done
+
+  for item in "${!items_reference}"; do
+    padding_len="$((${#padding} - ${#item}))"
+    __go_padded_result+=("${item}${padding:0:padding_len}")
+  done
+}
+
+# Concatenates parallel elements from each input array
+#
+# Will produce a number of results matching that of the left-hand input array.
+#
+# Arguments:
+#   $1: Name of the left-hand input array in the caller's scope
+#   $2: Name of the right-hand input array in the caller's scope
+#   $3: The string used as a delimiter between elements (defaults to two spaces)
+# Outputs:
+#   __go_zipped_result: The caller-declared array to which results are assigned
+@go.zip_items() {
+  local lhs_array_reference="${1}[@]"
+  local rhs_reference="$2"
+  local delimiter="${3:-  }"
+  local rhs_item_ref
+  local item
+  local i=-1
+
+  for item in "${!lhs_array_reference}"; do
+    rhs_item_ref="${rhs_reference}[$((++i))]"
+    __go_zipped_result+=("${item}${delimiter}${!rhs_item_ref}")
+  done
+}

--- a/scripts/lib/kcov
+++ b/scripts/lib/kcov
@@ -54,6 +54,8 @@ run_kcov() {
   mkdir "$coverage_dir"
   printf 'Starting coverage run:\n  %s\n' "${kcov_argv[*]}"
 
+  # We redirect stderr because all the kcov coverage info will get dumped to the
+  # Travis log otherwise.
   if "${kcov_argv[@]}" 2>/dev/null; then
     if [[ "$send_to_coveralls" == 'false' ]]; then
       @go.printf 'Coverage results located in:\n  %s\n' \

--- a/scripts/test
+++ b/scripts/test
@@ -75,7 +75,7 @@ _test() {
     _test '--coverage' "$@"
   else
     local tests=($(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "$@"))
-    "$BASH" "$bats_path" "${tests[@]}"
+    time "$BASH" "$bats_path" "${tests[@]}"
   fi
 }
 

--- a/tests/complete/remove-completions.bats
+++ b/tests/complete/remove-completions.bats
@@ -1,0 +1,66 @@
+#! /usr/bin/env bats
+
+load ../environment
+load ../assertions
+
+. "$_GO_ROOTDIR/lib/complete"
+
+@test "$SUITE: empty args, empty completions" {
+  local argv=()
+  local completions=()
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal '' "${completions[*]}"
+}
+
+@test "$SUITE: empty args, single completion" {
+  local argv=()
+  local completions=('foo')
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal 'foo' "${completions[*]}"
+}
+
+@test "$SUITE: single arg, no completions" {
+  local argv=('foo')
+  local completions=()
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal '' "${completions[*]}"
+}
+
+@test "$SUITE: single arg remove single matching completion" {
+  local argv=('foo')
+  local completions=('foo')
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal '' "${completions[*]}"
+}
+
+@test "$SUITE: single arg, two completions, remove match" {
+  local argv=('foo/bar')
+  local completions=('foo/bar' 'foo/baz')
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal 'foo/baz' "${completions[*]}"
+}
+
+@test "$SUITE: two args, twos completions, remove both" {
+  local argv=('foo/bar' 'foo/baz')
+  local completions=('foo/bar' 'foo/baz')
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+  assert_equal '' "${completions[*]}"
+}
+
+@test "$SUITE: several args, several completions" {
+  local argv=('foo/bar' 'baz/quux' 'xyzzy/plugh' 'frotz/frobozz')
+  local completions=('foo/bar' 'foo/baz' 'foo/quux' 
+    'frotz' 'frotz/blorple' 'frotz/frobozz')
+  @go.complete_remove_completions_already_present \
+    'argv' 'completions' "${#completions[@]}"
+
+  local expected=('foo/baz' 'foo/quux' 'frotz' 'frotz/blorple')
+  local IFS=$'\n'
+  assert_equal "${expected[*]}" "${completions[*]}"
+}

--- a/tests/format.bats
+++ b/tests/format.bats
@@ -1,0 +1,46 @@
+#! /usr/bin/env bats
+
+load environment
+load assertions
+
+setup() {
+  . 'lib/format'
+}
+
+@test "$SUITE: does nothing for empty argv" {
+  local items=()
+  local __go_padded_result=()
+  @go.pad_items 'items'
+  assert_equal '' "${__go_padded_result[*]}"
+}
+
+@test "$SUITE: pads argv items" {
+  local items=('foo' 'bar' 'baz' 'xyzzy' 'quux')
+  local __go_padded_result=()
+  @go.pad_items 'items'
+
+  local IFS='|'
+  assert_equal 'foo  |bar  |baz  |xyzzy|quux ' "${__go_padded_result[*]}"
+}
+
+@test "$SUITE: zip empty items" {
+  local lhs=()
+  local rhs=()
+  local __go_zipped_result=()
+  @go.zip_items 'lhs' 'rhs' '='
+
+  assert_equal '' "${__go_zipped_result[*]}"
+}
+
+@test "$SUITE: zip matching items" {
+  local lhs=('foo' 'xyzzy' 'quux')
+  local rhs=('bar' 'baz' 'plugh')
+  local __go_zipped_result=()
+  @go.zip_items 'lhs' 'rhs' '='
+
+  local expected=('foo=bar' 'xyzzy=baz' 'quux=plugh')
+  local IFS=$'\n'
+  local indent='    '
+  assert_equal $'\n'"${expected[*]/#/$indent}" \
+    $'\n'"${__go_zipped_result[*]/#/$indent}"
+}

--- a/tests/script_helper.bash
+++ b/tests/script_helper.bash
@@ -8,6 +8,7 @@ TEST_GO_ROOTDIR="$BATS_TMPDIR/test rootdir"
 TEST_GO_SCRIPT="$TEST_GO_ROOTDIR/go"
 TEST_GO_SCRIPTS_RELATIVE_DIR="scripts"
 TEST_GO_SCRIPTS_DIR="$TEST_GO_ROOTDIR/$TEST_GO_SCRIPTS_RELATIVE_DIR"
+TEST_GO_PLUGINS_DIR="$TEST_GO_SCRIPTS_DIR/plugins"
 
 # The FS_MISSING_PERM_SUPPORT variable provides a generic means of determining
 # whether or not to skip certain tests, since the lack of permission support

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -6,7 +6,7 @@ load script_helper
 
 TEST_MODULES=(
   "$_GO_ROOTDIR/lib/builtin-test"
-  "$TEST_GO_SCRIPTS_DIR/plugins/test-plugin/lib/plugin-test"
+  "$TEST_GO_PLUGINS_DIR/test-plugin/lib/plugin-test"
   "$TEST_GO_SCRIPTS_DIR/lib/project-test"
 )
 IMPORTS=('test-plugin/plugin-test' 'project-test' 'builtin-test')


### PR DESCRIPTION
This includes the `format` and `complete` modules, which I'm using to develop the upcoming `modules` builtin command (currently in the `modules-builtin` branch).