### PR TITLE
Fix latent assertion output bug

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -24,6 +24,17 @@
 #     fail "output should not match: '$pattern'"
 #   fi
 #
+# Alternatively, write your own assertion functions starting with:
+#
+#   set +o functrace
+#
+# and then make sure every return path calls:
+#
+#   return_from_bats_assertion "$return_status" "$BASH_SOURCE"
+#
+# You may wish to wrap `return_from_bats_assertion` in a local helper function
+# to avoid having to specify `$BASH_SOURCE` everywhere.
+#
 # The assertions borrow inspiration from rbenv/test/test_helper.bash.
 
 # Unconditionally returns a failing status
@@ -165,6 +176,48 @@ assert_line_matches() {
   __assert_line 'assert_matches' "$@"
 }
 
+# Scrubs the Bats stacks of functions from the assertion source file
+#
+# You must ensure that `set +o functrace` is in effect prior to calling this
+# function. If you write an assertion function that uses an assertion from this
+# file, or which uses any other assertion that evantually calls this function,
+# you will need to call `set +o functrace` again following those assertions.
+#
+# This helps ensure that Bats failure messages only contain the location at
+# which an assertion was called, rather than containing stack trace information
+# about the assertion implementation itself.
+#
+# Bats sets 'functrace' to make sure failing commands are pinpointed. This is
+# almost always the desired behavior, except that we don't actually want a stack
+# trace showing assertion implementation details. When it does, it produces a
+# bit of mental overhead when reviewing test failures to identify the location
+# of the failing assertion in the test case itself.
+#
+# Notice that each public assertion function starts with 'set +o functrace', and
+# this function ends with 'set -o functrace'. However, just calling 'set +o
+# functrace' still leaves the function, file, and line number where the
+# assertion was defined in the Bats failure output. Plus, we want to ensure that
+# 'set -o functrace' goes back into effect once the assertion has finished.
+#
+# Arguments:
+#   $1:  The $BASH_SOURCE value from the assertion source file
+#   $2:  Return value of the calling assertion; defaults to 0
+return_from_bats_assertion() {
+  local assertion_source_file="$1"
+  local result="${2:-0}"
+
+  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+    unset 'BATS_CURRENT_STACK_TRACE[0]'
+  fi
+
+  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+    unset 'BATS_PREVIOUS_STACK_TRACE[0]'
+  fi
+
+  set -o functrace
+  return "$result"
+}
+
 # --------------------------------
 # IMPLEMENTATION - HERE BE DRAGONS
 #
@@ -214,35 +267,10 @@ __assert_line() {
 
 # Scrubs the Bats stacks of references to functions from this file
 #
-# This helps ensure that Bats failure messages only contain the location at
-# which an assertion was called, rather than containing stack trace information
-# about the assertion implementation itself.
-#
-# Bats sets 'functrace' to make sure failing commands are pinpointed. This is
-# almost always the desired behavior, except that we don't actually want a stack
-# trace showing assertion implementation details. When it does, it produces a
-# bit of mental overhead when reviewing test failures to identify the location
-# of the failing assertion in the test case itself.
-#
-# Notice that each public assertion function starts with 'set +o functrace', and
-# this function ends with 'set -o functrace'. However, just calling 'set +o
-# functrace' still leaves the function, file, and line number where the
-# assertion was defined in the Bats failure output. Plus, we want to ensure that
-# 'set -o functrace' goes back into effect once the assertion has finished.
+# See the comment for return_from_bats_assertion for details.
 #
 # Arguments:
 #   $1:  Return value of the calling assertion; defaults to 0
 __return_from_bats_assertion() {
-  local result="${1:-0}"
-
-  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $BASH_SOURCE ]]; then
-    unset 'BATS_CURRENT_STACK_TRACE[0]'
-  fi
-
-  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $BASH_SOURCE ]]; then
-    unset 'BATS_PREVIOUS_STACK_TRACE[0]'
-  fi
-
-  set -o functrace
-  return "$result"
+  return_from_bats_assertion "$BASH_SOURCE" "$1"
 }

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -215,6 +215,7 @@ bats_assertion_return_trap() {
   if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $1 ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
+  trap - RETURN
   set -o functrace
 }
 
@@ -237,9 +238,8 @@ __assert_output() {
   if [[ "$#" -ne 2 ]]; then
     echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
     return 1
-  else
-    "$assertion" "$constraint" "$output" 'output'
   fi
+  "$assertion" "$constraint" "$output" 'output'
 }
 
 # Common implementation for assertions that evaluate the Bats $line variable

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -24,13 +24,16 @@
 #     fail "output should not match: '$pattern'"
 #   fi
 #
-# Alternatively, write your own assertion functions that call the following
-# before returning:
+# Alternatively, write your own assertion functions starting with:
 #
 #   set +o functrace
-#   trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
 #
