### PR TITLE
Add modules builtin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,7 @@ plugins, or your own project's scripts directory by sourcing the
 . $_GO_USE_MODULES 'log'
 ```
 
-See the header comment in [lib/internal/use](lib/internal/use) for more
-information.
+Run `./go help modules` and `./go modules help` for more information.
 
 ### Feedback and contributions
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ plugins, or your own project's scripts directory by sourcing the
 . $_GO_USE_MODULES 'log'
 ```
 
-Run `./go help modules` and `./go modules help` for more information.
+Run `./go help modules` and `./go modules --help` for more information.
 
 ### Feedback and contributions
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -62,9 +62,9 @@ cd "$_GO_ROOTDIR" || exit 1
 # the core framework, from installed plugins, and from your scripts directory
 # like so:
 #
-#   . $_GO_USE_MODULES 'log'
+#   . "$_GO_USE_MODULES" 'log'
 #
-# See the header comment from lib/internal/use for more information.
+# See `./go modules --help` for more information.
 declare -r _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
 
 # Array of modules imported via _GO_USE_MODULES

--- a/lib/internal/command_descriptions
+++ b/lib/internal/command_descriptions
@@ -91,7 +91,10 @@ _@go.command_summary() {
     fi
   done < "$cmd_path"
 
-  if [[ -z "$__go_cmd_desc" ]]; then
+  if [[ "$?" -ne '0' ]]; then
+    echo "ERROR: problem reading $cmd_path" >&2
+    return 1
+  elif [[ -z "$__go_cmd_desc" ]]; then
     __go_cmd_desc='No description available'
   fi
 }
@@ -153,7 +156,10 @@ _@go.command_description() {
     fi
   done < "$cmd_path"
 
-  if [[ -z "$__go_cmd_desc" ]]; then
+  if [[ "$?" -ne '0' ]]; then
+    echo "ERROR: problem reading $cmd_path" >&2
+    return 1
+  elif [[ -z "$__go_cmd_desc" ]]; then
     __go_cmd_desc='No description available'
   fi
 }

--- a/lib/internal/command_descriptions
+++ b/lib/internal/command_descriptions
@@ -161,6 +161,8 @@ _@go.command_description() {
     return 1
   elif [[ -z "$__go_cmd_desc" ]]; then
     __go_cmd_desc='No description available'
+  else
+    __go_cmd_desc="${__go_cmd_desc%% }"
   fi
 }
 

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -3,16 +3,21 @@
 # Imports optional Bash library modules
 #
 # Usage:
-#   .  $_GO_USE_MODULES <module> [<module>...]
+#   .  "$_GO_USE_MODULES" <module> [<module>...]
+#
+#   NOTE: It's important to wrap `$_GO_USE_MODULES` in double-quotes to ensure
+#   the statement is portable to environments in which the file paths may
+#   contain spaces. It's good practice to wrap each `<module>` in
+#   single-quotes as well.
 #
 # Where:
 #   <module>  The name of an optional Bash library module
 #
-# After sourcing `go-core.bash`, you can source the `_GO_USE_MODULES` script to
-# import optional library code from the core framework, from plugins, or from
-# your scripts directory. You can invoke `_GO_USE_MODULES` in your `./go`
-# script, making the module code available to all your Bash command scripts, or
-# use it in specfic Bash command scripts or Bash functions.
+# After sourcing `go-core.bash`, you can source the `_GO_USE_MODULES` script
+# to import optional library code from the core framework, from plugins, or
+# from your scripts directory. You can do so in your `./go` script, making the
+# module code available to all your Bash command scripts, or use it in specfic
+# Bash command scripts or Bash functions.
 #
 # This aims to be a convenient, flexible, standard, and self-documenting means
 # of reusing Bash library code that incurs no overhead if such functionality
@@ -29,7 +34,7 @@
 # then available to the rest of the `./go` script and any command scripts also
 # written in Bash:
 #
-#   . $_GO_USE_MODULES 'log'
+#   . "$_GO_USE_MODULES" 'log'
 #
 # Alternatively, specific command scripts or individual Bash functions that
 # require the functionality can use `_GO_CORE_MODULES` on an as-needed basis,
@@ -48,7 +53,7 @@
 # module file `lib/bar` (installed as `scripts/plugins/foo/lib/bar` in your
 # project repository), you could import the module via:
 #
-#   . $_GO_USE_MODULES 'foo/bar'
+#   . "$_GO_USE_MODULES" 'foo/bar'
 #
 # Module loading is idempotent, as the names of imported modules are added to
 # the `_GO_IMPORTED_MODULES` array and are not sourced again if their names are

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -53,6 +53,14 @@
 # Module loading is idempotent, as the names of imported modules are added to
 # the `_GO_IMPORTED_MODULES` array and are not sourced again if their names are
 # already in the array.
+#
+# To see what modules are currently imported and their corresponding files, use:
+#
+#   for modules imported by the top-level `./go` script:
+#   {{go}} modules --imported
+#
+#   for modules imported within a Bash command script or function:
+#   @go modules --imported
 
 declare __go_module_name
 declare __go_loaded_module

--- a/libexec/modules
+++ b/libexec/modules
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# List optional Bash modules available for import via `. $_GO_USE_MODULES`
+# List optional Bash modules available for import via `. "$_GO_USE_MODULES"`
 #
 # Usage:
 #   A list of all available plugins by class (core, plugin, project):
@@ -29,7 +29,7 @@
 #
 # Modules are reusable libraries of Bash code that may be sourced by the
 # top-level `./go` script, by individual Bash command scripts, and individual
