### PR TITLE
core: Update how COLUMNS is set

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -250,16 +250,10 @@ _@go.set_scripts_dir() {
 if ! _@go.set_scripts_dir "$@"; then
   exit 1
 elif [[ -z "$COLUMNS" ]]; then
-  # On Travis, $TERM is set to 'dumb', but `tput cols` still fails.
-  if command -v 'tput' >/dev/null && tput cols >/dev/null 2>&1; then
-    COLUMNS="$(tput cols)"
-  elif command -v 'mode.com' >/dev/null; then
-    COLUMNS="$(mode.com) con:"
-    shopt -s extglob
-    COLUMNS="${COLUMNS##*Columns:+( )}"
-    shopt -u extglob
-    COLUMNS="${COLUMNS%%[ $'\r'$'\n']*}"
+  if [[ "$(tput cols 2>/dev/null)" =~ ^[0-9]+$ ]]; then
+    COLUMNS="${BASH_REMATCH[0]}"
+  elif [[ "$(mode.com 'con' 2>/dev/null)" =~ Columns:\ +([0-9]+) ]]; then
+    COLUMNS="${BASH_REMATCH[1]}"
   fi
-
   export COLUMNS="${COLUMNS:-80}"
 fi

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -26,13 +26,15 @@ teardown() {
   assert_success '80'
 }
 
-@test "$SUITE: default to 80 columns if tput fails" {
-  if ! command -v 'tput' >/dev/null; then
-    skip 'tput not available on this system'
+@test "$SUITE: default to 80 columns if tput fails or use mode.com on Windows" {
+  local expected_cols='80'
+
+  if [[ "$(mode.com con)" =~ Columns:\ +([0-9]+) ]]; then
+    expected_cols="${BASH_REMATCH[1]}"
   fi
 
   # One way to cause tput to fail is to set `$TERM` to null. On Travis it's set
   # to 'dumb', but tput fails anyway. The code now defaults to 80 on all errors.
   run env COLUMNS= TERM= "$TEST_GO_SCRIPT"
-  assert_success '80'
+  assert_success "$expected_cols"
 }


### PR DESCRIPTION
Using `C:\Program Files\Git\bin\bash.exe` from a vanilla Command Prompt window set to 161 columns, the `default to 80 columns if tput fails` test case kept failing because columns was getting computed as 161 instead of 80. Eventually I realized this wasn't because the test wasn't getting `tput` to fail—it was—but because `mode.com` was picking up the slack, as designed.

So the test has been updated to `default to 80 columns if tput fails or use mode.com on Windows`. Also streamlined the existing `go-core.bash` logic that handles `tput` and `mode.com` to use regular expressions and `BASH_REMATCH`, dispensing with `shopt` and multiple steps in the `mode.com` case.