### PR TITLE
Add @go.setup_project, fix @go.critical_section_end bug

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -18,6 +18,9 @@
 #   @go.critical_section_end
 #     Cause @go.log_command to log ERROR on error
 #
+#   @go.setup_project
+#     Runs the project's 'setup' script and logs the result
+#
 # See the function comments for each of the above for further information.
 
 # Set this if you want to force terminal-formatted output from @go.log.
@@ -249,6 +252,66 @@ declare __GO_CRITICAL_SECTION=0
       @go.log FATAL "$exit_status" "$cmd_string"
     fi
     @go.log ERROR "$exit_status" "$cmd_string"
+  fi
+}
+
+# Runs the project's setup script and logs the result.
+#
+# Helps with automating and logging project setup steps upon running the ./go
+# script in a freshly-cloned repository for the first time, and providing the
+# user with useful hints on how to use the ./go script upon success.
+#
+# If the setup script returns an error, the process will exit with the status
+# code returned by the script.
+#
+# For example, in a Node.js project, your ./go script may include the following:
+#
+#   export PATH="node_modules/.bin:$PATH"
+#   if [[ ! -d 'node_modules' ]]; then
+#     @go.setup_project 'setup'
+#   else
+#     @go "$@"
+#   fi
+#
+# And your `$_GO_SCRIPTS_DIR/setup` script may include (assuming your own `test`
+# script as well):
+#
+#   @go.critical_section_begin
+#   @go.log_command npm install
+#   @go.log_command @go test
+#   @go.critical_section_end
+#
+# Arguments:
+#   $1:   The path of setup script relative to the project scripts directory
+#   ...:  Any arguments to pass through to the 'setup' script
+@go.setup_project() {
+  local setup_script="$_GO_SCRIPTS_DIR/$1"
+  local setup_status
+  shift
+
+  @go.log START Project setup in "$_GO_ROOTDIR"
+
+  if [[ ! -f "$setup_script" ]]; then
+    @go.log FATAL "Create $setup_script before invoking $FUNCNAME."
+  elif  [[ ! -x "$setup_script" ]]; then
+    @go.log FATAL "$setup_script is not executable."
+  fi
+
+  @go.log RUN "${setup_script#$_GO_ROOTDIR/}" "$@"
+  _@go.run_command_script "$setup_script" "$@"
+  setup_status="$?"
+
+  if [[ "$setup_status" -ne '0' ]]; then
+    @go.log FATAL "$setup_status" "Project setup failed"
+  fi
+
+  @go.log FINISH Project setup successful
+  @go.log INFO "Run \`$0 help\` to see the available commands."
+
+  if [[ "$_GO_CMD" == "$0" ]]; then
+    @go.log INFO \
+      "Run \`$0 help env\` to see how to set up your shell environment" \
+      'for this project.'
   fi
 }
 

--- a/lib/log
+++ b/lib/log
@@ -213,6 +213,7 @@ declare __GO_CRITICAL_SECTION=0
 @go.critical_section_end() {
   if [[ "$__GO_CRITICAL_SECTION" -ne '0' ]]; then
     ((--__GO_CRITICAL_SECTION))
+    return 0
   fi
 }
 

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -7,6 +7,12 @@ run_log_script() {
   run "$TEST_GO_SCRIPT"
 }
 
