### PR TITLE
cmd_desc: Show full command names in descriptions

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -230,6 +230,7 @@ if ! _@go.set_scripts_dir "$@"; then
   exit 1
 elif [[ -z "$COLUMNS" ]]; then
   if command -v 'tput' >/dev/null && [[ -n "$TERM" ]]; then
+    echo "TERM: $TERM" >&2
     COLUMNS="$(tput cols)"
   elif command -v 'mode.com' >/dev/null; then
     COLUMNS="$(mode.com) con:"

--- a/go-core.bash
+++ b/go-core.bash
@@ -229,17 +229,16 @@ _@go.set_scripts_dir() {
 if ! _@go.set_scripts_dir "$@"; then
   exit 1
 elif [[ -z "$COLUMNS" ]]; then
-  if command -v 'tput' >/dev/null && [[ -n "$TERM" ]]; then
-    echo "TERM: $TERM" >&2
-    COLUMNS="$(tput cols)"
+  if command -v 'tput' >/dev/null; then
+    # On Travis, $TERM is set to 'dumb', but tput still fails.
+    COLUMNS="$(tput cols 2>/dev/null)"
   elif command -v 'mode.com' >/dev/null; then
     COLUMNS="$(mode.com) con:"
     shopt -s extglob
     COLUMNS="${COLUMNS##*Columns:+( )}"
     shopt -u extglob
     COLUMNS="${COLUMNS%%[ $'\r'$'\n']*}"
-  else
-    COLUMNS=80
   fi
-  export COLUMNS
+
+  export COLUMNS="${COLUMNS:-80}"
 fi

--- a/go-core.bash
+++ b/go-core.bash
@@ -108,7 +108,7 @@ declare -r -x _GO_CORE_URL='https://github.com/mbland/go-script-bash'
   fi
 
   if command -v fold >/dev/null; then
-    printf "$format" "$@" | fold -s -w $COLUMNS
+    printf "$format" "$@" | fold -s -w "$COLUMNS"
   else
     printf "$format" "$@"
   fi
@@ -229,7 +229,7 @@ _@go.set_scripts_dir() {
 if ! _@go.set_scripts_dir "$@"; then
   exit 1
 elif [[ -z "$COLUMNS" ]]; then
-  if command -v 'tput' >/dev/null; then
+  if command -v 'tput' >/dev/null && [[ -n "$TERM" ]]; then
     COLUMNS="$(tput cols)"
   elif command -v 'mode.com' >/dev/null; then
     COLUMNS="$(mode.com) con:"

--- a/lib/internal/command_descriptions
+++ b/lib/internal/command_descriptions
@@ -68,17 +68,16 @@ _@go.format_summary() {
 
 _@go.command_summary() {
   local cmd_path="$1"
+  local __go_cmd_name
   __go_cmd_desc=''
 
-  if ! _@go.check_command_path "$cmd_path"; then
+  if ! _@go.check_command_path_and_parse_command_name "$cmd_path"; then
     return 1
   fi
 
   local line
   local summary=''
   local summary_pattern='^# [[:alnum:]]'
-  local cmd_name="${1##*/}"
-  cmd_name="${cmd_name//\// }"
 
   while read -r line; do
     line="${line%$'\r'}"
@@ -103,9 +102,10 @@ _@go.command_summary() {
 # way less hacky/more readable.
 _@go.command_description() {
   local cmd_path="$1"
+  local __go_cmd_name
   __go_cmd_desc=''
 
-  if ! _@go.check_command_path "$cmd_path"; then
+  if ! _@go.check_command_path_and_parse_command_name "$cmd_path"; then
     return 1
   fi
 
@@ -116,8 +116,6 @@ _@go.command_description() {
   local preformatted_pattern='^#    *[[:graph:]]'
   local summary_item
   local summary
-  local cmd_name="${1##*/}"
-  cmd_name="${cmd_name//\// }"
 
   while read -r line; do
     line="${line%$'\r'}"
@@ -168,12 +166,13 @@ _@go.command_description() {
 
 _@go.filter_description_line() {
   line="${line//\{\{go\}\}/$_GO_CMD}"
-  line="${line//\{\{cmd\}\}/${cmd_name}}"
+  line="${line//\{\{cmd\}\}/${__go_cmd_name}}"
   line="${line//\{\{root\}\}/$_GO_ROOTDIR}"
 }
 
-_@go.check_command_path() {
+_@go.check_command_path_and_parse_command_name() {
   local cmd_path="$1"
+  local subcommand_pattern='/([^/]+\.d/.*)'
 
   if [[ -z "$cmd_path" ]]; then
     echo "ERROR: no command script specified" >&2
@@ -181,5 +180,9 @@ _@go.check_command_path() {
   elif [[ ! -e "$cmd_path" ]]; then
     echo "ERROR: command script \"$cmd_path\" does not exist" >&2
     return 1
+  elif [[ "$cmd_path" =~ $subcommand_pattern ]]; then
+    __go_cmd_name="${BASH_REMATCH[1]//.d\// }"
+  else
+    __go_cmd_name="${cmd_path##*/}"
   fi
 }

--- a/tests/command-descriptions/from-file.bats
+++ b/tests/command-descriptions/from-file.bats
@@ -140,3 +140,26 @@ Indented lines that look like tables (there are two or more adjacent spaces afte
   # '[args...]' above.
   assert_equal "$expected" "$__go_cmd_desc" 'command description'
 }
+
+@test "$SUITE: format subcommand description" {
+  mkdir -p "$TEST_GO_SCRIPTS_DIR/root-command.d/node-command.d"
+  create_test_command_script 'root-command.d/node-command.d/leaf-command' '#
+# Leaf command that does something in {{root}}
+#
+# Usage: {{go}} {{cmd}} [args...]
+
+echo The command script starts now.
+'
+
+  local _GO_CMD='test-go'
+  local expected=("Leaf command that does something in $_GO_ROOTDIR"
+    ''
+    "Usage: $_GO_CMD root-command node-command leaf-command [args...]"
+    '')
+  local __go_cmd_desc
+  _@go.command_description \
+    "$TEST_GO_SCRIPTS_DIR/root-command.d/node-command.d/leaf-command"
+
+  local IFS=$'\n'
+  assert_equal "${expected[*]}" "$__go_cmd_desc"
+}

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -28,11 +28,13 @@ teardown() {
   assert_success '80'
 }
 
-@test "$SUITE: default to 80 columns if \$TERM not set on systems with tput" {
+@test "$SUITE: default to 80 columns if tput fails" {
   if ! command -v 'tput' >/dev/null; then
     skip 'tput not available on this system'
   fi
 
+  # One way to cause tput to fail is to set `$TERM` to null. On Travis it's set
+  # to 'dumb', but tput fails anyway. The code now defaults to 80 on all errors.
   run env COLUMNS= TERM= "$TEST_GO_SCRIPT"
   assert_success '80'
 }

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -27,3 +27,12 @@ teardown() {
   run env COLUMNS= PATH= "$BASH" "$TEST_GO_SCRIPT"
   assert_success '80'
 }
+
+@test "$SUITE: default to 80 columns if \$TERM not set on systems with tput" {
+  if ! command -v 'tput' >/dev/null; then
+    skip 'tput not available on this system'
+  fi
+
+  run env COLUMNS= TERM= "$TEST_GO_SCRIPT"
+  assert_success '80'
+}


### PR DESCRIPTION
Previously, only the last component of a command name for a subcommand would be substituted for `{{cmd}}` placeholders in description text. Now the full command name, including all parent commands, is included.