### PR TITLE
Export _GO_CMD_{NAME,ARGV}, add Bash test

### DIFF
--- a/lib/internal/path
+++ b/lib/internal/path
@@ -60,6 +60,7 @@ _@go.set_command_path_and_argv() {
   fi
 
   local cmd_arg_index=1
+  __go_cmd_name=("$cmd_name")
 
   for arg in "${cmd_args[@]}"; do
     # This is most likely to happen during argument completion.
@@ -76,6 +77,7 @@ _@go.set_command_path_and_argv() {
       return 1
     fi
 
+    __go_cmd_name+=("$arg")
     cmd_path="$try_path"
     unset "cmd_args[$((cmd_arg_index++))]"
   done

--- a/tests/path/set-path-and-argv.bats
+++ b/tests/path/set-path-and-argv.bats
@@ -11,7 +11,8 @@ setup() {
     '  exit 1' \
     'fi' \
     'echo "PATH: $__go_cmd_path"' \
-    'echo "ARGV: ${__go_argv[@]}"'
+    'echo "NAME: ${__go_cmd_name[*]}"' \
+    'echo "ARGV: ${__go_argv[*]}"'
 }
 
 teardown() {
@@ -33,7 +34,8 @@ teardown() {
   run "$TEST_GO_SCRIPT" "${builtin_cmd##*/}" '--exists' 'ls'
   assert_success
   assert_line_equals 0 "PATH: $builtin_cmd"
-  assert_line_equals 1 'ARGV: --exists ls'
+  assert_line_equals 1 "NAME: ${builtin_cmd##*/}"
+  assert_line_equals 2 'ARGV: --exists ls'
 }
 
 @test "$SUITE: list available commands if command not found" {
@@ -53,7 +55,8 @@ teardown() {
   run "$TEST_GO_SCRIPT" 'foobar' 'baz' 'quux'
   assert_success
   assert_line_equals 0 "PATH: $TEST_GO_SCRIPTS_DIR/foobar"
-  assert_line_equals 1 'ARGV: baz quux'
+  assert_line_equals 1 'NAME: foobar'
+  assert_line_equals 2 'ARGV: baz quux'
 }
 
 @test "$SUITE: empty string argument is not an error" {
@@ -64,7 +67,8 @@ teardown() {
   run "$TEST_GO_SCRIPT" 'foobar' '' 'baz' 'quux'
   assert_success
   assert_line_equals 0 "PATH: $TEST_GO_SCRIPTS_DIR/foobar"
-  assert_line_equals 1 'ARGV:  baz quux'
+  assert_line_equals 1 'NAME: foobar'
+  assert_line_equals 2 'ARGV:  baz quux'
 }
 
 @test "$SUITE: error if top-level command name is a directory" {
@@ -95,7 +99,8 @@ teardown() {
   run "$TEST_GO_SCRIPT" 'foobar' 'baz' 'quux'
   assert_success
   assert_line_equals 0 "PATH: $TEST_GO_SCRIPTS_DIR/foobar.d/baz"
-  assert_line_equals 1 'ARGV: quux'
+  assert_line_equals 1 'NAME: foobar baz'
+  assert_line_equals 2 'ARGV: quux'
 }
 
 @test "$SUITE: error if subcommand name is a directory" {


### PR DESCRIPTION
Theoretically, any command can now re-invoke the original `./go` script command via:
```bash
"$_GO_SCRIPT" "${_GO_CMD_NAME[@]}" "${_GO_CMD_ARGV[@]}"
```
In scripts written in other languages, the `_GO_CMD_NAME` and `_GO_CMD_ARGV` environment variables will have to be split using ASCII NUL as the delimiter to get the arguments, but the idea is the same.

`_GO_CMD_NAME` will be used to implement the generic `lib/test` module in a future commit. Specifically, it will enable `@go.test_coverage` to invoke `kcov` using the original command
arguments without requiring the caller to pass the name of the test command script as an argument, or requiring that it always be named `test`.