### PR TITLE
use: Detect module path before sourcing

### DIFF
--- a/lib/internal/use
+++ b/lib/internal/use
@@ -68,6 +68,7 @@
 #   @go modules --imported
 
 declare __go_module_name
+declare __go_module_file
 declare __go_loaded_module
 
 for __go_module_name in "$@"; do
@@ -77,17 +78,28 @@ for __go_module_name in "$@"; do
     fi
   done
 
-  # Prevent self- and circular importing.
+  # Prevent self- and circular importing by registering name before sourcing.
   _GO_IMPORTED_MODULES+=("$__go_module_name")
+  __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
 
-  # Convert <plugin>/<module> to _GO_SCRIPTS_DIR/plugins/<plugin>/lib/<module>
-  if ! . "$_GO_CORE_DIR/lib/$__go_module_name" 2>/dev/null &&
-     ! . "$_GO_SCRIPTS_DIR/plugins/${__go_module_name/\///lib/}" 2>/dev/null &&
-     ! . "$_GO_SCRIPTS_DIR/lib/$__go_module_name" 2>/dev/null; then
+  if [[ ! -f "$__go_module_file" ]]; then
+    # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
+    __go_module_file="$_GO_SCRIPTS_DIR/plugins/${__go_module_name/\///lib/}"
+  fi
+  if [[ ! -f "$__go_module_file" ]]; then
+    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
+  fi
+  if [[ ! -f "$__go_module_file" ]]; then
     @go.printf "ERROR: Unknown module: $__go_module_name" >&2
+    exit 1
+  fi
+
+  if ! . "$__go_module_file"; then
+    @go.printf "ERROR: Module contains errors: $__go_module_file" >&2
     exit 1
   fi
 done
 
 unset __go_loaded_module
+unset __go_module_file
 unset __go_module_name

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -85,13 +85,15 @@ for __go_module_name in "$@"; do
   if [[ ! -f "$__go_module_file" ]]; then
     # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
     __go_module_file="$_GO_SCRIPTS_DIR/plugins/${__go_module_name/\///lib/}"
-  fi
-  if [[ ! -f "$__go_module_file" ]]; then
-    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
-  fi
-  if [[ ! -f "$__go_module_file" ]]; then
-    @go.printf "ERROR: Unknown module: $__go_module_name" >&2
-    exit 1
+
+    if [[ ! -f "$__go_module_file" ]]; then
+      __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
+
+      if [[ ! -f "$__go_module_file" ]]; then
+        @go.printf "ERROR: Unknown module: $__go_module_name" >&2
+        exit 1
+      fi
+    fi
   fi
 
   if ! . "$__go_module_file"; then

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -90,14 +90,14 @@ for __go_module_name in "$@"; do
       __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
 
       if [[ ! -f "$__go_module_file" ]]; then
-        @go.printf "ERROR: Unknown module: $__go_module_name" >&2
+        @go.printf "ERROR: Unknown module: $__go_module_name\n" >&2
         exit 1
       fi
     fi
   fi
 
   if ! . "$__go_module_file"; then
-    @go.printf "ERROR: Module contains errors: $__go_module_file" >&2
+    @go.printf "ERROR: Module import failed for: $__go_module_file\n" >&2
     exit 1
   fi
 done

--- a/libexec/modules
+++ b/libexec/modules
@@ -43,7 +43,7 @@
 #   'f*/'    All modules in all plugins that begin with 'f'
 #   'f*/b*'  Modules beginning with 'b' in all plugins that begin with 'f'
 #
-# For detailed information about the module system, run `{{go}} {{cmd}} help`
+# For detailed information about the module system, run `{{go}} {{cmd}} --help`
 # without a `<module-name>` argument.
 
 _@go.modules_help() {

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -71,3 +71,14 @@ teardown() {
   local IFS=$'\n'
   assert_success "${EXPECTED[*]}"
 }
+
+@test "$SUITE: error if module contains errors" {
+  echo "This is a totally broken module." >> "${TEST_MODULES[1]}"
+  run "$TEST_GO_SCRIPT" "${IMPORTS[@]}"
+
+  local expected=("${IMPORTS[0]##*/} loaded"
+    "${TEST_MODULES[1]}: line 2: This: command not found"
+    "ERROR: Module contains errors: ${TEST_MODULES[1]}")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -78,7 +78,7 @@ teardown() {
 
   local expected=("${IMPORTS[0]##*/} loaded"
     "${TEST_MODULES[1]}: line 2: This: command not found"
-    "ERROR: Module contains errors: ${TEST_MODULES[1]}")
+    "ERROR: Module import failed for: ${TEST_MODULES[1]}")
   local IFS=$'\n'
   assert_failure "${expected[*]}"
 }


### PR DESCRIPTION
Closes #25. Now any modules containing errors will be identified as such, rather than being reported as unknown.

Also contains a minor fix to the `./go help modules` text.

cc: @JohnOmernik