### PR TITLE
log: Add @go.log_command, critical section flag

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -219,7 +219,11 @@ declare __GO_CRITICAL_SECTION=0
 # In between calls to @go.critical_section_begin and @go.critical_section_end,
 # it will instead log FATAL and exit the process with the command's status code.
 #
-# `./go` script commands can be invoked using `@go`.
+# `./go` script commands can be invoked using `@go`. Note that this means all of
+# the logging variables and flags set in parent commands apply directly to `@go`
+# commands written in Bash, but not other languages. Most notably, the state of
+# the critical section flag will be shared between parent and child Bash
+# scripts.
 #
 # Arguments:
 #   $@: The command and its arguments to log and execute

--- a/lib/log
+++ b/lib/log
@@ -9,6 +9,15 @@
 #   @go.add_or_update_log_level
 #     Modifies existing log level labels, formatting, and file descriptors
 #
+#   @go.log_command
+#     Logs a command and its outcome
+#
+#   @go.critical_section_begin
+#     Causes @go.log_command to log FATAL on error
+#
+#   @go.critical_section_end
+#     Cause @go.log_command to log ERROR on error
+#
 # See the function comments for each of the above for further information.
 
 # Set this if you want to force terminal-formatted output from @go.log.
@@ -17,6 +26,11 @@
 # descriptor is not a terminal. Can be set either in the script or on the
 # command line.
 declare _GO_LOG_FORMATTING="$_GO_LOG_FORMATTING"
+
+# If not empty, @go.log_command will only print the command and not execute it.
+#
+# Can be set either in the script or on the command line.
+declare _GO_DRY_RUN="$_GO_DRY_RUN"
 
 # Default log level labels
 #
@@ -58,12 +72,15 @@ declare __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
 # DO NOT EDIT: Initialized by @go.log
 declare __GO_LOG_LEVELS_FORMATTED=()
 
+# Set by @go.critical_section_{begin,end}
+declare __GO_CRITICAL_SECTION=0
+
 # Outputs a single log line that may contain terminal control characters.
 #
 # Usage:
 #
 #   @go.log <log-level> args...
-#   @go.log <ERROR|FATAL> <exit-status|''> args...
+#   @go.log <ERROR|FATAL> [exit-status] args...
 #
 # Where:
 #
@@ -181,6 +198,53 @@ declare __GO_LOG_LEVELS_FORMATTED=()
   fi
   if [[ "$level_fd" != 'keep' ]]; then
     __GO_LOG_LEVELS_FILE_DESCRIPTORS[$__go_log_level_index]="$level_fd"
