### PR TITLE
log: Replace `echo -e` with `printf`

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -137,7 +137,6 @@ declare __GO_CRITICAL_SECTION=0
   local level_fd=1
   local exit_status=0
   local close_code='\e[0m'
-  local echo_mode='-e'
 
   unset 'args[0]'
   _@go.log_init
@@ -164,14 +163,13 @@ declare __GO_CRITICAL_SECTION=0
   fi
 
   if [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
-    echo_mode='-E'
     args=("${args[@]//\\e\[[0-9]m}")
     args=("${args[@]//\\e\[[0-9][0-9]m}")
     args=("${args[@]//\\e\[[0-9][0-9][0-9]m}")
     close_code=''
   fi
 
-  echo "$echo_mode" "$formatted_log_level ${args[*]}$close_code" >&"$level_fd"
+  printf "$formatted_log_level ${args[*]}$close_code\n" >&"$level_fd"
 
   if [[ "$log_level" == FATAL ]]; then
     exit "$exit_status"

--- a/tests/log/add-update.bats
+++ b/tests/log/add-update.bats
@@ -49,7 +49,7 @@ teardown() {
     '@go.log FOOBAR Hello, World!'
   assert_success ''
 
-  local expected="$(echo -e "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m")"
+  local expected="$(printf "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m\n")"
   assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
 }
 
@@ -57,14 +57,14 @@ teardown() {
   run_log_script "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT'" \
     '_GO_LOG_FORMATTING=true' \
     '@go.log FOOBAR Hello, World!'
-  assert_success "$(echo -e "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m")"
+  assert_success "$(printf "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: update format of existing log level" {
   run_log_script "@go.add_or_update_log_level INFO '$START_FORMAT' keep" \
     '_GO_LOG_FORMATTING=true' \
     '@go.log INFO Hello, World!'
-  assert_success "$(echo -e "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+  assert_success "$(printf "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: update file descriptor of existing log level" {
@@ -74,7 +74,7 @@ teardown() {
     '@go.log INFO Hello, World!'
   assert_success ''
   
-  local expected="$(echo -e "${INFO_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+  local expected="$(printf "${INFO_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
   assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
 }
 
@@ -85,6 +85,6 @@ teardown() {
     '@go.log INFO Hello, World!'
   assert_success ''
 
-  local expected="$(echo -e "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m")"
+  local expected="$(printf "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
   assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
 }

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -39,7 +39,7 @@ __expected_log_line() {
     stripped_level="${stripped_level//\\e\[[0-9][0-9]m}"
     stripped_level="${stripped_level//\\e\[[0-9][0-9][0-9]m}"
     level="${level}${padding:0:$((${#padding} - ${#stripped_level}))}"
-    echo -e "$level $message\e[0m"
+    printf "$level $message\e[0m\n"
   else
     level="${level}${padding:0:$((${#padding} - ${#level}))}"
     echo "$level $message"


### PR DESCRIPTION
Turns out on my desktop macOS 10.12.1 installation, `echo -e` under Bash 3.2.57(1)-release in Terminal.app isn't actually converting `\e` sequences to actual ANSI escape sequences. `printf`, however, works.