+# For tests that run command scripts via @go, set _GO_CMD to make sure that's
+# the variable included in the log.
+test-go() {
+  env _GO_CMD="$FUNCNAME" "$TEST_GO_SCRIPT" "$@"
+}
+
 format_label() {
   local label="$1"
 

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -7,12 +7,6 @@ teardown() {
   remove_test_go_rootdir
 }
 
-# For tests that run command scripts via @go, set _GO_CMD to make sure that's
-# the variable included in the log.
-test-go() {
-  env _GO_CMD="$FUNCNAME" "$TEST_GO_SCRIPT" "$@"
-}
-
 @test "$SUITE: log single command" {
   run_log_script '@go.log_command echo Hello, World!'
   assert_success

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -95,6 +95,29 @@ teardown() {
     RUN 'echo Goodbye, World!'
 }
 
+@test "$SUITE: critical section in function" {
+  # This reproduces a bug whereby @go.critical_section_end will return an error
+  # status because of its decrementing a variable to zero, resulting in an ERROR
+  # log for `critical subsection`.
+  run_log_script 'failing_function() { return 127; }' \
+    'critical_subsection() {' \
+    '  @go.critical_section_begin' \
+    '  @go.log_command echo $*' \
+    '  @go.critical_section_end' \
+    '}' \
+    '@go.log_command critical_subsection Hello, World!' \
+    '@go.log_command failing_function foo bar baz' \
+    '@go.log_command echo We made it!'
+  assert_success
+  assert_log_equals RUN 'critical_subsection Hello, World!' \
+    RUN 'echo Hello, World!' \
+    'Hello, World!' \
+    RUN 'failing_function foo bar baz' \
+    ERROR 'failing_function foo bar baz (exit status 127)' \
+    RUN 'echo We made it!' \
+    'We made it!'
+}
+
 @test "$SUITE: nested critical sections" {
   run_log_script 'failing_function() { return 127; }' \
     'critical_subsection() {' \

--- a/tests/log/setup-project.bats
+++ b/tests/log/setup-project.bats
@@ -1,0 +1,78 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: fail if no 'setup' script exists" {
+  run_log_script '@go.setup_project setup Hello, World!'
+  assert_failure
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    FATAL "Create $TEST_GO_SCRIPTS_DIR/setup before invoking @go.setup_project."
+}
+
+@test "$SUITE: fail if the 'setup' script isn't executable" {
+  create_test_command_script 'setup' 'echo $*'
+  chmod 600 "$TEST_GO_SCRIPTS_DIR/setup"
+
+  run_log_script '@go.setup_project setup Hello, World!'
+  assert_failure
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    FATAL "$TEST_GO_SCRIPTS_DIR/setup is not executable."
+}
+
+@test "$SUITE: setup project successfully using ./go script directly" {
+  create_test_command_script 'setup' 'echo $*'
+
+  run_log_script '@go.setup_project setup Hello, World!'
+  assert_success
+
+  local env_message="Run \`$TEST_GO_SCRIPT help env\` to see how to set up "
+  env_message+='your shell environment for this project.'
+
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    RUN    "${TEST_GO_SCRIPTS_RELATIVE_DIR}/setup Hello, World!" \
+    'Hello, World!' \
+    FINISH 'Project setup successful' \
+    INFO   "Run \`$TEST_GO_SCRIPT help\` to see the available commands." \
+    INFO   "$env_message"
+}
+
+@test "$SUITE: setup project successfully using ./go script shell function" {
+  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+    '@go.setup_project setup "$@"'
+
+  create_test_command_script 'setup' 'echo $*'
+
+  run test-go Hello, World!
+  assert_success
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    RUN    "${TEST_GO_SCRIPTS_RELATIVE_DIR}/setup Hello, World!" \
+    'Hello, World!' \
+    FINISH 'Project setup successful' \
+    INFO   "Run \`$TEST_GO_SCRIPT help\` to see the available commands."
+}
+
+@test "$SUITE: setup fails" {
+  create_test_command_script 'setup' '@go.log ERROR 127 "$@"'
+  run_log_script '@go.setup_project setup foo bar baz'
+  assert_failure
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    RUN    "${TEST_GO_SCRIPTS_RELATIVE_DIR}/setup foo bar baz" \
+    ERROR  'foo bar baz (exit status 127)' \
+    FATAL  'Project setup failed (exit status 127)'
+}
+
+@test "$SUITE: Bash setup script exits directly" {
+  # Note that the "Project setup failed" message doesn't appear, because the
+  # `setup` script was executed in the same Bash process.
+  create_test_command_script 'setup' '@go.log FATAL 127 "$@"'
+  run_log_script '@go.setup_project setup foo bar baz'
+  assert_failure
+  assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
+    RUN    "${TEST_GO_SCRIPTS_RELATIVE_DIR}/setup foo bar baz" \
+    FATAL  'foo bar baz (exit status 127)'
+}


### PR DESCRIPTION
`@go.setup_project` provides a convenient scaffolding for introducing first-time project contributors to the `./go` script interface by logging the setup process and providing helpful hints upon success.

Also, it turns out any arithmetic expression that evaluates to zero returns a nonzero status, and vice versa. This was causing a problem in a setup script whose last line was `@go.critical_section_end`, causing it to register an error when it actually succeeded.