-# See the comment for `bats_assertion_return_trap` for more details.
+# and then make sure every return path calls:
+#
+#   return_from_bats_assertion "$return_status" "$BASH_SOURCE"
+#
+# You may wish to wrap `return_from_bats_assertion` in a local helper function
+# to avoid having to specify `$BASH_SOURCE` everywhere.
 #
 # The assertions borrow inspiration from rbenv/test/test_helper.bash.
 
@@ -43,14 +46,13 @@
 #   $1:  (optional) Reason to include in the failure output
 fail() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local reason="$1"
 
   if [[ -n "$reason" ]]; then
     printf 'failed for the following reason:\n  %s\n' "$reason" >&2
   fi
   printf 'STATUS: %s\nOUTPUT:\n%s\n' "$status" "$output" >&2
-  return 1
+  __return_from_bats_assertion 1
 }
 
 # Compares two values for equality
@@ -61,7 +63,6 @@ fail() {
 #   $3: A label explaining the value being evaluated
 assert_equal() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local expected="$1"
   local actual="$2"
   local label="$3"
@@ -69,7 +70,9 @@ assert_equal() {
   if [[ "$expected" != "$actual" ]]; then
     printf '%s not equal to expected value:\n  %s\n  %s\n' \
       "$label" "expected: '$expected'" "actual:   '$actual'" >&2
-    return 1
+    __return_from_bats_assertion 1
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -81,7 +84,6 @@ assert_equal() {
 #   $3: A label explaining the value being matched
 assert_matches() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local pattern="$1"
   local value="$2"
   local label="$3"
@@ -89,7 +91,9 @@ assert_matches() {
   if [[ ! "$value" =~ $pattern ]]; then
     printf '%s does not match expected pattern:\n  %s\n  %s\n' \
       "$label" "pattern: '$pattern'" "value:   '$value'" >&2
-    return 1
+    __return_from_bats_assertion 1
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -117,7 +121,6 @@ assert_output_matches() {
 #   $1: The expected value for $status
 assert_status() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   assert_equal "$1" "$status" "exit status"
 }
 
@@ -127,13 +130,13 @@ assert_status() {
 #   $1: The regular expression to match against $output
 assert_success() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
-
   if [[ "$status" -ne '0' ]]; then
     printf 'expected success, but command failed\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -143,13 +146,13 @@ assert_success() {
 #   $1: The regular expression to match against $output
 assert_failure() {
   set +o functrace
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
-
   if [[ "$status" -eq '0' ]]; then
     printf 'expected failure, but command succeeded\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -175,25 +178,15 @@ assert_line_matches() {
 
 # Scrubs the Bats stacks of functions from the assertion source file
 #
+# You must ensure that `set +o functrace` is in effect prior to calling this
+# function. If you write an assertion function that uses an assertion from this
+# file, or which uses any other assertion that evantually calls this function,
+# you will need to call `set +o functrace` again following those assertions.
+#
 # This helps ensure that Bats failure messages only contain the location at
 # which an assertion was called, rather than containing stack trace information
 # about the assertion implementation itself.
 #
-# You must ensure that `set +o functrace` is in effect prior to calling this
-# function. Usually you'll do this by making these the first two lines of your
-# assertion function, or by adding them just before returning an error value (if
-# you accumulate multiple assertion errors in one function, since each assertion
-# may reset `set -e functrace`):
-#
-#   set +o functrace
-#   trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
-#
-# Or, if you have a shared implementation function, call `set +o functrace` at
-# the beginning of each public-facing function, and set the trap in the
-# implementation function, as with __assert_output and __assert_line.
-#
-# Background
-# ----------
 # Bats sets 'functrace' to make sure failing commands are pinpointed. This is
 # almost always the desired behavior, except that we don't actually want a stack
 # trace showing assertion implementation details. When it does, it produces a
@@ -208,15 +201,21 @@ assert_line_matches() {
 #
 # Arguments:
 #   $1:  The $BASH_SOURCE value from the assertion source file
-bats_assertion_return_trap() {
-  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $1 ]]; then
+#   $2:  Return value of the calling assertion; defaults to 0
+return_from_bats_assertion() {
+  local assertion_source_file="$1"
+  local result="${2:-0}"
+
+  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
     unset 'BATS_CURRENT_STACK_TRACE[0]'
   fi
-  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $1 ]]; then
+
+  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
-  trap - RETURN
+
   set -o functrace
+  return "$result"
 }
 
 # --------------------------------
@@ -231,15 +230,15 @@ bats_assertion_return_trap() {
 #   $1: The assertion to execute
 #   $2: The assertion argument signifying the expected outcome for $output
 __assert_output() {
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local assertion="$1"
   local constraint="$2"
 
   if [[ "$#" -ne 2 ]]; then
     echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
-    return 1
+    __return_from_bats_assertion 1
+  else
+    "$assertion" "$constraint" "$output" 'output'
   fi
-  "$assertion" "$constraint" "$output" 'output'
 }
 
 # Common implementation for assertions that evaluate the Bats $line variable
@@ -249,7 +248,6 @@ __assert_output() {
 #   $2: The index into $line identifying the line to evaluate
 #   $3: The assertion argument signifying the expected outcome for ${line[$2]}
 __assert_line() {
-  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local assertion="$1"
   local lineno="$2"
   local constraint="$3"
@@ -261,6 +259,18 @@ __assert_line() {
 
   if ! "$assertion" "$constraint" "${lines[$lineno]}" "line $lineno"; then
     printf 'OUTPUT:\n%s\n' "$output" >&2
-    return 1
+    __return_from_bats_assertion 1
+  else
+    __return_from_bats_assertion
   fi
+}
+
+# Scrubs the Bats stacks of references to functions from this file
+#
+# See the comment for return_from_bats_assertion for details.
+#
+# Arguments:
+#   $1:  Return value of the calling assertion; defaults to 0
+__return_from_bats_assertion() {
+  return_from_bats_assertion "$BASH_SOURCE" "$1"
 }

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -24,16 +24,13 @@
 #     fail "output should not match: '$pattern'"
 #   fi
 #
-# Alternatively, write your own assertion functions starting with:
+# Alternatively, write your own assertion functions that call the following
+# before returning:
 #
 #   set +o functrace
+#   trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
 #
-# and then make sure every return path calls:
-#
-#   return_from_bats_assertion "$return_status" "$BASH_SOURCE"
-#
-# You may wish to wrap `return_from_bats_assertion` in a local helper function
-# to avoid having to specify `$BASH_SOURCE` everywhere.
+# See the comment for `bats_assertion_return_trap` for more details.
 #
 # The assertions borrow inspiration from rbenv/test/test_helper.bash.
 
@@ -46,13 +43,14 @@
 #   $1:  (optional) Reason to include in the failure output
 fail() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local reason="$1"
 
   if [[ -n "$reason" ]]; then
     printf 'failed for the following reason:\n  %s\n' "$reason" >&2
   fi
   printf 'STATUS: %s\nOUTPUT:\n%s\n' "$status" "$output" >&2
-  __return_from_bats_assertion 1
+  return 1
 }
 
 # Compares two values for equality
@@ -63,6 +61,7 @@ fail() {
 #   $3: A label explaining the value being evaluated
 assert_equal() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local expected="$1"
   local actual="$2"
   local label="$3"
@@ -70,9 +69,7 @@ assert_equal() {
   if [[ "$expected" != "$actual" ]]; then
     printf '%s not equal to expected value:\n  %s\n  %s\n' \
       "$label" "expected: '$expected'" "actual:   '$actual'" >&2
-    __return_from_bats_assertion 1
-  else
-    __return_from_bats_assertion
+    return 1
   fi
 }
 
@@ -84,6 +81,7 @@ assert_equal() {
 #   $3: A label explaining the value being matched
 assert_matches() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local pattern="$1"
   local value="$2"
   local label="$3"
@@ -91,9 +89,7 @@ assert_matches() {
   if [[ ! "$value" =~ $pattern ]]; then
     printf '%s does not match expected pattern:\n  %s\n  %s\n' \
       "$label" "pattern: '$pattern'" "value:   '$value'" >&2
-    __return_from_bats_assertion 1
-  else
-    __return_from_bats_assertion
+    return 1
   fi
 }
 
@@ -121,6 +117,7 @@ assert_output_matches() {
 #   $1: The expected value for $status
 assert_status() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   assert_equal "$1" "$status" "exit status"
 }
 
@@ -130,13 +127,13 @@ assert_status() {
 #   $1: The regular expression to match against $output
 assert_success() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
+
   if [[ "$status" -ne '0' ]]; then
     printf 'expected success, but command failed\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
-  else
-    __return_from_bats_assertion
   fi
 }
 
@@ -146,13 +143,13 @@ assert_success() {
 #   $1: The regular expression to match against $output
 assert_failure() {
   set +o functrace
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
+
   if [[ "$status" -eq '0' ]]; then
     printf 'expected failure, but command succeeded\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
-  else
-    __return_from_bats_assertion
   fi
 }
 
@@ -178,15 +175,25 @@ assert_line_matches() {
 
 # Scrubs the Bats stacks of functions from the assertion source file
 #
-# You must ensure that `set +o functrace` is in effect prior to calling this
-# function. If you write an assertion function that uses an assertion from this
-# file, or which uses any other assertion that evantually calls this function,
-# you will need to call `set +o functrace` again following those assertions.
-#
 # This helps ensure that Bats failure messages only contain the location at
 # which an assertion was called, rather than containing stack trace information
 # about the assertion implementation itself.
 #
+# You must ensure that `set +o functrace` is in effect prior to calling this
+# function. Usually you'll do this by making these the first two lines of your
+# assertion function, or by adding them just before returning an error value (if
+# you accumulate multiple assertion errors in one function, since each assertion
+# may reset `set -e functrace`):
+#
+#   set +o functrace
+#   trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
+#
+# Or, if you have a shared implementation function, call `set +o functrace` at
+# the beginning of each public-facing function, and set the trap in the
+# implementation function, as with __assert_output and __assert_line.
+#
+# Background
+# ----------
 # Bats sets 'functrace' to make sure failing commands are pinpointed. This is
 # almost always the desired behavior, except that we don't actually want a stack
 # trace showing assertion implementation details. When it does, it produces a
@@ -201,21 +208,14 @@ assert_line_matches() {
 #
 # Arguments:
 #   $1:  The $BASH_SOURCE value from the assertion source file
-#   $2:  Return value of the calling assertion; defaults to 0
-return_from_bats_assertion() {
-  local assertion_source_file="$1"
-  local result="${2:-0}"
-
-  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+bats_assertion_return_trap() {
+  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $1 ]]; then
     unset 'BATS_CURRENT_STACK_TRACE[0]'
   fi
-
-  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $1 ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
-
   set -o functrace
-  return "$result"
 }
 
 # --------------------------------
@@ -230,12 +230,13 @@ return_from_bats_assertion() {
 #   $1: The assertion to execute
 #   $2: The assertion argument signifying the expected outcome for $output
 __assert_output() {
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local assertion="$1"
   local constraint="$2"
 
   if [[ "$#" -ne 2 ]]; then
     echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
-    __return_from_bats_assertion 1
+    return 1
   else
     "$assertion" "$constraint" "$output" 'output'
   fi
@@ -248,6 +249,7 @@ __assert_output() {
 #   $2: The index into $line identifying the line to evaluate
 #   $3: The assertion argument signifying the expected outcome for ${line[$2]}
 __assert_line() {
+  trap "bats_assertion_return_trap '$BASH_SOURCE'" RETURN
   local assertion="$1"
   local lineno="$2"
   local constraint="$3"
@@ -259,18 +261,6 @@ __assert_line() {
 
   if ! "$assertion" "$constraint" "${lines[$lineno]}" "line $lineno"; then
     printf 'OUTPUT:\n%s\n' "$output" >&2
-    __return_from_bats_assertion 1
-  else
-    __return_from_bats_assertion
+    return 1
   fi
-}
-
-# Scrubs the Bats stacks of references to functions from this file
-#
-# See the comment for return_from_bats_assertion for details.
-#
-# Arguments:
-#   $1:  Return value of the calling assertion; defaults to 0
-__return_from_bats_assertion() {
-  return_from_bats_assertion "$BASH_SOURCE" "$1"
 }

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -124,6 +124,8 @@ assert_success() {
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -138,6 +140,8 @@ assert_failure() {
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
+  else
+    __return_from_bats_assertion
   fi
 }
 

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -22,6 +22,13 @@ expect_success() {
     return 1
   fi
 
+  eval $assertion || :
+
+  if [[ ! "$-" =~ T ]]; then
+    printf "The assertion did not reset \`set -o functrace\`: $-" >&2
+    return 1
+  fi
+
   run_test_script "  run $command" "  $assertion"
 
   if [[ "$status" -ne 0 ]]; then
@@ -46,6 +53,13 @@ expect_failure() {
   if [[ "$status" -eq '0' ]]; then
     printf "In process: expected failure, but succeeded\nOutput:\n%s\n" \
       "$output" >&2
+    return 1
+  fi
+
+  eval $assertion || :
+
+  if [[ ! "$-" =~ T ]]; then
+    printf "The assertion did not reset \`set -o functrace\`: $-" >&2
     return 1
   fi
 


### PR DESCRIPTION
Turned out the successful return path for `assert_success` and `assert_failure` when no arguments were given wasn't routed through `__return_from_bats_assertion`, which meant `set -o functrace` was not going back into effect.

Noticed this while writing tests for the upcoming `lib/log` module, whereby the custom `assert_log_equals` assertion was not showing up in error stack traces despite not scrubbing the Bats stack trace arrays. Figured out this was because `assert_success` was called before `assert_log_equals`, and eventually found the bug.

Then I thought things over and decided that `__return_from_bats_assertion` was a fragile means of resetting `set -o functrace`, and came up with the `bats_assertion_return_trap` method. When used as described in the comments, it works very well (though there are still some mysteries about how `RETURN` traps play with `DEBUG` traps, `ERR` traps, and `set -o functrace` that I'll be exploring for some time to come).

*Update:* I reverted the trap-based solution, as it added O(20s) to the test suite.

