### PR TITLE
core: Reproduce and fix `tput cols` error from #17

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -250,9 +250,11 @@ _@go.set_scripts_dir() {
 if ! _@go.set_scripts_dir "$@"; then
   exit 1
 elif [[ -z "$COLUMNS" ]]; then
-  if [[ "$(tput cols 2>/dev/null)" =~ ^[0-9]+$ ]]; then
-    COLUMNS="${BASH_REMATCH[0]}"
-  elif [[ "$(mode.com 'con' 2>/dev/null)" =~ Columns:\ +([0-9]+) ]]; then
+  # On Travis, $TERM is set to 'dumb', but `tput cols` still fails.
+  if command -v tput >/dev/null && tput cols >/dev/null 2>&1; then
+    COLUMNS="$(tput cols)"
+  elif command -v mode.com >/dev/null &&
+    [[ "$(mode.com 'con')" =~ Columns:\ +([0-9]+) ]]; then
     COLUMNS="${BASH_REMATCH[1]}"
   fi
   export COLUMNS="${COLUMNS:-80}"

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -3,7 +3,16 @@
 load ../environment
 
 setup() {
-  create_test_go_script 'echo "$COLUMNS"'
+  # We want standard output and standard error to be connected to the actual
+  # terminal to make sure `tput cols` isn't automatically defaulting to 80.
+  # Thankfully Bash creates the /dev/tty pseudo file on our behalf on Windows.
+  create_bats_test_script 'go' \
+    'exec 27>&1 >/dev/tty 2>&1' \
+    ". '$_GO_ROOTDIR/go-core.bash' '$TEST_GO_SCRIPTS_RELATIVE_DIR'" \
+    'exec 1>&27 27>&- 2>&1' \
+    'echo "$COLUMNS"'
+
+  mkdir "$TEST_GO_SCRIPTS_DIR"
 }
 
 teardown() {
@@ -24,6 +33,22 @@ teardown() {
 @test "$SUITE: default COLUMNS to 80 if actual columns can't be determined" {
   run env COLUMNS= PATH= "$BASH" "$TEST_GO_SCRIPT"
   assert_success '80'
+}
+
+@test "$SUITE: use tput to set columns if available" {
+  if ! command -v tput >/dev/null; then
+    skip "tput not found on this system"
+  elif [[ -z "$TERM" ]]; then
+    skip "TERM not set on this system"
+  fi
+
+  # See the comment in setup() for context on the redirection shenanigans.
+  exec 27>&1 >/dev/tty 2>&1
+  local expected_cols="$(env COLUMNS= tput cols)"
+  exec 1>&27 27>&- 2>&1
+
+  run env COLUMNS= "$TEST_GO_SCRIPT"
+  assert_success "$expected_cols"
 }
 
 @test "$SUITE: default to 80 columns if tput fails or use mode.com on Windows" {

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -27,7 +27,7 @@ TEST_GO_SCRIPTS_DIR="$TEST_GO_ROOTDIR/$TEST_GO_SCRIPTS_RELATIVE_DIR"
 TEST_GO_PLUGINS_DIR="$TEST_GO_SCRIPTS_DIR/plugins"
 
 create_test_go_script() {
-  create_bats_test_script "go" \
+  create_bats_test_script 'go' \
     ". '$_GO_ROOTDIR/go-core.bash' '$TEST_GO_SCRIPTS_RELATIVE_DIR'" \
     "$@"
 


### PR DESCRIPTION
Turns out that redirecting standard error to `/dev/null` has the effect of causing `tput cols` to output '80', which defeats the entire purpose of trying to set `COLUMNS` dynamically with `tput` in the first place.

To reproduce the problem in the test, I had to realize that Bats will redirect standard output and standard error to a file, and override that behavior by redirecting both back to `/dev/tty`--which Bash conveniently emulates on Windows as well. Then I had to go back to the `command -v` checks for `tput` and `mode.com`, though I kept the `BASH_REMATCH` assignment in the `mode.com` case.