-# Bash functions by executing `. $_GO_USE_MODULES` followed by one or more
+# Bash functions by executing `. "$_GO_USE_MODULES"` followed by one or more
 # module names.
 #
 # It's best to include each `<module-glob>` argument in single-quotes.

--- a/libexec/modules
+++ b/libexec/modules
@@ -1,0 +1,404 @@
+#! /bin/bash
+#
+# List optional Bash modules available for import via `. $_GO_USE_MODULES`
+#
+# Usage:
+#   A list of all available plugins by class (core, plugin, project):
+#   {{go}} {{cmd}} [--paths|--summaries]
+#
+#   The paths or one-line summaries for all or individual modules:
+#   {{go}} {{cmd}} [--paths|--summaries] <module-glob...>
+#
+#   The modules currently imported by the script and their source paths:
+#   {{go}} {{cmd}} --imported
+#
+#   Detailed help for an individual module:
+#   {{go}} {{cmd}} [-h|-help|--help] <module-name>
+#
+#   Detailed help for the module system itself:
+#   {{go}} {{cmd}} [-h|-help|--help]
+#
+# Options:
+#   -h,-help,--help  Show the help message for a specific module
+#   --paths          List the path of each module
+#   --summaries      List the summary of each module
+#
+# Where:
+#   <module-name>  Name of one of the installed modules
+#   <module-glob>  Module name, plugin package (trailing /), or glob pattern
+#
+# Modules are reusable libraries of Bash code that may be sourced by the
+# top-level `./go` script, by individual Bash command scripts, and individual
+# Bash functions by executing `. $_GO_USE_MODULES` followed by one or more
+# module names.
+#
+# It's best to include each `<module-glob>` argument in single-quotes.
+# `<module-glob>` defaults to `*` and will try to match file names by default,
+# to make it easier to find plugin modules. To explicitly try to match plugin
+# names instead, add `/` to the end of `<module-glob>`, followed by an optional
+# file name glob. For example:
+#
+#   '*'      All installed modules
+#   'f*'     All modules whose file name begins with 'f'
+#   'f*/'    All modules in all plugins that begin with 'f'
+#   'f*/b*'  Modules beginning with 'b' in all plugins that begin with 'f'
+#
+# For detailed information about the module system, run `{{go}} {{cmd}} help`
+# without a `<module-name>` argument.
+
+_@go.modules_help() {
+  local module_name="$1"
+  local __go_module_path
+
+  if [[ "$#" -eq '0' ]]; then
+    module_name='$_GO_USE_MODULES'
+    __go_module_path="$_GO_USE_MODULES"
+  elif [[ "$#" -ne '1' ]]; then
+    @go.printf "Please specify only one module name.\n" >&2
+    return 1
+  elif ! _@go.modules_path "$module_name"; then
+    @go.printf "Unknown module: $1\n" >&2
+    return 1
+  fi
+
+  local __go_cmd_desc
+
+  . "$_GO_CORE_DIR/lib/internal/command_descriptions"
+
+  if ! _@go.command_description "$__go_module_path"; then
+    @go.printf "ERROR: failed to parse description from %s\n" \
+      "$__go_module_path" >&2
+    return 1
+  fi
+  @go.printf "$module_name - $__go_cmd_desc\n"
+}
+
+_@go.modules_path() {
+  local module_name="$1"
+
+  __go_module_path="$_GO_CORE_DIR/lib/$module_name"
+  if [[ -f "$__go_module_path" ]]; then
+    return
+  fi
+
+  # Convert <plugin>/<module> to _GO_PLUGINS_DIR/<plugin>/lib/<module>
+  __go_module_path="$_GO_PLUGINS_DIR/${module_name/\///lib/}"
+  if [[ -n "$_GO_PLUGINS_DIR" && -f "$__go_module_path" ]]; then
+    return
+  fi
+
+  __go_module_path="$_GO_SCRIPTS_DIR/lib/$module_name"
+  if [[ -f "$__go_module_path" ]]; then
+    return
+  fi
+  return 1
+}
+
+_@go.modules_find_all_in_dir() {
+  local module_dir="$1"
+  local glob="${2:-*}"
+  local module_path
+
+  for module_path in "$module_dir"/lib/$glob; do
+    if [[ -f "$module_path" ]]; then
+      __go_modules+=("$module_path")
+    fi
+  done
+}
+
+_@go.modules_summaries() {
+  local module_path
+  local __go_cmd_desc
+
+  . "$_GO_CORE_DIR/lib/internal/command_descriptions"
+
+  for module_path in "${__go_modules[@]}"; do
+    if ! _@go.command_summary "$module_path"; then
+      @go.printf "ERROR: failed to parse summary from %s\n" "$module_path" >&2
+      return 1
+    fi
+    __go_modules_summaries+=("$__go_cmd_desc")
+  done
+}
+
+# Produces a listing of module information
+#
+# Arguments:
+#   $1: the type of listing to produce:
+#     '': standard module names for use by _GO_USE_MODULES
+#     paths: module names to paths relative to _GO_ROOTDIR
+#     summaries: module names to one-line summary descriptions
+#
+# Input:
+#   __go_modules: array of absolute paths to modules
+#
+# Output:
+#   __go_modules_listing: array of listing output
+_@go.modules_produce_listing() {
+  local action="$1"
+  local modules=("${__go_modules[@]#$_GO_CORE_DIR/lib/}")
+  modules=("${modules[@]#$_GO_SCRIPTS_DIR/lib/}")
+
+  if [[ -n "$_GO_PLUGINS_DIR" ]]; then
+    modules=("${modules[@]#$_GO_PLUGINS_DIR/}")
+    modules=("${modules[@]/lib\//}")
+  fi
+
+  if [[ -z "$action" ]]; then
+    __go_modules_listing=("${modules[@]}")
+    return
+  fi
+
+  . "$_GO_CORE_DIR/lib/format"
+
+  local __go_padded_result=()
+  local __go_zipped_result=()
+
+  @go.pad_items 'modules'
+  modules=("${__go_padded_result[@]}")
+
+  case "$action" in
+  paths)
+    local relative_paths=("${__go_modules[@]#$_GO_ROOTDIR/}")
+    @go.zip_items 'modules' 'relative_paths'
+    ;;
+  summaries)
+    local __go_modules_summaries=()
+    if ! _@go.modules_summaries; then
+      return 1
+    fi
+    @go.zip_items 'modules' '__go_modules_summaries'
+    ;;
+  *)
+    # Should only happen if _@go.modules is updated and this case statement
+    # isn't.
+    @go.printf 'ERROR: Unknown action: %s\n' "$action" >&2
+    return 1
+  esac
+  __go_modules_listing=("${__go_zipped_result[@]}")
+}
+
+_@go.modules_search() {
+  local glob="${1:-*}"
+  # Default to matching modules within any plugin.
+  local plugin_glob=("*" "$glob")
+  local plugin
+
+  if [[ "$glob" =~ / ]]; then
+    plugin_glob[0]="${glob%/*}"
+    plugin_glob[1]="${glob#*/}"
+    # Since it's a plugin glob, prevent deep core/lib and project/lib matches.
+    glob='/'
+  fi
+
+  _@go.modules_find_all_in_dir "$_GO_CORE_DIR" "$glob"
+  __go_core_modules_end="${#__go_modules[@]}"
+
+  if [[ -n "$_GO_PLUGINS_DIR" ]]; then
+    for plugin in "$_GO_PLUGINS_DIR/"${plugin_glob[0]:-*}; do
+      _@go.modules_find_all_in_dir "$plugin" "${plugin_glob[1]:-*}"
+    done
+  fi
+  __go_plugin_modules_end="${#__go_modules[@]}"
+
+  _@go.modules_find_all_in_dir "$_GO_SCRIPTS_DIR" "$glob"
+  __go_project_modules_end="${#__go_modules[@]}"
+}
+
+_@go.modules_emit_class() {
+  local class="$1"
+  local action="$2"
+  local begin="$3"
+  local end="$4"
+  local __go_modules=("${__go_all_modules[@]:$begin:$((end - begin))}")
+  local __go_modules_listing=()
+
+  if [[ "${#__go_modules[@]}" -ne '0' ]] &&
+        _@go.modules_produce_listing "$action"; then
+    local IFS=$'\n'
+    printf "From the %s:\n%s\n\n" "$class" "${__go_modules_listing[*]/#/  }"
+  fi
+}
+
+_@go.modules_list_by_class() {
+  local action="$1"
+  local __go_modules=()
+  local __go_core_modules_end=0
+  local __go_plugin_modules_end=0
+  local __go_project_modules_end=0
+  local __go_all_modules
+
+  _@go.modules_search
+  __go_all_modules=("${__go_modules[@]}")
+  _@go.modules_emit_class 'core framework library' "$action" \
+    0 "$__go_core_modules_end"
+  _@go.modules_emit_class 'installed plugin libraries' "$action" \
+    "$__go_core_modules_end" "$__go_plugin_modules_end"
+  _@go.modules_emit_class 'project library' "$action" \
+    "$__go_plugin_modules_end" "$__go_project_modules_end"
+}
+
+_@go.modules_list() {
+  local action="$1"
+  shift
+  local module_specs=("$@")
+  local __go_modules=()
+  local __go_module_path
+  local module_spec
+
+  for module_spec in "${module_specs[@]}"; do
+    if [[ "$module_spec" == '*' ]]; then
+      if [[ "${#module_specs[@]}" -ne 1 ]]; then
+        @go.printf "Do not specify other patterns when '*' is present.\n" >&2
+        return 1
+      fi
+      _@go.modules_search
+    elif [[ "$module_spec" =~ \*|/$ ]]; then
+      _@go.modules_search "$module_spec"
+    elif ! _@go.modules_path "$module_spec"; then
+      @go.printf "Unknown module: $module_spec\n" >&2
+      return 1
+    else
+      __go_modules+=("$__go_module_path")
+    fi
+  done
+
+  local __go_modules_listing=()
+  if _@go.modules_produce_listing "$action"; then
+    local IFS=$'\n'
+    echo "${__go_modules_listing[*]}"
+  else
+    return 1
+  fi
+}
+
+_@go.modules_tab_completion() {
+  local word_index="${1:-0}"
+  shift
+  local args=("$@")
+  local first="${args[0]}"
+  local word=("${args[$word_index]}")
+  unset "args[$word_index]"
+  local glob="${word}*"
+  local flags=('-h' '-help' '--help' '--paths' '--summaries' '--imported')
+  local completions=()
+
+  local origIFS="$IFS"
+  local IFS='|'
+  flags_pattern="^(${flags[*]})$"
+  IFS="$origIFS"
+
+  if [[ ( "$word_index" -ne '0' && "${first:0:1}" == '-' ) &&
+        ( ! "$first" =~ $flags_pattern || "$first" == '--imported' ) ]]; then
+    return 1
+  elif [[ "$first" =~ ^(-h|-help|--help)$ && "$word_index" -gt '1' ]]; then
+    return 1
+  fi
+
+  if [[ "$#" -eq '0' || "$word_index" -eq '0' ]]; then
+    completions+=("${flags[@]}")
+  fi
+
+  local __go_modules=()
+  local plugins=()
+  local plugin_modules=()
+
+  . "$_GO_USE_MODULES" 'complete'
+
+  if [[ -n "$_GO_PLUGINS_DIR" ]]; then
+    local plugin
+
+    # Complete a specific plugin module (word contains a '/').
+    if [[ "$glob" =~ / ]]; then
+      plugin="${glob%/*}"
+      _@go.modules_find_all_in_dir "$_GO_PLUGINS_DIR/$plugin" "${glob#*/}*"
+
+    else
+      # Otherwise collect all plugin modules and the names of the plugins to
+      # which they belong. Which set gets returned will be decided at the end.
+      for plugin in "$_GO_PLUGINS_DIR"/$glob; do
+        _@go.modules_find_all_in_dir "$plugin"
+        if [[ "${#__go_modules[@]}" -eq '0' ]]; then
+          continue
+        fi
+
+        __go_modules=("${__go_modules[@]#$_GO_PLUGINS_DIR/}")
+        __go_modules=("${__go_modules[@]/\/lib\///}")
+        @go.complete_remove_completions_already_present \
+          'args' '__go_modules' "${#__go_modules[@]}"
+
+        if [[ "${#__go_modules[@]}" -ne '0' ]]; then
+          plugins+=("$plugin/")
+          plugin_modules+=("${__go_modules[@]}")
+          __go_modules=()
+        fi
+      done
+    fi
+  fi
+
+  # Don't search other dirs if completing a plugin (word contains a '/').
+  if [[ ! "$glob" =~ / ]]; then
+    _@go.modules_find_all_in_dir "$_GO_CORE_DIR" "$glob"
+    _@go.modules_find_all_in_dir "$_GO_SCRIPTS_DIR" "$glob"
+  fi
+
+  # The trick here is, if only one plugin matches, we want to return all of
+  # its modules so that there is no space completed after the '/'. Otherwise
+  # we want to return plugin names with '/' added.
+  if [[ "${#__go_modules[@]}" -eq '0' && "${#plugins[@]}" -eq '1' ]]; then
+    __go_modules=("${plugin_modules[@]}")
+  else
+    __go_modules+=("${plugins[@]}")
+  fi
+
+  local __go_modules_listing=()
+  if _@go.modules_produce_listing; then
+    completions+=("${__go_modules_listing[@]}")
+    @go.complete_remove_completions_already_present \
+      'args' 'completions' "${#completions[@]}"
+    compgen -W "${completions[*]}" -- "$word"
+  else
+    # Shouldn't happen, since modules_produce_listing isn't parsing summaries.
+    return 1
+  fi
+}
+
+_@go.modules() {
+  local action="$1"
+  shift
+
+  case "$action" in
+  --complete)
+    # Tab completions
+    _@go.modules_tab_completion "$@"
+    ;;
+  -h|-help|--help)
+    _@go.modules_help "$@"
+    ;;
+  ''|--paths|--summaries)
+    action="${action#--}"
+    if [[ "$#" -eq '0' ]]; then
+      _@go.modules_list_by_class "$action"
+    else
+      _@go.modules_list "$action" "$@"
+    fi
+    ;;
+  --imported)
+    if [[ "$#" -ne 0 ]]; then
+      @go.printf 'The --imported option takes no other arguments.\n' >&2
+      return 1
+    elif [[ "${#_GO_IMPORTED_MODULES[@]}" -ne '0' ]]; then
+      _@go.modules_list 'paths' "${_GO_IMPORTED_MODULES[@]}"
+    fi
+    ;;
+  -*)
+    @go.printf "Unknown option: $action\n" >&2
+    return 1
+    ;;
+  *)
+    # Here we treat $action as a potential glob pattern.
+    _@go.modules_list '' "$action" "$@"
+  esac
+}
+
+_@go.modules "$@"

