### PR TITLE
assertions: Add assert_lines_equal

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -176,6 +176,52 @@ assert_line_matches() {
   __assert_line 'assert_matches' "$@"
 }
 
+# Validates that each output line equals each corresponding argument
+#
+# Also ensures there are no more and no fewer lines of output than expected.
+#
+# Arguments:
+#   $@: Values to compare to each element of `${lines[@]}` for equality
+assert_lines_equal() {
+  set +o functrace
+  local expected=("$@")
+  local num_lines="${#expected[@]}"
+  local lines_diff="$((${#lines[@]} - num_lines))"
+  local num_errors=0
+  local i
+
+  for ((i=0; i != ${#expected[@]}; ++i)); do
+    if ! assert_equal "${expected[$i]}" "${lines[$i]}" "line $i"; then
+      ((++num_errors))
+    fi
+    set +o functrace
+  done
+
+  if [[ "$lines_diff" -gt '0' ]]; then
+    if [[ "$lines_diff" -eq '1' ]]; then
+      echo "There is one more line of output than expected:" >&2
+    else
+      echo "There are $lines_diff more lines of output than expected:" >&2
+    fi
+    local IFS=$'\n'
+    echo "${lines[*]:$num_lines}" >&2
+    ((++num_errors))
+
+  elif [[ "$lines_diff" -lt '0' ]]; then
+    lines_diff="$((-lines_diff))"
+    if [[ "$lines_diff" -eq '1' ]]; then
+      echo "There is one fewer line of output than expected." >&2
+    else
+      echo "There are $lines_diff fewer lines of output than expected." >&2
+    fi
+    ((++num_errors))
+  fi
+
+  if [[ "$num_errors" -ne '0' ]]; then
+    __return_from_bats_assertion 1
+  fi
+}
+
 # Scrubs the Bats stacks of functions from the assertion source file
 #
 # You must ensure that `set +o functrace` is in effect prior to calling this

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -324,3 +324,74 @@ check_expected_output() {
     'OUTPUT:' \
     '% not interpreted as a format spec'
 }
+
+@test "$SUITE: assert_lines_equal" {
+  expect_success "printf 'foo\nbar\nbaz\n'" \
+    "assert_lines_equal 'foo' 'bar' 'baz'"
+}
+
+@test "$SUITE: assert_lines_equal failure" {
+  expect_failure "printf 'foo\nbar\nbaz\n'" \
+    "assert_lines_equal 'foo' 'quux' 'baz'" \
+    'line 1 not equal to expected value:' \
+    "  expected: 'quux'" \
+    "  actual:   'bar'"
+}
+
+@test "$SUITE: assert_lines_equal failure due to one output line too many" {
+  expect_failure "printf 'foo\nbar\nbaz\nquux\n'" \
+    "assert_lines_equal 'foo' 'bar' 'baz'" \
+    'There is one more line of output than expected:' \
+    'quux'
+}
+
+@test "$SUITE: assert_lines_equal failure from bad matches and too many lines" {
+  expect_failure "printf 'foo\nbar\nbaz\nquux\nxyzzy\nplugh\n'" \
+    "assert_lines_equal 'frobozz' 'frotz' 'blorple'" \
+    'line 0 not equal to expected value:' \
+    "  expected: 'frobozz'" \
+    "  actual:   'foo'" \
+    'line 1 not equal to expected value:' \
+    "  expected: 'frotz'" \
+    "  actual:   'bar'" \
+    'line 2 not equal to expected value:' \
+    "  expected: 'blorple'" \
+    "  actual:   'baz'" \
+    'There are 3 more lines of output than expected:' \
+    'quux' \
+    'xyzzy' \
+    'plugh'
+}
+
+@test "$SUITE: assert_lines_equal failure due to one output line too few" {
+  expect_failure "printf 'foo\nbar\nbaz\n'" \
+    "assert_lines_equal 'foo' 'bar' 'baz' 'quux'" \
+    'line 3 not equal to expected value:' \
+    "  expected: 'quux'" \
+    "  actual:   ''" \
+    'There is one fewer line of output than expected.'
+}
+
+@test "$SUITE: assert_lines_equal failure from bad matches and too few lines" {
+  expect_failure "printf 'foo\nbar\nbaz\n'" \
+    "assert_lines_equal 'frobozz' 'frotz' 'blorple' 'quux' 'xyzzy' 'plugh'" \
+    'line 0 not equal to expected value:' \
+    "  expected: 'frobozz'" \
+    "  actual:   'foo'" \
+    'line 1 not equal to expected value:' \
+    "  expected: 'frotz'" \
+    "  actual:   'bar'" \
+    'line 2 not equal to expected value:' \
+    "  expected: 'blorple'" \
+    "  actual:   'baz'" \
+    'line 3 not equal to expected value:' \
+    "  expected: 'quux'" \
+    "  actual:   ''" \
+    'line 4 not equal to expected value:' \
+    "  expected: 'xyzzy'" \
+    "  actual:   ''" \
+    'line 5 not equal to expected value:' \
+    "  expected: 'plugh'" \
+    "  actual:   ''" \
+    'There are 3 fewer lines of output than expected.'
+}


### PR DESCRIPTION
Whereas `assert_output` compares the entire `output` string, and `assert_line_equals` compares against a single element of `lines`, this assertion compares its command line arguments against each element of `lines` and also fails if there is any output left over, showing the remaining lines not accounted for.

The bulk of the implementation was extracted from `assert_log_equals` in `tests/log/helpers.bash`.