+  fi
+}
+
+# Sets @go.log_command to log FATAL when its command exits with an error status.
+@go.critical_section_begin() {
+  ((++__GO_CRITICAL_SECTION))
+}
+
+# Sets @go.log_command to log ERROR when its command exits with an error status.
+@go.critical_section_end() {
+  if [[ "$__GO_CRITICAL_SECTION" -ne '0' ]]; then
+    ((--__GO_CRITICAL_SECTION))
+  fi
+}
+
+# Logs the specified command and its outcome.
+#
+# By default it will log ERROR and return the command's exit status on failure.
+# In between calls to @go.critical_section_begin and @go.critical_section_end,
+# it will instead log FATAL and exit the process with the command's status code.
+#
+# `./go` script commands can be invoked using `@go`.
+#
+# Arguments:
+#   $@: The command and its arguments to log and execute
+@go.log_command() {
+  local args=("$@")
+  local cmd_string="${args[*]}"
+  local exit_status
+
+  if [[ "${args[0]}" == '@go' ]]; then
+    cmd_string="$_GO_CMD ${args[*]:1}"
+  fi
+  @go.log RUN "$cmd_string"
+
+  if [[ -n "$_GO_DRY_RUN" ]]; then
+    return
+  fi
+
+  "${args[@]}"
+  exit_status="$?"
+
+  if [[ "$exit_status" -ne '0' ]]; then
+    if [[ "$__GO_CRITICAL_SECTION" -ne '0' ]]; then
+      @go.log FATAL "$exit_status" "$cmd_string"
+    fi
+    @go.log ERROR "$exit_status" "$cmd_string"
   fi
 }
 

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -1,0 +1,181 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: log single command" {
+  run_log_script '@go.log_command echo Hello, World!'
+  assert_success
+  assert_log_equals RUN 'echo Hello, World!' \
+    'Hello, World!'
+}
+
+@test "$SUITE: log single failing command" {
+  run_log_script 'failing_function() { return 127; }' \
+    '@go.log_command failing_function foo bar baz'
+  assert_failure
+  assert_log_equals RUN 'failing_function foo bar baz' \
+    ERROR 'failing_function foo bar baz (exit status 127)'
+}
+
+@test "$SUITE: log single failing command in critical section" {
+  run_log_script 'failing_function() { return 127; }' \
+    '@go.critical_section_begin' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.critical_section_end'
+  assert_failure
+  assert_log_equals RUN 'failing_function foo bar baz' \
+    FATAL 'failing_function foo bar baz (exit status 127)'
+}
+
+@test "$SUITE: log single failing command without executing during dry run" {
+  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+    'failing_function() { return 127; }' \
+    '@go.log_command failing_function foo bar baz'
+  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
+  assert_success
+  assert_log_equals RUN 'failing_function foo bar baz'
+}
+
+@test "$SUITE: log multiple commands" {
+  run_log_script '@go.log_command echo Hello, World!' \
+    "@go.log_command echo I don\'t know why you say goodbye," \
+    '@go.log_command echo while I say hello...'
+  assert_success
+  assert_log_equals RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN "echo I don't know why you say goodbye," \
+    "I don't know why you say goodbye," \
+    RUN "echo while I say hello..." \
+    "while I say hello..."
+}
+
+@test "$SUITE: log multiple commands, second one fails" {
+  run_log_script 'failing_function() { return 127; }' \
+    '@go.log_command echo Hello, World!' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo Goodbye, World!'
+  assert_success
+  assert_log_equals RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN "failing_function foo bar baz" \
+    ERROR 'failing_function foo bar baz (exit status 127)' \
+    RUN "echo Goodbye, World!" \
+    "Goodbye, World!"
+}
+
+@test "$SUITE: log multiple commands, second one fails in critical section" {
+  run_log_script 'failing_function() { return 127; }' \
+    '@go.critical_section_begin' \
+    '@go.log_command echo Hello, World!' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo Goodbye, World!' \
+    '@go.critical_section_end'
+  assert_failure
+  assert_log_equals RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN "failing_function foo bar baz" \
+    FATAL 'failing_function foo bar baz (exit status 127)'
+}
+
+@test "$SUITE: log multiple commands without executing during dry run" {
+  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+    'failing_function() { return 127; }' \
+    '@go.log_command echo Hello, World!' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo Goodbye, World!'
+  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
+  assert_success
+  assert_log_equals RUN 'echo Hello, World!' \
+    RUN "failing_function foo bar baz" \
+    RUN 'echo Goodbye, World!'
+}
+
+@test "$SUITE: nested critical sections" {
+  run_log_script 'failing_function() { return 127; }' \
+    'critical_subsection() {' \
+    '  @go.critical_section_begin' \
+    '  @go.log_command echo $*' \
+    '  @go.critical_section_end' \
+    '}' \
+    '@go.critical_section_begin' \
+    '@go.log_command critical_subsection Hello, World!' \
+    '@go.critical_section_end' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo We made it!'
+  assert_success
+  assert_log_equals RUN 'critical_subsection Hello, World!' \
+    RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN 'failing_function foo bar baz' \
+    ERROR 'failing_function foo bar baz (exit status 127)' \
+    RUN 'echo We made it!' \
+    'We made it!'
+}
+
+@test "$SUITE: nested critical sections dry run" {
+  # Note that `echo Hello, World!` inside `critical_subsection` isn't logged,
+  # since `critical_subsection` is only logged but not executed.
+  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+    'failing_function() { return 127; }' \
+    'critical_subsection() {' \
+    '  @go.critical_section_begin' \
+    '  @go.log_command echo $*' \
+    '  @go.critical_section_end' \
+    '}' \
+    '@go.critical_section_begin' \
+    '@go.log_command critical_subsection Hello, World!' \
+    '@go.critical_section_end' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo We made it!'
+  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
+  assert_success
+  assert_log_equals RUN 'critical_subsection Hello, World!' \
+    RUN 'failing_function foo bar baz' \
+    RUN 'echo We made it!'
+}
+
+@test "$SUITE: critical section is reentrant" {
+  run_log_script 'failing_function() { return 127; }' \
+    'critical_subsection() {' \
+    '  @go.critical_section_begin' \
+    '  @go.log_command echo $*' \
+    '  @go.critical_section_end' \
+    '}' \
+    '@go.critical_section_begin' \
+    '@go.log_command critical_subsection Hello, World!' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.critical_section_end' \
+    "@go.log_command echo We shouldn\'t make it this far..."
+  assert_failure
+  assert_log_equals RUN 'critical_subsection Hello, World!' \
+    RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN 'failing_function foo bar baz' \
+    FATAL 'failing_function foo bar baz (exit status 127)'
+}
+
+@test "$SUITE: critical section counter does not go below zero" {
+  run_log_script 'failing_function() { return 127; }' \
+    '@go.critical_section_begin' \
+    '@go.log_command echo Hello, World!' \
+    '@go.critical_section_end' \
+    '@go.critical_section_end' \
+    '@go.critical_section_end' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.critical_section_begin' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command Should not get this far' \
+    '@go.critical_section_end'
+  assert_failure
+  assert_log_equals RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN 'failing_function foo bar baz' \
+    ERROR 'failing_function foo bar baz (exit status 127)' \
+    RUN 'failing_function foo bar baz' \
+    FATAL 'failing_function foo bar baz (exit status 127)'
+}


### PR DESCRIPTION
This enables scripts to both execute and log commands in a single line, recording the command arguments and the exit status if unsuccessful.

The critical section flag allows scripts to abort with a `@go.log FATAL` if any one of a series of commands fails. This facility is reentrant.

There's also a `_GO_DRY_RUN` flag that, when set, will cause `@go.log_command` to only log the command arguments without executing the command.