### PR TITLE
log: Implement @go.add_or_update_log_level

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -6,6 +6,9 @@
 #   @go.log
 #     Outputs a log line; supports terminal formatting and format stripping
 #
+#   @go.add_or_update_log_level
+#     Modifies existing log level labels, formatting, and file descriptors
+#
 # See the function comments for each of the above for further information.
 
 # Set this if you want to force terminal-formatted output from @go.log.
@@ -16,6 +19,8 @@
 declare _GO_LOG_FORMATTING="$_GO_LOG_FORMATTING"
 
 # Default log level labels
+#
+# DO NOT UPDATE DIRECTLY: Use @go.add_or_update_log_level instead.
 declare _GO_LOG_LEVELS=(
   'INFO'
   'RUN'
@@ -134,6 +139,49 @@ declare __GO_LOG_LEVELS_FORMATTED=()
     exit "$exit_status"
   fi
   return "$exit_status"
+}
+
+# Adds a new log level or updates an existing one.
+#
+# If you wish to keep the existing format code or file descriptor, specify
+# 'keep' as the second argument or third argument, respectively.
+#
+# Arguments:
+#   $1: The log level label
+#   $2: The terminal format code that should precede the label
+#   $3: The file descriptor to which to output level messages (defaults to 1)
+@go.add_or_update_log_level() {
+  local log_level="$1"
+  local format_code="$2"
+  local level_fd="${3:-1}"
+
+  if [[ -n "$__GO_LOG_INIT" ]]; then
+    @go.log 'FATAL' "Can't set logging level $log_level; already initialized"
+  elif [[ "$level_fd" != 'keep' && ! "$level_fd" =~ ^[1-9]+[0-9]*$ ]]; then
+    @go.log FATAL "File descriptor $level_fd for $log_level must be > 0"
+  elif ! echo -n 2>/dev/null >&"$level_fd"; then
+    @go.log FATAL "File descriptor $level_fd for $log_level isn't open"
+  fi
+
+  local __go_log_level_index=0
+  if ! _@go.log_level_index "$log_level"; then
+    if [[ "$format_code" == 'keep' || "$level_fd" == 'keep' ]]; then
+      @go.log FATAL "Can't keep defaults for nonexistent log level $log_level"
+    fi
+    _GO_LOG_LEVELS+=("$log_level")
+    __GO_LOG_LEVELS_FORMAT_CODES+=("$format_code")
+    __GO_LOG_LEVELS_FILE_DESCRIPTORS+=("$level_fd")
+    return
+  fi
+
+  _GO_LOG_LEVELS[$__go_log_level_index]="$log_level"
+
+  if [[ "$format_code" != 'keep' ]]; then
+    __GO_LOG_LEVELS_FORMAT_CODES[$__go_log_level_index]="$format_code"
+  fi
+  if [[ "$level_fd" != 'keep' ]]; then
+    __GO_LOG_LEVELS_FILE_DESCRIPTORS[$__go_log_level_index]="$level_fd"
+  fi
 }
 
 # --------------------------------

--- a/tests/log/add-update.bats
+++ b/tests/log/add-update.bats
@@ -1,0 +1,90 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+INFO_FORMAT='\e[1m\e[36m'
+START_FORMAT='\e[1m\e[32m'
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: fail if logging already initialized" {
+  run_log_script '@go.log INFO Hello, World!' \
+    '@go.add_or_update_log_level INFO keep keep'
+  assert_failure
+  assert_log_equals INFO 'Hello, World!' \
+    FATAL "Can't set logging level INFO; already initialized"
+}
+
+@test "$SUITE: fail if file descriptor isn't a positive integer" {
+  run_log_script '@go.add_or_update_log_level INFO keep 0'
+  assert_failure
+  assert_log_equals FATAL "File descriptor 0 for INFO must be > 0"
+}
+
+@test "$SUITE: fail if file descriptor isn't open" {
+  run_log_script '@go.add_or_update_log_level INFO keep 27'
+  assert_failure
+  assert_log_equals FATAL "File descriptor 27 for INFO isn't open"
+}
+
+@test "$SUITE: fail if keeping the format code for a nonexistent level" {
+  run_log_script '@go.add_or_update_log_level FOOBAR keep 1'
+  assert_failure
+  assert_log_equals FATAL "Can't keep defaults for nonexistent log level FOOBAR"
+}
+
+@test "$SUITE: fail if keeping the file descriptor for a nonexistent level" {
+  run_log_script "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT' keep"
+  assert_failure
+  assert_log_equals FATAL "Can't keep defaults for nonexistent log level FOOBAR"
+}
+
+@test "$SUITE: add new log level" {
+  run_log_script 'exec 27>logfile' \
+    "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT' 27" \
+    '_GO_LOG_FORMATTING=true' \
+    '@go.log FOOBAR Hello, World!'
+  assert_success ''
+
+  local expected="$(echo -e "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m")"
+  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+}
+
+@test "$SUITE: add new log level defaulting to standard output" {
+  run_log_script "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT'" \
+    '_GO_LOG_FORMATTING=true' \
+    '@go.log FOOBAR Hello, World!'
+  assert_success "$(echo -e "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m")"
+}
+
+@test "$SUITE: update format of existing log level" {
+  run_log_script "@go.add_or_update_log_level INFO '$START_FORMAT' keep" \
+    '_GO_LOG_FORMATTING=true' \
+    '@go.log INFO Hello, World!'
+  assert_success "$(echo -e "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+}
+
+@test "$SUITE: update file descriptor of existing log level" {
+  run_log_script 'exec 27>logfile' \
+    '@go.add_or_update_log_level INFO keep 27' \
+    '_GO_LOG_FORMATTING=true' \
+    '@go.log INFO Hello, World!'
+  assert_success ''
+  
+  local expected="$(echo -e "${INFO_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+}
+
+@test "$SUITE: update format and file descriptor of existing log level" {
+  run_log_script 'exec 27>logfile' \
+    "@go.add_or_update_log_level INFO '$START_FORMAT' 27" \
+    '_GO_LOG_FORMATTING=true' \
+    '@go.log INFO Hello, World!'
+  assert_success ''
+
+  local expected="$(echo -e "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+}

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -82,7 +82,7 @@ assert_log_equals() {
 
   for ((i=0; $# != 0; ++i)); do
     expected_line="$(__expected_log_line "$1" "$2")"
-    if ! assert_equal "${lines[$i]}" "$expected_line" "line $i"; then
+    if ! assert_equal "$expected_line" "${lines[$i]}" "line $i"; then
       ((++num_errors))
     fi
     set +o functrace


### PR DESCRIPTION
This provides the interface for users to programmatically add new log levels with corresponding formatting codes and file descriptors, as well as update the codes and descriptors for existing levels (even built-in levels).