### PR TITLE
Add logging module

### DIFF
--- a/lib/internal/complete
+++ b/lib/internal/complete
@@ -13,7 +13,7 @@ _@go.complete_top_level_commands() {
 #
 # An error return status indicates that argument completion is finished.
 #
-# It may omit potential completion values to standard output regardless of the
+# It may emit potential completion values to standard output regardless of the
 # return status.
 _@go.complete_command_path() {
   if [[ "$#" -eq 0 ]]; then

--- a/lib/log
+++ b/lib/log
@@ -1,0 +1,245 @@
+#! /bin/bash
+#
+# Standard logging
+#
+# Exports:
+#   @go.log
+#     Outputs a log line; supports terminal formatting and format stripping
+#
+# See the function comments for each of the above for further information.
+
+# Set this if you want to force terminal-formatted output from @go.log.
+#
+# @go.log will remove terminal formatting codes by default when the output file
+# descriptor is not a terminal. Can be set either in the script or on the
+# command line.
+declare _GO_LOG_FORMATTING="$_GO_LOG_FORMATTING"
+
+# Default log level labels
+declare _GO_LOG_LEVELS=(
+  'INFO'
+  'RUN'
+  'WARN'
+  'ERROR'
+  'FATAL'
+  'START'
+  'FINISH'
+)
+
+# Default log level terminal format codes
+declare __GO_LOG_LEVELS_FORMAT_CODES=(
+  '\e[1m\e[36m'
+  '\e[1m\e[35m'
+  '\e[1m\e[33m'
+  '\e[1m\e[31m'
+  '\e[1m\e[31m'
+  '\e[1m\e[32m'
+  '\e[1m\e[32m'
+)
+
+# Default log level output file descriptors
+#
+# '1' is standard output and '2' is standard error.
+declare __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
+  '1'
+  '1'
+  '1'
+  '2'
+  '2'
+  '1'
+  '1'
+)
+
+# DO NOT EDIT: Initialized by @go.log
+declare __GO_LOG_LEVELS_FORMATTED=()
+
+# Outputs a single log line that may contain terminal control characters.
+#
+# Usage:
+#
+#   @go.log <log-level> args...
+#   @go.log <ERROR|FATAL> <exit-status|''> args...
+#
+# Where:
+#
+#   <log-level>    A label from _GO_LOG_LEVELS
+#   <exit-status>  The exit status number to return from an ERROR or FATAL call
+#   args...        Arguments comprising the log record text
+#
+# Will automatically format the '<log-level>' label if writing to the terminal
+# or _GO_LOG_FORMATTING is set. Will automatically strip format codes from the
+# remaining arguments if not writing to the terminal and _GO_LOG_FORMATTING is
+# empty.
+#
+# If the first argument is ERROR or FATAL, the second argument is the exit
+# status, and the remainder of the arguments comprise the log record. The exit
+# status will be appended to the log record if it is not the empty string.
+#
+# ERROR will cause @go.log to return the exit status; FATAL will exit the
+# process with the exit status. If the exit status is the empty string, it will
+# default to 1.
+#
+# If you want to add a custom log level, or change an existing log level, do so
+# using @go.add_or_update_log_level before the first call to @go.log, most
+# likely in your ./go script.
+#
+# Arguments:
+#   $1: log level label; will be converted to all-uppercase
+#   $2: exit status if $1 is ERROR or FATAL; first log record element otherwise
+#   $3..$#: remainder of the log record
+@go.log() {
+  local args=("$@")
+  local log_level="${args[0]^^}"
+  local formatted_log_level
+  local level_fd=1
+  local exit_status=0
+  local close_code='\e[0m'
+  local echo_mode='-e'
+
+  unset 'args[0]'
+  _@go.log_init
+
+  local __go_log_level_index=0
+  if ! _@go.log_level_index "$log_level"; then
+    @go.log ERROR "Unknown log level $log_level; defaulting to WARN"
+    @go.log WARN "${args[@]}"
+    return 1
+  fi
+
+  formatted_log_level="${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]}"
+  level_fd="${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$__go_log_level_index]}"
+
+  if [[ "$log_level" =~ ERROR|FATAL ]]; then
+    exit_status="${args[1]}"
+
+    if [[ -n "$exit_status" && "$exit_status" =~ ^-?[0-9]+$ ]]; then
+      unset 'args[1]'
+      args+=("(exit status $exit_status)")
+    else
+      exit_status=1
+    fi
+  fi
+
+  if [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
+    echo_mode='-E'
+    args=("${args[@]//\\e\[[0-9]m}")
+    args=("${args[@]//\\e\[[0-9][0-9]m}")
+    args=("${args[@]//\\e\[[0-9][0-9][0-9]m}")
+    close_code=''
+  fi
+
+  echo "$echo_mode" "$formatted_log_level ${args[*]}$close_code" >&"$level_fd"
+
+  if [[ "$log_level" == FATAL ]]; then
+    exit "$exit_status"
+  fi
+  return "$exit_status"
+}
+
+# --------------------------------
+# IMPLEMENTATION - HERE BE DRAGONS
+#
+# None of the functions below this line are part of the public interface.
+# --------------------------------
+
+# Initializes the logging system variables
+#
+# May be called multiple times; initialization will only happen once.
+_@go.log_init() {
+  if [[ -z "$__GO_LOG_INIT" ]]; then
+    _@go.log_format_level_labels
+    readonly __GO_LOG_INIT='done'
+  fi
+}
+
+# Assigns formatted log level labels to __GO_LOG_LEVELS_FORMATTED.
+#
+# If `_GO_LOG_FORMATTING` is not empty, or the file descriptor corresponding to
+# a log level corresponds to a terminal, this will assign a corresponding value
+# wrapped by terminal formatting codes to __GO_LOG_LEVELS_FORMATTED. Otherwise
+# the original label value is assigned.
+#
+# Each element of `__GO_LOG_LEVELS_FORMATTED` will also be padded with trailing
+# spaces so that each element will be the same length.
+#
+# Globals:
+#   _GO_LOG_LEVELS:                    List of valid log level labels
+#   _GO_LOG_FORMATTING                 If set, always produce formatted labels
+#   __GO_LOG_LEVELS_FORMAT_CODES:      Terminal format codes for each log level
+#   __GO_LOG_LEVELS_FILE_DESCRIPTORS:  Output descriptors for each log level
+#   __GO_LOG_LEVELS_FORMATTED:         Formatted labels
+_@go.log_format_level_labels() {
+  local num_levels="${#_GO_LOG_LEVELS[@]}"
+  local label_length
+  local longest_label_length
+  local padding=''
+  local log_level
+  local padding_len
+  local level_var
+  local level_fd
+  local i
+
+  for ((i=0; i != num_levels; ++i)); do
+    label_length="${#_GO_LOG_LEVELS[$i]}"
+    if [[ "$label_length" -gt "$longest_label_length" ]]; then
+      longest_label_length="$label_length"
+    fi
+  done
+
+  for ((i=0; i != longest_label_length; ++i)); do
+    padding+=' '
+  done
+
+  for ((i=0; i != num_levels; ++i)); do
+    log_level="${_GO_LOG_LEVELS[$i]}"
+    padding_len="$((${#padding} - ${#log_level}))"
+    level_fd="${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$i]}"
+
+    if [[ -n "$_GO_LOG_FORMATTING" || -t "$level_fd" ]]; then
+      log_level="${__GO_LOG_LEVELS_FORMAT_CODES[$i]}$log_level\e[0m"
+    fi
+    __GO_LOG_LEVELS_FORMATTED[$i]="${log_level}${padding:0:$padding_len}"
+  done
+}
+
+# Sets the index into the __GO_LOG arrays for the specified label
+#
+#
+# Globals:
+#   __go_log_level_index:  Variable into which the label's index will be stored
+#
+# Arguments:
+#   $1:  The log level label to look up
+#
+# Returns:
+#   0:  if the label exists
+#   1:  if the label does not exist
+_@go.log_level_index() {
+  local i
+  for ((i=0; i != "${#_GO_LOG_LEVELS[@]}"; ++i)); do
+    if [[ "${_GO_LOG_LEVELS[$i]}" == "$1" ]]; then
+      __go_log_level_index="$i"
+      return
+    fi
+  done
+  return 1
+}
+
+# Sanity check that the __GO_LOG arrays are all of the same size
+#
+# Will cause the process to exit with an error message and status if not.
+_@go.log_load() {
+  local num_levels="${#_GO_LOG_LEVELS[@]}"
+
+  if [[ "${#__GO_LOG_LEVELS_FORMAT_CODES[@]}" != "$num_levels" ]]; then
+    echo "Should have $num_levels log level format codes," \
+      "only have ${#__GO_LOG_LEVELS_FORMAT_CODES[@]}" >&2
+    exit 1
+  elif [[ "${#__GO_LOG_LEVELS_FILE_DESCRIPTORS[@]}" != "$num_levels" ]]; then
+    echo "Should have $num_levels log level file descriptors," \
+      "only have ${#__GO_LOG_LEVELS_FILE_DESCRIPTORS[@]}" >&2
+    exit 1
+  fi
+}
+
+_@go.log_load

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -1,0 +1,103 @@
+#! /bin/bash
+#
+# Helper functions for `lib/log` tests.
+
+run_log_script() {
+  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" "$@"
+  run "$TEST_GO_SCRIPT"
+}
+
+format_label() {
+  local label="$1"
+
+  if [[ -z "$__GO_LOG_INIT" ]]; then
+    . "$_GO_CORE_DIR/lib/log"
+    _GO_LOG_FORMATTING='true'
+    _@go.log_init
+  fi
+
+  local __go_log_level_index=0
+  if ! _@go.log_level_index "$label"; then
+    echo "Unknown log level label: $label" >&2
+    return 1
+  fi
+  echo "${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]}"
+}
+
+__expected_log_line() {
+  local level="$1"
+  local message="$2"
+
+  if [[ "${level:0:3}" == '\e[' ]]; then
+    stripped_level="${level//\\e\[[0-9]m}"
+    stripped_level="${stripped_level//\\e\[[0-9][0-9]m}"
+    stripped_level="${stripped_level//\\e\[[0-9][0-9][0-9]m}"
+    level="${level}${padding:0:$((${#padding} - ${#stripped_level}))}"
+    echo -e "$level $message\e[0m"
+  else
+    level="${level}${padding:0:$((${#padding} - ${#level}))}"
+    echo "$level $message"
+  fi
+}
+
+__all_output_consumed() {
+  local index="$1"
+  local remaining_lines="$((${#lines[@]} - index))"
+
+  if [[ "$remaining_lines" -gt '0' ]]; then
+    if [[ "$remaining_lines" -eq '1' ]]; then
+      echo "There is one more line of output than expected:" >&2
+    else
+      echo "There are $remaining_lines more lines of output than expected:" >&2
+    fi
+    local IFS=$'\n'
+    echo "${lines[*]:$index}" >&2
+    return 1
+
+  elif [[ "$remaining_lines" -lt '0' ]]; then
+    remaining_lines="$((-remaining_lines))"
+    if [[ "$remaining_lines" -eq '1' ]]; then
+      echo "There is one fewer line of output than expected." >&2
+    else
+      echo "There are $remaining_lines fewer lines of output than expected." >&2
+    fi
+    return 1
+  fi
+}
+
+assert_log_equals() {
+  local level
+  local padding=''
+  local expected_line
+  local num_errors=0
+  local remaining_lines=0
+  local i
+
+  . "$_GO_CORE_DIR/lib/log"
+  for level in "${_GO_LOG_LEVELS[@]}"; do
+    while [[ "${#padding}" -lt "${#level}" ]]; do
+      padding+=' '
+    done
+  done
+
+  for ((i=0; $# != 0; ++i)); do
+    expected_line="$(__expected_log_line "$1" "$2")"
+    if ! assert_equal "${lines[$i]}" "$expected_line" "line $i"; then
+      ((++num_errors))
+    fi
+    set +o functrace
+
+    if ! shift 2; then
+      echo "ERROR: Wrong number of arguments for log line $i." >&2
+      return 1
+    fi
+  done
+
+  if ! __all_output_consumed "$i"; then
+    ((++num_errors))
+  fi
+
+  if [[ "$num_errors" -ne '0' ]]; then
+    return_from_bats_assertion "$BASH_SOURCE" 1
+  fi
+}

--- a/tests/log/main.bats
+++ b/tests/log/main.bats
@@ -1,0 +1,88 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: log INFO without formatting" {
+  run_log_script '@go.log INFO Hello, World!'
+  assert_success
+  assert_log_equals INFO 'Hello, World!'
+}
+
+@test "$SUITE: log INFO with formatting" {
+  run_log_script "_GO_LOG_FORMATTING='true'" \
+    '@go.log INFO Hello, World!'
+  assert_success
+  assert_log_equals "$(format_label INFO)" 'Hello, World!'
+}
+
+@test "$SUITE: log WARN and return error if log level is unknown" {
+  run_log_script '@go.log FOOBAR Hello, World!'
+  assert_failure
+  assert_log_equals ERROR 'Unknown log level FOOBAR; defaulting to WARN' \
+    WARN  'Hello, World!'
+}
+
+@test "$SUITE: return error on ERROR" {
+  # The first arg after ERROR is the exit status.
+  run_log_script 'if ! @go.log ERROR Hello, World!; then' \
+    '  @go.log INFO error without status as expected' \
+    'fi'
+  assert_success
+  assert_log_equals ERROR 'Hello, World!' \
+    INFO  'error without status as expected'
+}
+
+@test "$SUITE: show status on ERROR if supplied" {
+  # The first arg after ERROR is the exit status.
+  run_log_script 'if ! @go.log ERROR 127 Hello, World!; then' \
+    '  @go.log INFO error with status as expected' \
+    'fi'
+  assert_success
+  assert_log_equals ERROR 'Hello, World! (exit status 127)' \
+    INFO  'error with status as expected'
+}
+
+@test "$SUITE: exit with error on FATAL" {
+  # The first arg after FATAL is the exit status.
+  run_log_script 'if ! @go.log FATAL Hello, World!; then' \
+    '  @go.log INFO This line should be unreachable.' \
+    'fi'
+  assert_failure
+  assert_log_equals FATAL 'Hello, World!'
+}
+
+@test "$SUITE: show status on FATAL if supplied" {
+  # The first arg after FATAL is the exit status.
+  run_log_script 'if ! @go.log FATAL 127 Hello, World!; then' \
+    '  @go.log INFO This line should be unreachable.' \
+    'fi'
+  assert_failure
+  assert_log_equals FATAL 'Hello, World! (exit status 127)'
+}
+
+@test "$SUITE: exit with error if num format codes != num log levels" {
+  . "$_GO_CORE_DIR/lib/log"
+  local num_levels="${#_GO_LOG_LEVELS[@]}"
+  unset '__GO_LOG_LEVELS_FORMAT_CODES[0]'
+  run _@go.log_load
+
+  local expected="Should have $num_levels log level format codes, "
+  expected+="only have $((num_levels - 1))"
+  assert_failure "$expected"
+}
+
+@test "$SUITE: exit with error if num file descriptors != num log levels" {
+  . "$_GO_CORE_DIR/lib/log"
+  local num_levels="${#_GO_LOG_LEVELS[@]}"
+  unset '__GO_LOG_LEVELS_FILE_DESCRIPTORS[0]'
+  run _@go.log_load
+
+  local expected="Should have $num_levels log level file descriptors, "
+  expected+="only have $((num_levels - 1))"
+  assert_failure "$expected"
+}


### PR DESCRIPTION
This provides standard logging facilities for different levels of messages. Uses terminal formatting for log level prefixes when output is to a terminal, or `_GO_LOG_FORMATTING` is set.

I've several other logging functions already written that I've split off for future pull requests.

This PR also contains a very minor typo fix in another file.