--- a/scripts/test
+++ b/scripts/test
@@ -36,7 +36,7 @@ _test_tab_completion() {
 }
 
 _test_coverage() {
-  . $_GO_USE_MODULES 'kcov'
+  . "$_GO_USE_MODULES" 'kcov'
   run_kcov "tests/kcov" "tests/coverage" \
     'go,go-core.bash,lib/,libexec/,scripts/' \
     '/tmp,tests/bats/' \

--- a/tests/command-descriptions/from-file.bats
+++ b/tests/command-descriptions/from-file.bats
@@ -52,6 +52,12 @@ teardown() {
 }
 
 @test "$SUITE: return error if there's an error reading" {
+  if fs_missing_permission_support; then
+    skip "Can't trigger condition on this file system"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip "Can't trigger condition when run by superuser"
+  fi
+
   chmod ugo-r "$TEST_COMMAND_SCRIPT_PATH"
 
   run _@go.command_summary "$TEST_COMMAND_SCRIPT_PATH"

--- a/tests/command-descriptions/from-file.bats
+++ b/tests/command-descriptions/from-file.bats
@@ -70,21 +70,28 @@ teardown() {
 
   local __go_cmd_desc=''
   _@go.command_summary "$TEST_COMMAND_SCRIPT_PATH"
-  assert_success
   assert_equal 'No description available' "$__go_cmd_desc" 'command summary'
 
   __go_cmd_desc=''
   _@go.command_description "$TEST_COMMAND_SCRIPT_PATH"
-  assert_success
   assert_equal 'No description available' "$__go_cmd_desc" 'command description'
 }
 
 @test "$SUITE: parse summary from command script" {
   _GO_ROOTDIR='/foo/bar'
   _@go.command_summary "$TEST_COMMAND_SCRIPT_PATH"
-  assert_success
   assert_equal 'Command that does something in /foo/bar' "$__go_cmd_desc" \
     'command summary'
+}
+
+@test "$SUITE: one-line description from command script has no trailing space" {
+  echo '# Command that does something in {{root}}' > "$TEST_COMMAND_SCRIPT_PATH"
+  _GO_ROOTDIR='/foo/bar'
+  COLUMNS=40
+
+  _@go.command_description "$TEST_COMMAND_SCRIPT_PATH"
+  assert_equal 'Command that does something in /foo/bar' "$__go_cmd_desc" \
+    'one-line command description'
 }
 
 @test "$SUITE: parse description from command script" {
@@ -92,7 +99,6 @@ teardown() {
   _GO_ROOTDIR='/foo/bar'
   COLUMNS=40
   _@go.command_description "$TEST_COMMAND_SCRIPT_PATH"
-  assert_success
 
   local expected='Command that does something in /foo/bar
 

--- a/tests/command-descriptions/from-file.bats
+++ b/tests/command-descriptions/from-file.bats
@@ -51,6 +51,19 @@ teardown() {
   remove_test_go_rootdir
 }
 
+@test "$SUITE: return error if there's an error reading" {
+  chmod ugo-r "$TEST_COMMAND_SCRIPT_PATH"
+
+  run _@go.command_summary "$TEST_COMMAND_SCRIPT_PATH"
+  assert_failure
+  assert_output_matches "ERROR: problem reading $TEST_COMMAND_SCRIPT_PATH\$"
+
+  output=''
+  run _@go.command_description "$TEST_COMMAND_SCRIPT_PATH"
+  assert_failure
+  assert_output_matches "ERROR: problem reading $TEST_COMMAND_SCRIPT_PATH\$"
+}
+
 @test "$SUITE: return default text when no description is available" {
   create_test_command_script 'test-command' \
     'echo "This script has no description"'

--- a/tests/modules/arg-completion.bats
+++ b/tests/modules/arg-completion.bats
@@ -1,0 +1,134 @@
+#! /usr/bin/env bats
+
+load ../environment
+load ../assertions
+load ../script_helper
+load helpers
+
+setup() {
+  create_test_go_script '@go "$@"'
+  setup_test_modules
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: zero arguments" {
+  run "$TEST_GO_SCRIPT" modules --complete
+  local expected=('-h' '-help' '--help' '--paths' '--summaries' '--imported'
+    "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: first argument matches help flags" {
+  run "$TEST_GO_SCRIPT" modules --complete 0 -h _foo
+  local expected=('-h' '-help')
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: first argument matches modules" {
+  run "$TEST_GO_SCRIPT" modules --complete 0 _f
+  local expected=('_frobozz' '_frotz' '_foo/')
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: only complete first flag" {
+  run "$TEST_GO_SCRIPT" modules --complete 0 --pat --sum
+  assert_success '--paths'
+
+  run "$TEST_GO_SCRIPT" modules --complete 1 --paths --sum
+  assert_failure ''
+}
+
+@test "$SUITE: only complete flag as first arg" {
+  run "$TEST_GO_SCRIPT" modules --complete 1 foo --pat
+  assert_failure ''
+}
+
+@test "$SUITE: nothing else when --imported present" {
+  run "$TEST_GO_SCRIPT" modules --complete 1 --imported foo
+  assert_failure ''
+}
+
+@test "$SUITE: nothing else when first flag not recognized" {
+  run "$TEST_GO_SCRIPT" modules --complete 1 --bogus-flag foo
+  assert_failure ''
+}
+
+@test "$SUITE: return plugin dirs, core and project modules for flag" {
+  # Note that plugins are offered last
+  local expected=(
+    "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
+  run "$TEST_GO_SCRIPT" modules --complete 1 --help
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: return matching plugins and modules" {
+  local expected=('_frobozz' '_frotz' '_foo/')
+  run "$TEST_GO_SCRIPT" modules --complete 1 help '_f'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: return only matching plugin names" {
+  local expected=('_bar/' '_baz/')
+  run "$TEST_GO_SCRIPT" modules --complete 1 help '_b'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: return all matches for a plugin when no other matches" {
+  local expected=('_foo/_plugh' '_foo/_quux' '_foo/_xyzzy')
+  run "$TEST_GO_SCRIPT" modules --complete 1 help '_fo'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: return matches for a plugin when arg ends with a slash" {
+  local expected=('_baz/_plugh' '_baz/_quux' '_baz/_xyzzy')
+  run "$TEST_GO_SCRIPT" modules --complete 1 help '_baz/'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: no matches" {
+  run "$TEST_GO_SCRIPT" modules --complete 1 help '_x'
+  assert_failure ''
+}
+
+@test "$SUITE: complete only first argument for help" {
+  run "$TEST_GO_SCRIPT" modules --complete 2 --help '_frobozz' '_fr'
+  assert_failure ''
+}
+
+@test "$SUITE: complete subsequent args for flags other than help" {
+  # Note that matches already on command line are not completed.
+  run "$TEST_GO_SCRIPT" modules --complete 2 --paths '_frobozz' '_fr'
+  assert_success '_frotz'
+}
+
+@test "$SUITE: complete subsequent args if first arg not a flag" {
+  # Note that matches already on command line are not completed.
+  run "$TEST_GO_SCRIPT" modules --complete 1 '_frobozz' '_fr'
+  assert_success '_frotz'
+}
+
+@test "$SUITE: remove plugin completions already present" {
+  local expected=('_foo/_quux' '_foo/_xyzzy')
+  run "$TEST_GO_SCRIPT" modules --complete 1 '_foo/_plugh' '_foo/'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: don't complete plugins when all modules already present" {
+  local expected=("${CORE_MODULES[@]}" '_frobozz' '_frotz' '_bar/' '_baz/')
+  run "$TEST_GO_SCRIPT" modules --complete 3 \
+    '_foo/_plugh' '_foo/_quux' '_foo/_xyzzy'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}

--- a/tests/modules/help.bats
+++ b/tests/modules/help.bats
@@ -1,0 +1,67 @@
+#! /usr/bin/env bats
+
+load ../environment
+load ../assertions
+load ../script_helper
+load helpers
+
+setup() {
+  create_test_go_script '@go "$@"'
+  setup_test_modules
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: no args shows module system help" {
+  run "$TEST_GO_SCRIPT" 'modules' '-h'
+  assert_output_matches '^\$_GO_USE_MODULES - '
+}
+
+@test "$SUITE: accept -h, -help, and --help as synonyms" {
+  run "$TEST_GO_SCRIPT" modules -h
+  assert_success
+
+  local help_output="$output"
+
+  run "$TEST_GO_SCRIPT" modules -help
+  assert_success "$help_output"
+
+  run "$TEST_GO_SCRIPT" modules --help
+  assert_success "$help_output"
+}
+
+@test "$SUITE: --help honored" {
+  run "$TEST_GO_SCRIPT" 'modules' '--help'
+  assert_output_matches '^\$_GO_USE_MODULES - '
+}
+
+@test "$SUITE: error if more than one module specified" {
+  run "$TEST_GO_SCRIPT" 'modules' '-h' '_foo/_plugh' '_bar/_quux'
+  assert_failure 'Please specify only one module name.'
+}
+
+@test "$SUITE: error if module does not exist" {
+  run "$TEST_GO_SCRIPT" 'modules' '-h' '_foo/_frotz'
+  assert_failure 'Unknown module: _foo/_frotz'
+}
+
+@test "$SUITE: error if parsing description fails" {
+  if fs_missing_permission_support; then
+    skip "Can't trigger condition on this file system"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip "Can't trigger condition when run by superuser"
+  fi
+
+  local module_path="$TEST_GO_PLUGINS_DIR/_foo/lib/_plugh"
+  chmod ugo-r "$module_path"
+  run "$TEST_GO_SCRIPT" 'modules' '-h' '_foo/_plugh'
+  assert_failure
+  assert_output_matches "ERROR: failed to parse description from $module_path\$"
+}
+
+@test "$SUITE: print help from the module's header comment" {
+  run "$TEST_GO_SCRIPT" 'modules' '-h' '_foo/_plugh'
+  assert_success '_foo/_plugh - Summary for _foo/_plugh'
+}

--- a/tests/modules/helpers.bash
+++ b/tests/modules/helpers.bash
@@ -1,0 +1,46 @@
+#! /bin/bash
+#
+# Helper functions for `./go modules` tests.
+
+CORE_MODULES=()
+CORE_MODULES_PATHS=()
+
+# We start all the test plugin and module names with '_' to avoid collisions
+# with any potential module names added to the core framework.
+TEST_PLUGINS=('_bar' '_baz' '_foo')
+TEST_PLUGIN_MODULES=(_{bar,baz,foo}/_{plugh,quux,xyzzy})
+TEST_PLUGIN_MODULES_PATHS=()
+
+TEST_PROJECT_MODULES=('_frobozz' '_frotz')
+TEST_PROJECT_MODULES_PATHS=()
+
+TOTAL_NUM_MODULES=0
+
+setup_test_modules() {
+  local module
+  local module_file
+
+  for module in "$_GO_ROOTDIR"/lib/*; do
+    if [[ -f "$module" ]]; then
+      CORE_MODULES_PATHS+=("$module")
+      CORE_MODULES+=("${module#$_GO_ROOTDIR/lib/}")
+      ((++TOTAL_NUM_MODULES))
+    fi
+  done
+
+  for module in "${TEST_PLUGIN_MODULES[@]}"; do
+    module_file="$TEST_GO_PLUGINS_DIR/${module/\///lib/}"
+    mkdir -p "${module_file%/*}"
+    echo "# Summary for $module"$'\n' > "$module_file"
+    TEST_PLUGIN_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
+    ((++TOTAL_NUM_MODULES))
+  done
+
+  for module in "${TEST_PROJECT_MODULES[@]}"; do
+    module_file="$TEST_GO_SCRIPTS_DIR/lib/$module"
+    mkdir -p "${module_file%/*}"
+    echo "# Summary for $module" > "$module_file"
+    TEST_PROJECT_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
+    ((++TOTAL_NUM_MODULES))
+  done
+}

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -71,7 +71,7 @@ get_first_and_last_core_module_summaries() {
 
 @test "$SUITE: --imported" {
   create_test_go_script \
-    '. $_GO_USE_MODULES "complete" "_foo/_plugh" "_bar/_quux" "_frotz"' \
+    '. "$_GO_USE_MODULES" "complete" "_foo/_plugh" "_bar/_quux" "_frotz"' \
     '@go "$@"'
 
   # The first will be an absolute path because the script's _GO_ROOTDIR doesn't

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -1,0 +1,257 @@
+#! /usr/bin/env bats
+
+load ../environment
+load ../assertions
+load ../script_helper
+load helpers
+
+LAST_CORE_MODULE=
+LAST_CORE_MODULE_PATH=
+
+FIRST_CORE_MOD_SUMMARY=
+LAST_CORE_MOD_SUMMARY=
+
+setup() {
+  create_test_go_script '@go "$@"'
+  setup_test_modules
+
+  local last_index="$((${#CORE_MODULES[@]} - 1))"
+  LAST_CORE_MODULE="${CORE_MODULES[$last_index]}"
+  LAST_CORE_MODULE_PATH="${CORE_MODULES_PATHS[$last_index]}"
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+get_first_and_last_core_module_summaries() {
+  local module
+  local __go_cmd_desc
+
+  . "$_GO_ROOTDIR/lib/internal/command_descriptions"
+  _@go.command_summary "${CORE_MODULES_PATHS[0]}"
+  FIRST_CORE_MOD_SUMMARY="$__go_cmd_desc"
+  _@go.command_summary "$LAST_CORE_MODULE_PATH"
+  LAST_CORE_MOD_SUMMARY="$__go_cmd_desc"
+}
+
+@test "$SUITE: error if unknown option" {
+  run "$TEST_GO_SCRIPT" modules --bogus-flag
+  assert_failure 'Unknown option: --bogus-flag'
+}
+
+@test "$SUITE: error if --imported is followed by arguments" {
+  run "$TEST_GO_SCRIPT" modules --imported foo bar
+  assert_failure 'The --imported option takes no other arguments.'
+}
+
+@test "$SUITE: error if '*' accompanied by other glob patterns" {
+  run "$TEST_GO_SCRIPT" modules '_f*' '*' '_b*'
+  assert_failure "Do not specify other patterns when '*' is present."
+}
+
+@test "$SUITE: error if parsing summary fails" {
+  if fs_missing_permission_support; then
+    skip "Can't trigger condition on this file system"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip "Can't trigger condition when run by superuser"
+  fi
+
+  local module_path="$TEST_GO_PLUGINS_DIR/_foo/lib/_plugh"
+  chmod ugo-r "$module_path"
+  run "$TEST_GO_SCRIPT" 'modules' '--summaries' '_foo/_plugh'
+  assert_failure
+  assert_output_matches "ERROR: failed to parse summary from $module_path\$"
+}
+
+@test "$SUITE: error if module spec without glob doesn't match anything" {
+  run "$TEST_GO_SCRIPT" 'modules' 'some-bogus-module'
+  assert_failure 'Unknown module: some-bogus-module'
+}
+
+@test "$SUITE: --imported" {
+  create_test_go_script \
+    '. $_GO_USE_MODULES "complete" "_foo/_plugh" "_bar/_quux" "_frotz"' \
+    '@go "$@"'
+
+  # The first will be an absolute path because the script's _GO_ROOTDIR doesn't
+  # contain the framework sources.
+  local expected=(
+    "complete     $_GO_ROOTDIR/lib/complete"
+    "_foo/_plugh  scripts/plugins/_foo/lib/_plugh"
+    "_bar/_quux   scripts/plugins/_bar/lib/_quux"
+    "_frotz       scripts/lib/_frotz"
+  )
+
+  run "$TEST_GO_SCRIPT" modules --imported
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: list by class, all modules" {
+  local expected=('From the core framework library:'
+    "${CORE_MODULES[@]/#/  }"
+    ''
+    'From the installed plugin libraries:'
+    "${TEST_PLUGIN_MODULES[@]/#/  }"
+    ''
+    'From the project library:'
+    "${TEST_PROJECT_MODULES[@]/#/  }"
+  )
+
+  run "$TEST_GO_SCRIPT" modules
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: list using glob, all modules" {
+  local expected=("${CORE_MODULES[@]}"
+    "${TEST_PLUGIN_MODULES[@]}"
+    "${TEST_PROJECT_MODULES[@]}"
+  )
+
+  run "$TEST_GO_SCRIPT" modules '*'
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: list by class, only core modules present" {
+  local expected=('From the core framework library:'
+    "${CORE_MODULES[@]/#/  }"
+  )
+
+  rm "${TEST_PLUGIN_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}" \
+    "${TEST_PROJECT_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}"
+  run "$TEST_GO_SCRIPT" modules
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: list using glob, only core modules present" {
+  rm "${TEST_PLUGIN_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}" \
+    "${TEST_PROJECT_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}"
+  run "$TEST_GO_SCRIPT" modules '*'
+  local IFS=$'\n'
+  assert_success "${CORE_MODULES[*]}"
+}
+
+@test "$SUITE: paths by class" {
+  run "$TEST_GO_SCRIPT" modules --paths
+  assert_success
+
+  # Note the two newlines at the end of each class section.
+  assert_output_matches "  ${CORE_MODULES[0]} +${CORE_MODULES_PATHS[0]}"$'\n'
+  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MODULE_PATH"$'\n'$'\n'
+
+  # Note the padding is relative to only the plugin modules. Use a variable to
+  # keep the assertion lines under 80 columns.
+  local plugins='scripts/plugins'
+  assert_output_matches "  _bar/_plugh  $plugins/_bar/lib/_plugh"$'\n'
+  assert_output_matches "  _foo/_quux   $plugins/_foo/lib/_quux"$'\n'
+  assert_output_matches "  _foo/_xyzzy  $plugins/_foo/lib/_xyzzy"$'\n'$'\n'
+
+  # Note the padding is relative to only the project modules. Bats trims
+  # the last newline of the output.
+  assert_output_matches "  _frobozz  scripts/lib/_frobozz"$'\n'
+  assert_output_matches "  _frotz    scripts/lib/_frotz$"
+
+  # Since the 'lines' array doesn't contain blank lines, we only add '3' to
+  # account for the 'From the...' line starting each class section.
+  assert_equal "$((TOTAL_NUM_MODULES + 3))" "${#lines[@]}"
+}
+
+@test "$SUITE: paths using glob, all modules" {
+  run "$TEST_GO_SCRIPT" modules --paths '*'
+  assert_success
+
+  # Note that there is no leading space, the padding is relative to the length
+  # of the longest module name overall, and there are no separate sections
+  # delimited by back-to-back newlines. Bats trims the final newline.
+  assert_output_matches "${CORE_MODULES[0]} +${CORE_MODULES_PATHS[0]}"$'\n'
+  assert_output_matches $'\n'"$LAST_CORE_MODULE +$LAST_CORE_MODULE_PATH"$'\n'
+  assert_output_matches $'\n'"_bar/_plugh  scripts/plugins/_bar/lib/_plugh"$'\n'
+  assert_output_matches $'\n'"_foo/_quux   scripts/plugins/_foo/lib/_quux"$'\n'
+  assert_output_matches $'\n'"_foo/_xyzzy  scripts/plugins/_foo/lib/_xyzzy"$'\n'
+  assert_output_matches $'\n'"_frobozz     scripts/lib/_frobozz"$'\n'
+  assert_output_matches $'\n'"_frotz       scripts/lib/_frotz$"
+
+  assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
+}
+
+@test "$SUITE: summaries by class" {
+  run "$TEST_GO_SCRIPT" modules --summaries
+  assert_success
+
+  # Note the two newlines at the end of each class section.
+  get_first_and_last_core_module_summaries
+  assert_output_matches "  ${CORE_MODULES[0]} +$FIRST_CORE_MOD_SUMMARY"$'\n'
+  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MOD_SUMMARY"$'\n'$'\n'
+
+  # Note the padding is relative to only the plugin modules.
+  assert_output_matches "  _bar/_plugh  Summary for _bar/_plugh"$'\n'
+  assert_output_matches "  _foo/_quux   Summary for _foo/_quux"$'\n'
+  assert_output_matches "  _foo/_xyzzy  Summary for _foo/_xyzzy"$'\n'$'\n'
+
+  # Note the padding is relative to only the project modules. Bats trims
+  # the last newline of the output.
+  assert_output_matches "  _frobozz  Summary for _frobozz"$'\n'
+  assert_output_matches "  _frotz    Summary for _frotz$"
+
+  # Since the 'lines' array doesn't contain blank lines, we only add '3' to
+  # account for the 'From the...' line starting each class section.
+  assert_equal "$((TOTAL_NUM_MODULES + 3))" "${#lines[@]}"
+}
+
+@test "$SUITE: summaries using glob, all modules" {
+  run "$TEST_GO_SCRIPT" modules --summaries '*'
+  assert_success
+
+  # Note that there is no leading space, the padding is relative to the length
+  # of the longest module name overall, and there are no separate sections
+  # delimited by back-to-back newlines. Bats trims the final newline.
+  get_first_and_last_core_module_summaries
+  assert_output_matches "${CORE_MODULES[0]} +$FIRST_CORE_MOD_SUMMARY"$'\n'
+  assert_output_matches $'\n'"$LAST_CORE_MODULE +$LAST_CORE_MOD_SUMMARY"$'\n'
+  assert_output_matches $'\n'"_bar/_plugh  Summary for _bar/_plugh"$'\n'
+  assert_output_matches $'\n'"_foo/_quux   Summary for _foo/_quux"$'\n'
+  assert_output_matches $'\n'"_foo/_xyzzy  Summary for _foo/_xyzzy"$'\n'
+  assert_output_matches $'\n'"_frobozz     Summary for _frobozz"$'\n'
+  assert_output_matches $'\n'"_frotz       Summary for _frotz$"
+
+  assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
+}
+
+@test "$SUITE: list only test modules" {
+  run "$TEST_GO_SCRIPT" modules '_*'
+  local IFS=$'\n'
+  assert_success "${TEST_PLUGIN_MODULES[*]}"$'\n'"${TEST_PROJECT_MODULES[*]}"
+}
+
+@test "$SUITE: list only test project modules" {
+  run "$TEST_GO_SCRIPT" modules '_fr*'
+  local IFS=$'\n'
+  assert_success "${TEST_PROJECT_MODULES[*]}"
+}
+
+@test "$SUITE: list only modules in the _bar and _baz plugins" {
+  run "$TEST_GO_SCRIPT" modules '_ba*/_*u*'
+  local expected=('_bar/_plugh' '_bar/_quux' '_baz/_plugh' '_baz/_quux')
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}
+
+@test "$SUITE: list test modules using multiple globs" {
+  # Note that the modules are listed in the order of the globs, so the project
+  # modules are listed before the plugin modules.
+  run "$TEST_GO_SCRIPT" modules '_frob*' '_f*/_*u*' '_bar/'
+  local expected=(
+    '_frobozz'
+    '_foo/_plugh'
+    '_foo/_quux'
+    '_bar/_plugh'
+    '_bar/_quux'
+    '_bar/_xyzzy'
+  )
+  local IFS=$'\n'
+  assert_success "${expected[*]}"
+}

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -1,8 +1,8 @@
 #! /usr/bin/env bats
 
-load environment
-load assertions
-load script_helper
+load ../environment
+load ../assertions
+load ../script_helper
 
 TEST_MODULES=(
   "$_GO_ROOTDIR/lib/builtin-test"


### PR DESCRIPTION
The `modules` builtin aims to make it easy to discover modules added to the project and to understand what they do by providing command-line help, command summary listings, and file path information. It supports command-line glob patterns and tab completion to filter the output.

In the future, it may gain the capability to provide a more granular interface targeted at parsing and documenting individual shell functions.

This PR also contains commits for other minor fixes.