### PR TITLE
Switch tests to use `./go complete` and remove most `compgen -W` calls

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -232,11 +232,11 @@ __return_from_bats_assertion() {
   local result="${1:-0}"
 
   if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $BASH_SOURCE ]]; then
-    unset "BATS_CURRENT_STACK_TRACE[0]"
+    unset 'BATS_CURRENT_STACK_TRACE[0]'
   fi
 
   if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $BASH_SOURCE ]]; then
-    unset "BATS_PREVIOUS_STACK_TRACE[0]"
+    unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
 
   set -o functrace

--- a/lib/internal/complete
+++ b/lib/internal/complete
@@ -1,15 +1,20 @@
 #! /bin/bash
 
 _@go.complete_top_level_commands() {
-  local cmd_name="$1"
-  local all_commands=()
-  all_commands+=($(_@go.source_builtin 'aliases'))
-  all_commands+=($(_@go.source_builtin 'commands'))
-
-  local IFS=$'\n'
-  compgen -W "${all_commands[*]}" -- "$cmd_name"
+  _@go.source_builtin 'aliases'
+  _@go.source_builtin 'commands'
 }
 
+# A successful return status from this function is a signal that __go_cmd_path
+# is set and that the caller should run the following to produce more
+# completion values (provided it contains a '# Tab completions' comment):
+#
+#   "$__go_cmd_path" --complete "$__go_complete_word_index" "${__go_argv[@]}"
+#
+# An error return status indicates that argument completion is finished.
+#
+# It may omit potential completion values to standard output regardless of the
+# return status.
 _@go.complete_command_path() {
   if [[ "$#" -eq 0 ]]; then
     return 1
@@ -20,8 +25,8 @@ _@go.complete_command_path() {
   . "$_GO_CORE_DIR/lib/internal/path"
 
   if [[ "$#" -le 1 || "$__go_complete_word_index" -eq '0' ]]; then
-    _@go.complete_top_level_commands "$1"
-    return
+    _@go.complete_top_level_commands
+    return 1
   elif ! _@go.set_command_path_and_argv "$@"; then
     return 1
   fi
@@ -30,7 +35,7 @@ _@go.complete_command_path() {
   if [[ "$__go_complete_word_index" -lt '0' ]]; then
     # This (sub)command itself is the completion target.
     echo "${__go_cmd_path##*/}"
-    return
+    return 1
 
   elif [[ "$__go_complete_word_index" -eq '0' ]]; then
     # Complete subcommand scripts.
@@ -41,10 +46,6 @@ _@go.complete_command_path() {
         subcommands+=("${c##*/}")
       fi
     done
-    compgen -W "${subcommands[*]}" -- "${__go_argv[$__go_complete_word_index]}"
-
-    # We want to return success because the caller may only be interested in
-    # completing as much of an otherwise valid subcommand as possible.
-    return 0
+    echo "${subcommands[@]}"
   fi
 }

--- a/lib/internal/env/bash
+++ b/lib/internal/env/bash
@@ -3,7 +3,7 @@
 # eval "$(%s env -)"
 
 __go_func() {
-  unset COMP_WORDS[0]
+  unset 'COMP_WORDS[0]'
   COMPREPLY=($("$_GO_SCRIPT" 'complete' "$((COMP_CWORD-1))" "${COMP_WORDS[@]}"))
   cd "$_GO_ROOTDIR"
 }

--- a/libexec/builtins
+++ b/libexec/builtins
@@ -75,7 +75,7 @@ _@go.builtins() {
     # Tab completions
     local word_index="$2"
     if [[ "$word_index" -eq '0' ]]; then
-      compgen -W '--exists --summaries' -- "$3"
+      echo '--exists' '--summaries'
     fi
     return
   fi

--- a/libexec/commands
+++ b/libexec/commands
@@ -94,12 +94,9 @@ _@go.commands_tab_completions() {
   shift
 
   if [[ "$word_index" -eq '0' ]]; then
-    local flag_result=0
-    if ! compgen -W '--paths --summaries' -- "$1"; then
-      ((++flag_result))
-    fi
+    echo '--paths' '--summaries'
     if [[ "${1:0:1}" == '-' || "$#" -gt 1 ]]; then
-      return $flag_result
+      return
     fi
   fi
 
@@ -115,8 +112,7 @@ _@go.commands_tab_completions() {
   if [[ "$word_index" -lt "$last_arg_index" ]]; then
     return 1
   fi
-  compgen -W "$(_@go.commands "${args[@]:0:$word_index}")" -- \
-    "${args[$word_index]}"
+  _@go.commands "${args[@]:0:$word_index}"
 }
 
 _@go.commands() {

--- a/libexec/complete
+++ b/libexec/complete
@@ -69,13 +69,13 @@ _@go.complete_args() {
       echo '-h'
       ;;
     -he*)
-      compgen -W "-help" -- "$1"
+      echo '-help'
       ;;
     -|--*)
-      compgen -W "--help" -- "$1"
+      echo '--help'
       ;;
     *)
-      _@go.complete_top_level_commands "$1"
+      compgen -W "$(_@go.complete_top_level_commands)" -- "$cmd_name"
       ;;
     esac
     return

--- a/libexec/env
+++ b/libexec/env
@@ -24,9 +24,7 @@ _@go.env() {
   if [[ "$1" == '--complete' ]]; then
     local word_index="$2"
     if [[ "$word_index" -eq '0' ]]; then
-      compgen -W '-' -- "$3"
-    else
-      return 1
+      echo '-'
     fi
     return
   fi

--- a/libexec/fullpath
+++ b/libexec/fullpath
@@ -15,14 +15,7 @@ _@go.fullpath_tab_completion() {
   local word="${args[$word_index]}"
 
   if [[ "$word_index" -eq '0' ]]; then
-    local err_count=0
-    if ! compgen -W '--existing' -- "$word"; then
-      ((++err_count))
-    fi
-    if ! compgen -f -- "$word"; then
-      ((++err_count))
-    fi
-    return $((err_count != 2 ? 0 : 1))
+    echo '--existing'
   fi
   compgen -f -- "$word"
 }

--- a/libexec/glob
+++ b/libexec/glob
@@ -189,17 +189,12 @@ _@go.glob_tab_completion() {
   if ! _@go.glob_tab_completion_parse_argv "$@"; then
     return 1
   elif [[ "$__go_glob_complete_flags_only" == 'true' ]]; then
-    compgen -W "${__go_glob_flags[*]}" -- "$__go_glob_complete_word"
+    echo "${__go_glob_flags[@]}"
     return
   elif [[ -z "$__go_glob_rootdir" ]]; then
-    local err_count=0
-    if ! compgen -W "${__go_glob_flags[*]}" -- "$__go_glob_complete_word"; then
-      ((++err_count))
-    fi
-    if ! compgen -d -- "$__go_glob_complete_word"; then
-      ((++err_count))
-    fi
-    return $((err_count != 2 ? 0 : 1))
+    echo "${__go_glob_flags[@]}"
+    compgen -d -- "$__go_glob_complete_word"
+    return
   fi
 
   local __go_glob_matches=()

--- a/libexec/modules
+++ b/libexec/modules
@@ -356,7 +356,7 @@ _@go.modules_tab_completion() {
     completions+=("${__go_modules_listing[@]}")
     @go.complete_remove_completions_already_present \
       'args' 'completions' "${#completions[@]}"
-    compgen -W "${completions[*]}" -- "$word"
+    echo "${completions[@]}"
   else
     # Shouldn't happen, since modules_produce_listing isn't parsing summaries.
     return 1

--- a/scripts/changes
+++ b/scripts/changes
@@ -19,11 +19,7 @@ _changes() {
     if [[ "$word_index" -gt 1 ]]; then
       return 1
     fi
-    shift
-    shift
-
-    local args=("$@")
-    compgen -W "$(git tag)" -- "${args[$word_index]}"
+    git tag
     return
   fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -48,7 +48,7 @@ _test_tab_completion() {
   local word_index="$1"
   shift
   if [[ "$word_index" -eq '0' ]]; then
-    compgen -W '--coverage --edit --list' -- "$1"
+    echo '--coverage' '--edit' '--list'
     if [[ "${1:0:1}" == '-' ]]; then
       return
     fi

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -10,17 +10,17 @@ load environment
 }
 
 @test "$SUITE: tab completions" {
-  run ./go aliases --complete 0 ''
+  run ./go complete 1 aliases ''
   assert_success '--exists'
 
-  run ./go aliases --complete 0 -
+  run ./go complete 1 aliases -
   assert_success '--exists'
 
-  run ./go aliases --complete 1 --exists
-  assert_success ''
+  run ./go complete 2 aliases --exists
+  assert_failure ''
 
-  run ./go aliases --complete 1 cd --exists
-  assert_success ''
+  run ./go complete 2 aliases cd --exists
+  assert_failure ''
 }
 
 @test "$SUITE: error on unknown flag" {

--- a/tests/builtins.bats
+++ b/tests/builtins.bats
@@ -13,14 +13,14 @@ load environment
   local expected=('--exists' '--summaries')
   local IFS=$'\n'
 
-  run ./go builtins --complete 0 ''
+  run ./go complete 1 builtins ''
   assert_success "${expected[*]}"
 
-  run ./go builtins --complete 0 -
+  run ./go complete 1 builtins -
   assert_success "${expected[*]}"
 
-  run ./go builtins --complete 1 --exists
-  assert_success ''
+  run ./go complete 2 builtins --exists
+  assert_failure ''
 }
 
 @test "$SUITE: return true if a builtin command exists, false if not" {

--- a/tests/changes.bats
+++ b/tests/changes.bats
@@ -35,16 +35,16 @@ create_fake_git() {
   assert_success "${versions[*]}"
 
   local PATH="$TEST_GO_ROOTDIR/bin:$PATH"
-  run ./go changes --complete 0 ''
+  run ./go complete 1 changes ''
   assert_success "${versions[*]}"
 
-  run ./go changes --complete 0 'v1.0'
+  run ./go complete 1 changes 'v1.0'
   assert_success 'v1.0.0'
 
-  run ./go changes --complete 1 'v1.0.0' 'v1.1'
+  run ./go complete 2 changes 'v1.0.0' 'v1.1'
   assert_success 'v1.1.0'
 
-  run ./go changes --complete 2 'v1.0.0' 'v1.1.0' ''
+  run ./go complete 3 changes 'v1.0.0' 'v1.1.0' ''
   assert_failure ''
 }
 

--- a/tests/commands/main.bats
+++ b/tests/commands/main.bats
@@ -19,35 +19,35 @@ teardown() {
 }
 
 @test "$SUITE: tab completions" {
-  run "$TEST_GO_SCRIPT" commands --complete 0
+  run "$TEST_GO_SCRIPT" complete 1 commands ''
   local flags=('--paths' '--summaries')
   local expected=("${flags[@]}" "${BUILTIN_CMDS[@]}")
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 0 --
+  run "$TEST_GO_SCRIPT" complete 1 commands --
   local flags=('--paths' '--summaries')
   assert_success "${flags[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 0 --p
+  run "$TEST_GO_SCRIPT" complete 1 commands --p
   local flags=('--paths')
   assert_success '--paths'
 
-  run "$TEST_GO_SCRIPT" commands --complete 0 --foo
+  run "$TEST_GO_SCRIPT" complete 1 commands --foo
   assert_failure
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 --paths
+  run "$TEST_GO_SCRIPT" complete 2 commands --paths
   assert_success "${BUILTIN_CMDS[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 --summaries
+  run "$TEST_GO_SCRIPT" complete 2 commands --summaries
   assert_success "${BUILTIN_CMDS[*]}"
 }
 
 @test "$SUITE: no tab completions for or after search paths" {
-  run "$TEST_GO_SCRIPT" commands --complete 0 "$TEST_GO_SCRIPTS_DIR"
+  run "$TEST_GO_SCRIPT" complete 1 commands "$TEST_GO_SCRIPTS_DIR"
   assert_failure
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 "$TEST_GO_SCRIPTS_DIR"
+  run "$TEST_GO_SCRIPT" complete 2 commands "$TEST_GO_SCRIPTS_DIR"
   assert_failure
 }
 
@@ -62,18 +62,18 @@ teardown() {
     create_test_command_script "foo.d/$subcommand"
   done
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 foo
+  run "$TEST_GO_SCRIPT" complete 2 commands foo
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 foo b
+  run "$TEST_GO_SCRIPT" complete 2 commands foo b
   expected=('bar' 'baz')
   assert_success "${expected[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 foo g
+  run "$TEST_GO_SCRIPT" complete 2 commands foo g
   assert_failure
 
-  run "$TEST_GO_SCRIPT" commands --complete 2 foo bar
+  run "$TEST_GO_SCRIPT" complete 3 commands foo bar
   assert_failure
 }
 
@@ -88,12 +88,12 @@ teardown() {
     create_test_command_script "foo.d/$subcommand"
   done
 
-  run "$TEST_GO_SCRIPT" commands --complete 0 '' foo
+  run "$TEST_GO_SCRIPT" complete 1 commands '' foo
   expected=('--paths' '--summaries')
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run "$TEST_GO_SCRIPT" commands --complete 1 foo '' bar
+  run "$TEST_GO_SCRIPT" complete 2 commands foo '' bar
   assert_failure
 }
 

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -110,10 +110,7 @@ teardown() {
   create_test_command_script foo \
     'if [[ "$1" == "--complete" ]]; then ' \
     '  # Tab completions' \
-    '  local index="$2"' \
-    '  shift; shift' \
-    '  local args=("$@")' \
-    '  compgen -W "bar baz quux" -- "${args[$index]}"' \
+    '  echo "bar" "baz" "quux"' \
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo
@@ -138,10 +135,7 @@ teardown() {
 @test "$SUITE: command script completion not detected without comment" {
   create_test_command_script foo \
     'if [[ "$1" == "--complete" ]]; then ' \
-    '  local index="$2"' \
-    '  shift; shift' \
-    '  local args=("$@")' \
-    '  compgen -W "bar baz quux" -- "${args[$index]}"' \
+    '  echo "bar" "baz" "quux"' \
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo
@@ -155,10 +149,7 @@ teardown() {
   create_test_command_script foo \
     'if [[ "$1" == "--complete" ]]; then ' \
     '  # Tab completions' \
-    '  local index="$2"' \
-    '  shift; shift' \
-    '  local args=("$@")' \
-    '  compgen -W "baz quux" -- "${args[$index]}"' \
+    '  echo "baz" "quux"' \
     'fi'
 
   mkdir "$TEST_GO_SCRIPTS_DIR/foo.d"
@@ -166,10 +157,7 @@ teardown() {
   create_test_command_script foo.d/bar \
     'if [[ "$1" == "--complete" ]]; then ' \
     '  # Tab completions' \
-    '  local index="$2"' \
-    '  shift; shift' \
-    '  local args=("$@")' \
-    '  compgen -W "plugh xyzzy" -- "${args[$index]}"' \
+    '  echo "plugh" "xyzzy"' \
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -11,16 +11,16 @@ teardown() {
 }
 
 @test "$SUITE: tab completions" {
-  run "$TEST_GO_SCRIPT" env --complete 0
+  run "$TEST_GO_SCRIPT" complete 1 env ''
   assert_success '-'
 
-  run "$TEST_GO_SCRIPT" env --complete 0 '-'
+  run "$TEST_GO_SCRIPT" complete 1 env '-'
   assert_success '-'
 
-  run "$TEST_GO_SCRIPT" env --complete 0 '--foo'
+  run "$TEST_GO_SCRIPT" complete 1 env '--foo'
   assert_failure ''
 
-  run "$TEST_GO_SCRIPT" env --complete 1 '-' 'invalid'
+  run "$TEST_GO_SCRIPT" complete 2 env '-' 'invalid'
   assert_failure ''
 }
 

--- a/tests/fullpath.bats
+++ b/tests/fullpath.bats
@@ -10,16 +10,16 @@ teardown() {
   local expected=('--existing')
   expected+=($(compgen -f))
 
-  run ./go fullpath --complete 0
+  run ./go complete 1 fullpath ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run ./go fullpath --complete 0 '-'
+  run ./go complete 1 fullpath '-'
   assert_success '--existing'
 
   expected=($(compgen -f -- 'li'))
   [[ "${#expected[@]}" -ne '0' ]]
-  run ./go fullpath --complete 0 'li'
+  run ./go complete 1 fullpath 'li'
   assert_success "${expected[*]}"
 }
 

--- a/tests/glob/arg-completion.bats
+++ b/tests/glob/arg-completion.bats
@@ -16,112 +16,107 @@ teardown() {
   local expected=('--trim' '--ignore')
   expected+=($(compgen -d))
 
-  run ./go glob --complete 0
+  run ./go complete 1 glob ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: first argument" {
   local expected=('--trim' '--ignore')
-  expected+=($(compgen -d))
 
-  run ./go glob --complete 0 ''
+  run ./go complete 1 glob '-'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  expected=('--trim' '--ignore')
-  run ./go glob --complete 0 '-'
-  assert_success "${expected[*]}"
-
-  run ./go glob --complete 0 '--t'
+  run ./go complete 1 glob '--t'
   assert_success '--trim'
 
-  run ./go glob --complete 0 '--i'
+  run ./go complete 1 glob '--i'
   assert_success '--ignore'
 
   expected=($(compgen -f -- 'li'))
   [[ "${#expected[@]}" -ne '0' ]]
-  run ./go glob --complete 0 'li'
+  run ./go complete 1 glob 'li'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: completion omits flags already present" {
   local expected=('--ignore' $(compgen -d))
-  run ./go glob --complete 1 '--trim'
+  run ./go complete 2 glob '--trim' ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 1 '--trim' '-'
+  run ./go complete 2 glob  '--trim' '-'
   assert_success '--ignore'
 
   expected[0]='--trim'
-  run ./go glob --complete 2 '--ignore' 'foo*:bar*'
+  run ./go complete 3 glob '--ignore' 'foo*:bar*' ''
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 2 '--ignore' 'foo*:bar*' '-'
+  run ./go complete 3 glob '--ignore' 'foo*:bar*' '-'
   assert_success '--trim'
 
   unset expected[0]
-  run ./go glob --complete 3 '--ignore' 'foo*:bar*' '--trim'
+  run ./go complete 4 glob '--ignore' 'foo*:bar*' '--trim' ''
   assert_success "${expected[*]}"
 
   expected=($(compgen -f -- 'li'))
   [[ "${#expected[@]}" -ne '0' ]]
-  run ./go glob --complete 3 '--ignore' 'foo*:bar*' '--trim' 'li'
+  run ./go complete 4 glob '--ignore' 'foo*:bar*' '--trim' 'li'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: argument does not complete if previous is --ignore" {
   # The next argument should be the GLOBIGNORE value.
-  run ./go glob --complete 1 '--ignore'
+  run ./go complete 2 glob '--ignore' ''
   assert_failure ''
 
-  run ./go glob --complete 2 '--trim' '--ignore'
+  run ./go complete 3 glob '--trim' '--ignore' ''
   assert_failure ''
 
-  run ./go glob --complete 1 '--ignore' '' 'tests'
+  run ./go complete 2 glob '--ignore' '' 'tests'
   assert_failure
 }
 
 @test "$SUITE: argument does not complete if previous is root dir" {
   # The next argument should be the suffix pattern.
-  run ./go glob --complete 1 'tests'
+  run ./go complete 2 glob 'tests' ''
   assert_failure ''
 
-  run ./go glob --complete 2 '--trim' 'tests'
+  run ./go complete 3 glob '--trim' 'tests' ''
   assert_failure ''
 
-  run ./go glob --complete 4 '--trim' '--ignore' 'foo*:bar*' 'tests'
+  run ./go complete 5 glob '--trim' '--ignore' 'foo*:bar*' 'tests' ''
   assert_failure ''
 }
 
 @test "$SUITE: arguments before flags only complete other flags" {
-  run ./go glob --complete 0 '' '--trim'
+  run ./go complete 1 glob '' '--trim'
   assert_success '--ignore'
 
-  run ./go glob --complete 0 '' '--ignore'
+  run ./go complete 1 glob '' '--ignore'
   assert_success '--trim'
 }
 
 @test "$SUITE: complete flags before rootdir" {
   local expected=('--trim' '--ignore')
-  run ./go glob --complete 0 '' 'tests'
+  run ./go complete 1 glob '' 'tests'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 1 '--trim' '' 'tests'
+  run ./go complete 2 glob '--trim' '' 'tests'
   assert_success '--ignore'
 
-  run ./go glob --complete 2 '--ignore' 'foo*:bar*' '' 'tests'
+  run ./go complete 3 glob '--ignore' 'foo*:bar*' '' 'tests'
   assert_success '--trim'
 }
 
 @test "$SUITE: complete rootdir" {
-  run ./go glob --complete 0 'tests'
+  run ./go complete 1 glob 'tests'
   assert_success 'tests'
 
   local expected=($(compgen -d 'tests/'))
-  run ./go glob --complete 0 'tests/'
+  run ./go complete 1 glob 'tests/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -130,18 +125,18 @@ teardown() {
   touch "$TESTS_DIR"/{foo,bar,baz}.bats
   local expected=('bar' 'baz' 'foo')
 
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 3 '--trim' "$TESTS_DIR" '.bats'
+  run ./go complete 4 glob '--trim' "$TESTS_DIR" '.bats' ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 3 "$TESTS_DIR" '.bats' 'foo'
+  run ./go complete 4 glob "$TESTS_DIR" '.bats' 'foo' ''
   assert_success "${expected[*]}"
 
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats' '' 'foo'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' '' 'foo'
   assert_success "${expected[*]}"
 }
 
@@ -152,7 +147,7 @@ teardown() {
     "$TESTS_DIR"/baz/plugh.bats
   local expected=('bar/' 'baz/' 'foo/')
 
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -162,7 +157,7 @@ teardown() {
   touch "$TESTS_DIR"/foo{,/bar,/baz}.bats
   local expected=('foo' 'foo/')
 
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats' 'f'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' 'f'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -172,7 +167,7 @@ teardown() {
   touch "$TESTS_DIR"/foo{,/bar,/baz}.bats
   local expected=('foo/bar' 'foo/baz')
 
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats' 'foo/'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' 'foo/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -182,7 +177,7 @@ teardown() {
   touch "$TESTS_DIR"/foo/{bar,baz}.bats
 
   local expected=('foo/bar' 'foo/baz')
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats' 'foo/'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' 'foo/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -192,20 +187,20 @@ teardown() {
   touch "$TESTS_DIR"/{foo/quux,bar/xyzzy,baz/plugh,baz/xyzzy}.bats
 
   # Remember that --ignore will add the rootdir to all the patterns.
-  run ./go glob --complete 4 '--ignore' "foo/*:bar/*:baz/pl*" \
-    "$TESTS_DIR" '.bats'
+  run ./go complete 5 glob '--ignore' "foo/*:bar/*:baz/pl*" \
+    "$TESTS_DIR" '.bats' ''
   local IFS=$'\n'
   assert_success 'baz/xyzzy'
 
   # Make sure the --ignore argument has any quotes removed, as the shell will
   # not expand any command line arguments or unquote them during completion.
-  run ./go glob --complete 4 '--ignore' "'foo/*:bar/*:baz/pl*'" \
-    "$TESTS_DIR" '.bats'
+  run ./go complete 5 glob '--ignore' "'foo/*:bar/*:baz/pl*'" \
+    "$TESTS_DIR" '.bats' ''
   assert_success 'baz/xyzzy'
 }
 
 @test "$SUITE: return error if no matches" {
-  run ./go glob --complete 2 "$TESTS_DIR" '.bats' 'foo'
+  run ./go complete 3 glob "$TESTS_DIR" '.bats' 'foo'
   assert_failure
 }
 

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -13,14 +13,14 @@ teardown() {
 @test "$SUITE: tab completion" {
   local subcommands=('plugh' 'quux' 'xyzzy')
   create_parent_and_subcommands foo "${subcommands[@]}"
-  run "$TEST_GO_SCRIPT" help --complete 0 'foo'
+  run "$TEST_GO_SCRIPT" complete 1 help 'foo'
   assert_success 'foo'
 
   local IFS=$'\n'
-  run "$TEST_GO_SCRIPT" help --complete 1 'foo' ''
+  run "$TEST_GO_SCRIPT" complete 2 help 'foo' ''
   assert_success "${subcommands[*]}"
 
-  run "$TEST_GO_SCRIPT" help --complete 1 'foo' 'q'
+  run "$TEST_GO_SCRIPT" complete 2 help 'foo' 'q'
   assert_success 'quux'
 }
 

--- a/tests/modules/arg-completion.bats
+++ b/tests/modules/arg-completion.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "$SUITE: zero arguments" {
-  run "$TEST_GO_SCRIPT" modules --complete
+  run "$TEST_GO_SCRIPT" complete 1 modules ''
   local expected=('-h' '-help' '--help' '--paths' '--summaries' '--imported'
     "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
   local IFS=$'\n'
@@ -21,39 +21,39 @@ teardown() {
 }
 
 @test "$SUITE: first argument matches help flags" {
-  run "$TEST_GO_SCRIPT" modules --complete 0 -h _foo
+  run "$TEST_GO_SCRIPT" complete 1 modules -h _foo
   local expected=('-h' '-help')
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: first argument matches modules" {
-  run "$TEST_GO_SCRIPT" modules --complete 0 _f
+  run "$TEST_GO_SCRIPT" complete 1 modules _f
   local expected=('_frobozz' '_frotz' '_foo/')
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: only complete first flag" {
-  run "$TEST_GO_SCRIPT" modules --complete 0 --pat --sum
+  run "$TEST_GO_SCRIPT" complete 1 modules --pat --sum
   assert_success '--paths'
 
-  run "$TEST_GO_SCRIPT" modules --complete 1 --paths --sum
+  run "$TEST_GO_SCRIPT" complete 2 modules --paths --sum
   assert_failure ''
 }
 
 @test "$SUITE: only complete flag as first arg" {
-  run "$TEST_GO_SCRIPT" modules --complete 1 foo --pat
+  run "$TEST_GO_SCRIPT" complete 2 modules _foo --pat
   assert_failure ''
 }
 
 @test "$SUITE: nothing else when --imported present" {
-  run "$TEST_GO_SCRIPT" modules --complete 1 --imported foo
+  run "$TEST_GO_SCRIPT" complete 2 modules --imported _foo
   assert_failure ''
 }
 
 @test "$SUITE: nothing else when first flag not recognized" {
-  run "$TEST_GO_SCRIPT" modules --complete 1 --bogus-flag foo
+  run "$TEST_GO_SCRIPT" complete 2 modules --bogus-flag _foo
   assert_failure ''
 }
 
@@ -61,72 +61,72 @@ teardown() {
   # Note that plugins are offered last
   local expected=(
     "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
-  run "$TEST_GO_SCRIPT" modules --complete 1 --help
+  run "$TEST_GO_SCRIPT" complete 2 modules --help ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: return matching plugins and modules" {
   local expected=('_frobozz' '_frotz' '_foo/')
-  run "$TEST_GO_SCRIPT" modules --complete 1 help '_f'
+  run "$TEST_GO_SCRIPT" complete 2 modules help '_f'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: return only matching plugin names" {
   local expected=('_bar/' '_baz/')
-  run "$TEST_GO_SCRIPT" modules --complete 1 help '_b'
+  run "$TEST_GO_SCRIPT" complete 2 modules help '_b'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: return all matches for a plugin when no other matches" {
   local expected=('_foo/_plugh' '_foo/_quux' '_foo/_xyzzy')
-  run "$TEST_GO_SCRIPT" modules --complete 1 help '_fo'
+  run "$TEST_GO_SCRIPT" complete 2 modules help '_fo'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: return matches for a plugin when arg ends with a slash" {
   local expected=('_baz/_plugh' '_baz/_quux' '_baz/_xyzzy')
-  run "$TEST_GO_SCRIPT" modules --complete 1 help '_baz/'
+  run "$TEST_GO_SCRIPT" complete 2 modules help '_baz/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: no matches" {
-  run "$TEST_GO_SCRIPT" modules --complete 1 help '_x'
+  run "$TEST_GO_SCRIPT" complete 2 modules help '_x'
   assert_failure ''
 }
 
 @test "$SUITE: complete only first argument for help" {
-  run "$TEST_GO_SCRIPT" modules --complete 2 --help '_frobozz' '_fr'
+  run "$TEST_GO_SCRIPT" complete 3 modules --help '_frobozz' '_fr'
   assert_failure ''
 }
 
 @test "$SUITE: complete subsequent args for flags other than help" {
   # Note that matches already on command line are not completed.
-  run "$TEST_GO_SCRIPT" modules --complete 2 --paths '_frobozz' '_fr'
+  run "$TEST_GO_SCRIPT" complete 3 modules --paths '_frobozz' '_fr'
   assert_success '_frotz'
 }
 
 @test "$SUITE: complete subsequent args if first arg not a flag" {
   # Note that matches already on command line are not completed.
-  run "$TEST_GO_SCRIPT" modules --complete 1 '_frobozz' '_fr'
+  run "$TEST_GO_SCRIPT" complete 2 modules '_frobozz' '_fr'
   assert_success '_frotz'
 }
 
 @test "$SUITE: remove plugin completions already present" {
   local expected=('_foo/_quux' '_foo/_xyzzy')
-  run "$TEST_GO_SCRIPT" modules --complete 1 '_foo/_plugh' '_foo/'
+  run "$TEST_GO_SCRIPT" complete 2 modules '_foo/_plugh' '_foo/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: don't complete plugins when all modules already present" {
   local expected=("${CORE_MODULES[@]}" '_frobozz' '_frotz' '_bar/' '_baz/')
-  run "$TEST_GO_SCRIPT" modules --complete 3 \
-    '_foo/_plugh' '_foo/_quux' '_foo/_xyzzy'
+  run "$TEST_GO_SCRIPT" complete 4 modules \
+    '_foo/_plugh' '_foo/_quux' '_foo/_xyzzy' ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }

--- a/tests/path.bats
+++ b/tests/path.bats
@@ -13,14 +13,14 @@ teardown() {
 @test "$SUITE: tab completion" {
   local subcommands=('plugh' 'quux' 'xyzzy')
   create_parent_and_subcommands foo "${subcommands[@]}"
-  run "$TEST_GO_SCRIPT" path --complete 0 'foo'
+  run "$TEST_GO_SCRIPT" complete 1 path 'foo'
   assert_success 'foo'
 
   local IFS=$'\n'
-  run "$TEST_GO_SCRIPT" path --complete 1 'foo' ''
+  run "$TEST_GO_SCRIPT" complete 2 path 'foo' ''
   assert_success "${subcommands[*]}"
 
-  run "$TEST_GO_SCRIPT" path --complete 1 'foo' 'q'
+  run "$TEST_GO_SCRIPT" complete 2 path 'foo' 'q'
   assert_success 'quux'
 }
 

--- a/tests/plugins.bats
+++ b/tests/plugins.bats
@@ -13,17 +13,17 @@ teardown() {
 
 @test "$SUITE: tab completion returns error if no plugins dir" {
   rmdir "$TEST_GO_PLUGINS_DIR"
-  run "$TEST_GO_SCRIPT" plugins --complete 0 ''
+  run "$TEST_GO_SCRIPT" complete 1 plugins ''
   assert_failure ''
 }
 
 @test "$SUITE: tab completion returns flags if plugins dir present" {
-  run "$TEST_GO_SCRIPT" plugins --complete 0 ''
+  run "$TEST_GO_SCRIPT" complete 1 plugins ''
   local expected=('--paths' '--summaries')
   local IFS=$'\n'
   assert_success "${expected[*]}"
 
-  run "$TEST_GO_SCRIPT" plugins --complete 0 '--paths'
+  run "$TEST_GO_SCRIPT" complete 1 plugins '--paths'
   assert_success '--paths'
 }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -10,7 +10,7 @@ teardown() {
 }
 
 @test "$SUITE: tab complete flags" {
-  run ./go test --complete 0 '-'
+  run ./go complete 1 test '-'
   local expected=('--coverage' '--edit' '--list')
   local IFS=$'\n'
   assert_success "${expected[*]}"
@@ -22,14 +22,14 @@ teardown() {
     '--trim' '--ignore' 'bats' 'tests' '.bats'))
   [[ "${#expected[@]}" -ne 1 ]]
 
-  run ./go test --complete 0 ''
+  run ./go complete 1 test ''
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
 
 @test "$SUITE: tab completion matches test file and matching directory" {
   expected=('core' 'core/')
-  run ./go test --complete 0 'core'
+  run ./go complete 1 test 'core'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }
@@ -43,7 +43,7 @@ _trim_expected() {
   local expected=(tests/core/*.bats)
   _trim_expected
 
-  run ./go test --complete 0 'core/'
+  run ./go complete 1 test 'core/'
   local IFS=$'\n'
   assert_success "${expected[*]}"
 }


### PR DESCRIPTION
The test update ensures that the `./go complete` contract continues to hold for all commands. After updating the tests, all of the `compgen -W` calls outside of `libexec/complete` could be replaced with `echo`, since the output had always been funneled through `compgen -W` in `_@go.complete_args`. Not requiring individual command scripts to call `compgen -W` should make it easier to implement argument completion.

The PR also has a couple of very minor variable quoting updates for `lib/bats/assertions` and `lib/internal/env/bash`.