### PR TITLE
Add file module

### DIFF
--- a/lib/file
+++ b/lib/file
@@ -1,0 +1,167 @@
+#! /usr/bin/env bash
+#
+# File I/O
+#
+# Exports:
+#   @go.open_file_or_duplicate_fd
+#     Opens a file or duplicates an existing descriptor, returns the new fd
+#
+#   @go.fds_printf
+#     Calls `printf` on its arguments for each of a list of file descriptors
+#
+#   @go.close_fds
+#     Closes one or more file descriptors
+
+# Maximum number of file descriptors to attempt opening. May be overridden by
+# the user.
+declare -r _GO_MAX_FILE_DESCRIPTORS="${_GO_MAX_FILE_DESCRIPTORS:-256}"
+
+# DO NOT EDIT: First file descriptor attempted by @go.open_file_or_duplicate_fd
+declare -r __GO_START_FD='3'
+
+if [[ ! "$_GO_MAX_FILE_DESCRIPTORS" =~ ^[1-9][0-9]*$ ||
+  "$_GO_MAX_FILE_DESCRIPTORS" -le "$__GO_START_FD" ]]; then
+  printf "_GO_MAX_FILE_DESCRIPTORS is %s, must be a number greater than %d.\n" \
+    "\"$_GO_MAX_FILE_DESCRIPTORS\"" "$__GO_START_FD" >&2
+  @go.print_stack_trace '2' >&2
+  exit 1
+fi
+
+# Opens a file or duplicates an existing descriptor, and returns the new fd.
+#
+# The newly-opened file descriptor will be assigned to the variable specified
+# by the `fd_var_reference` argument.
+#
+# Principle of least surprise:
+#
+# Rather than supply a separate function to return an unused file descriptor,
+# this interface ensures that unused descriptors are allocated in one step. This
+# avoids the situation where the user makes multiple calls to discover unused
+# descriptors and doesn't realize that, unless each call is followed by an
+# `exec` to open the descriptor, each call will return the same value.
+#
+# Arguments:
+#   file_path_or_fd:   Path to the file to open, or an existing file descriptor
+#   mode:              File operation mode: r, w, a, or rw
+#   fd_var_reference:  Name of variable to which to assign new fd value
+@go.open_file_or_duplicate_fd() {
+  local file_path_or_fd="$1"
+  local mode="$2"
+  local fd_var_reference="$3"
+  local bash_mode
+  local i
+
+  if [[ "$file_path_or_fd" =~ ^[0-9]+$ ]]; then
+    file_path_or_fd="&$file_path_or_fd"
+  else
+    file_path_or_fd="\"$file_path_or_fd\""
+  fi
+
+  case "$mode" in
+  r)
+    bash_mode='<'
+    ;;
+  w)
+    bash_mode='>'
+    ;;
+  a)
+    bash_mode='>>'
+    ;;
+  rw)
+    bash_mode='<>'
+    ;;
+  *)
+    echo "Unknown mode: $mode" >&2
+    @go.print_stack_trace '1' >&2
+    exit 1
+    ;;
+  esac
+
+  if [[ -z "$fd_var_reference" ]]; then
+    echo "No variable reference given for the resulting file descriptor." >&2
+    @go.print_stack_trace '1' >&2
+    exit 1
+  fi
+
+  for ((i=_GO_START_FD; i != _GO_MAX_FILE_DESCRIPTORS; ++i)); do
+    if [[ ! -e "/dev/fd/$i" ]]; then
+      if ! eval "exec ${i}${bash_mode}${file_path_or_fd}"; then
+        echo "Failed to open fd $i for $file_path_or_fd in mode '$mode' at:" >&2
+        @go.print_stack_trace '1' >&2
+        exit 1
+      fi
+      eval "$fd_var_reference=$i"
+      return
+    fi
+  done
+  echo "No file descriptors < $_GO_MAX_FILE_DESCRIPTORS available; failed at:" \
+    >&2
+  @go.print_stack_trace '1' >&2
+  exit 1
+}
+
+# Calls `printf` on its arguments for each of a list of file descriptors.
+#
+# These file descriptors should already be created manually using
+# `@go.open_file_or_duplicate_fd` or by using `exec FD` manually.
+#
+# Note that standard output is NOT automatically included in the list of file
+# descriptors.
+#
+# Also note that the `$COLUMNS` environment variable has no influence, as it
+# does with `@go.printf`; output will not be folded to the terminal width.
+#
+# Arguments:
+#   output_fds:  Comma-separated list of output file descriptors
+#   ...:         Arguments to pass to the `printf` builtin
+@go.fds_printf() {
+  local origIFS="$IFS"
+  local IFS=','
+  local output_fds=($1)
+  local result=0
+
+  IFS="$origIFS"
+  shift
+
+  for output_fd in "${output_fds[@]}"; do
+    if [[ ! "$output_fd" =~ ^[1-9][0-9]*$ ]]; then
+      echo "Invalid file descriptor value \"$output_fd\" for $FUNCNAME at:" >&2
+      @go.print_stack_trace '1' >&2
+      exit 1
+    fi
+  done
+
+  for output_fd in "${output_fds[@]}"; do
+    if ! printf "$@" >&"$output_fd"; then
+      echo "Failed to print to fd $output_fd at:" >&2
+      @go.print_stack_trace '1' >&2
+      result=1
+    fi
+  done
+  return "$result"
+}
+
+# Closes one or more file descriptors.
+#
+# Arguments:
+#   $@:  One or more file descriptors
+@go.close_fds() {
+  local close_fd_strings=()
+  local fd
+
+  if [[ "$#" -eq 0 ]]; then
+    echo "No file descriptors to close specified at:" >&2
+    @go.print_stack_trace '1' >&2
+    return 1
+  fi
+
+  for fd in "$@"; do
+    close_fd_strings+=("$fd>&-")
+  done
+
+  if ! eval "exec ${close_fd_strings[*]}"; then
+    echo "Failed to close one or more file descriptors: $* at:" >&2
+    @go.print_stack_trace '1' >&2
+    return 1
+  fi
+}

--- a/tests/file/close_fds.bats
+++ b/tests/file/close_fds.bats
@@ -1,0 +1,54 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+create_close_fds_test_script() {
+  create_test_go_script \
+    '. "$_GO_USE_MODULES" "file"' \
+    'declare fds=()' \
+    'declare fd' \
+    "$@" \
+    '@go.close_fds "${fds[@]}"' \
+    'declare result="$?"' \
+    '' \
+    'for fd in "${fds[@]}"; do' \
+    '  if [[ -e "/dev/fd/$fd" ]]; then' \
+    '    echo "/dev/fd/$fd" >&2' \
+    '    result=1' \
+    '  fi' \
+    'done' \
+    'exit "$result"'
+}
+
+@test "$SUITE: error if no file descriptor arguments" {
+  create_close_fds_test_script
+  run "$TEST_GO_SCRIPT"
+
+  local expected=("No file descriptors to close specified at:"
+    "  $TEST_GO_SCRIPT:6 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: successfully close stdin, stdout, and stderr" {
+  create_close_fds_test_script \
+    'fds+=(0 1 2)'
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: error if an argument isn't a file descriptor" {
+  create_close_fds_test_script \
+    'fds+=(-1)'
+  run "$TEST_GO_SCRIPT"
+
+  assert_failure
+  assert_line_matches -2 \
+    "Failed to close one or more file descriptors: -1 at:"
+  assert_line_matches -1 \
+    "  $TEST_GO_SCRIPT:7 main"
+}

--- a/tests/file/fds-printf.bats
+++ b/tests/file/fds-printf.bats
@@ -1,0 +1,83 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+MESSAGE='Hello, World!'
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+create_fds_printf_test_script() {
+  create_test_go_script \
+    '. "$_GO_USE_MODULES" "file"' \
+    'declare output_fds' \
+    "$@" \
+    "@go.fds_printf \"\$output_fds\" '$MESSAGE\n'"
+}
+
+@test "$SUITE: print to standard output" {
+  create_fds_printf_test_script \
+    'output_fds="1"'
+  run "$TEST_GO_SCRIPT"
+  assert_success "$MESSAGE"
+}
+
+@test "$SUITE: print to a file" {
+  local file_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  create_fds_printf_test_script \
+    "declare output_file='$file_path'" \
+    'declare output_fd' \
+    "@go.open_file_or_duplicate_fd '$file_path' 'w' 'output_fd'" \
+    'output_fds="$output_fd"'
+  run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_equal "$MESSAGE" "$(< "$file_path")"
+}
+
+@test "$SUITE: print to standard output and to a file" {
+  local file_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  create_fds_printf_test_script \
+    "declare output_file='$file_path'" \
+    'declare output_fd' \
+    "@go.open_file_or_duplicate_fd '$file_path' 'w' 'output_fd'" \
+    'output_fds="1,$output_fd"'
+  run "$TEST_GO_SCRIPT"
+  assert_success "$MESSAGE"
+  assert_equal "$MESSAGE" "$(< "$file_path")"
+}
+
+@test "$SUITE: error if non-file descriptor argument given" {
+  local file_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  create_fds_printf_test_script \
+    "output_fds='1,$file_path'"
+  run "$TEST_GO_SCRIPT"
+
+  local expected=(
+    "Invalid file descriptor value \"$file_path\" for @go.fds_printf at:"
+    "  $TEST_GO_SCRIPT:6 main"
+  )
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: error if write to a file descriptor fails" {
+  local file_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  create_fds_printf_test_script \
+    "declare output_file='$file_path'" \
+    'declare output_fd' \
+    "@go.open_file_or_duplicate_fd '$file_path' 'w' 'output_fd'" \
+    'output_fds="1,$output_fd"' \
+    '@go.close_fds "$output_fd"'
+  run "$TEST_GO_SCRIPT"
+
+  assert_failure
+  assert_line_equals  0    "$MESSAGE"
+  assert_line_matches '-2' "Failed to print to fd [1-9][0-9]* at:"
+  assert_line_matches '-1' "  $TEST_GO_SCRIPT:10 main"
+  assert_equal '' "$(< "$file_path")"
+}

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -1,0 +1,195 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+FILE_PATH="$TEST_GO_ROOTDIR/hello.txt"
+
+setup() {
+  mkdir -p "$TEST_GO_ROOTDIR"
+  echo "Hello, World!" >"$FILE_PATH"
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+create_file_open_test_go_script() {
+  create_test_go_script \
+    ". \"\$_GO_USE_MODULES\" 'file'" \
+    "declare file_path='$FILE_PATH'" \
+    "$@"
+}
+
+@test "$SUITE: open file for reading" {
+  create_file_open_test_go_script \
+    'declare read_fd' \
+    'declare file_content' \
+    '@go.open_file_or_duplicate_fd "$file_path" "r" "read_fd"' \
+    'read -r -u "$read_fd" file_content' \
+    'printf "$file_content"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  assert_success "$(< "$FILE_PATH")"
+}
+
+@test "$SUITE: duplicate descriptor for reading" {
+  create_file_open_test_go_script \
+    'declare read_fd' \
+    'declare dup_read_fd' \
+    'declare file_content' \
+    '@go.open_file_or_duplicate_fd "$file_path" "r" "read_fd"' \
+    '@go.open_file_or_duplicate_fd "$read_fd" "r" "dup_read_fd"' \
+    'read -r -u "$dup_read_fd" file_content' \
+    'printf "$file_content"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  assert_success "$(< "$FILE_PATH")"
+}
+
+
+@test "$SUITE: open file for writing" {
+  create_file_open_test_go_script \
+    'declare write_fd' \
+    '@go.open_file_or_duplicate_fd "$file_path" "w" "write_fd"' \
+    'echo "Goodbye, World!" >&"$write_fd"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  assert_success
+  assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
+}
+
+@test "$SUITE: duplicate descriptor for writing" {
+  create_file_open_test_go_script \
+    'declare write_fd' \
+    'declare dup_write_fd' \
+    '@go.open_file_or_duplicate_fd "$file_path" "w" "write_fd"' \
+    '@go.open_file_or_duplicate_fd "$write_fd" "w" "dup_write_fd"' \
+    'echo "Goodbye, World!" >&"$dup_write_fd"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  assert_success
+  assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
+}
+
+@test "$SUITE: open file for appending" {
+  local expected=("$(< "$FILE_PATH")"
+    "Goodbye, World!")
+
+  create_file_open_test_go_script \
+    'declare append_fd' \
+    '@go.open_file_or_duplicate_fd "$file_path" "a" "append_fd"' \
+    'echo "Goodbye, World!" >&"$append_fd"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  assert_success
+
+  local IFS=$'\n'
+  assert_equal "${expected[*]}" "$(< "$FILE_PATH")"
+}
+
+@test "$SUITE: open file for read and write" {
+  # Turns out this is random access. Let's have some fun here!
+  # Per: http://www.tldp.org/LDP/abs/html/io-redirection.html
+  local first_line='You say'
+  local second_line='and I say'
+  echo "${first_line}_________" >"$FILE_PATH"
+  echo "${second_line}_______" >>"$FILE_PATH"
+
+  create_file_open_test_go_script \
+    'declare read_write_fd' \
+    'declare file_content' \
+    '@go.open_file_or_duplicate_fd "$file_path" "rw" "read_write_fd"' \
+    '' \
+    "read -n ${#first_line} -u \"\$read_write_fd\" file_content" \
+    'printf "$file_content\n"' \
+    'echo " goodbye," >&"$read_write_fd"' \
+    '' \
+    "read -n ${#second_line} -u \"\$read_write_fd\" file_content" \
+    'printf "$file_content\n"' \
+    'echo " hello!" >&"$read_write_fd"' \
+
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+
+  local IFS=$'\n'
+  local orig_content=("$first_line"
+    "$second_line")
+  assert_success "${orig_content[*]}"
+
+  local updated_content=('You say goodbye,'
+    'and I say hello!')
+  assert_equal "${updated_content[*]}" "$(< "$FILE_PATH")"
+}
+
+@test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS is not an integer" {
+  create_file_open_test_go_script
+  _GO_MAX_FILE_DESCRIPTORS='foobar' run "$TEST_GO_SCRIPT" "$TEST_FILE"
+
+  local expected=(
+    '_GO_MAX_FILE_DESCRIPTORS is "foobar", must be a number greater than 3.'
+    "  $TEST_GO_SCRIPT:3 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS isn't greater than 3" {
+  create_file_open_test_go_script
+  _GO_MAX_FILE_DESCRIPTORS='3' run "$TEST_GO_SCRIPT" "$TEST_FILE"
+
+  local expected=(
+    '_GO_MAX_FILE_DESCRIPTORS is "3", must be a number greater than 3.'
+    "  $TEST_GO_SCRIPT:3 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: error if mode is unknown" {
+  create_file_open_test_go_script \
+    '@go.open_file_or_duplicate_fd "$file_path" "bogus" "bogus_fd"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+
+  local expected=('Unknown mode: bogus'
+    "  $TEST_GO_SCRIPT:5 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: error if no file descriptor variable reference given" {
+  create_file_open_test_go_script \
+    '@go.open_file_or_duplicate_fd "$file_path" "r"'
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+
+  local expected=(
+    'No variable reference given for the resulting file descriptor.'
+    "  $TEST_GO_SCRIPT:5 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: error if the file descriptor can't be opened" {
+  if fs_missing_permission_support; then
+    skip "Can't trigger condition on this file system"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip "Can't trigger condition when run by superuser"
+  fi
+
+  create_file_open_test_go_script \
+    'declare read_fd' \
+    '@go.open_file_or_duplicate_fd "$file_path" "r" "read_fd"'
+  chmod ugo-r "$FILE_PATH"
+  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+
+  assert_failure
+  assert_line_matches '-2' \
+    "Failed to open fd [1-9][0-9]* for \"$FILE_PATH\" in mode 'r' at:"
+  assert_line_matches '-1' \
+    "  $TEST_GO_SCRIPT:6 main"
+}
+
+@test "$SUITE: error if no file descriptors are available" {
+  create_file_open_test_go_script \
+    'declare read_fd' \
+    'while "true"; do' \
+    '  @go.open_file_or_duplicate_fd "$file_path" "r" "read_fd_success"' \
+    'done'
+  _GO_MAX_FILE_DESCRIPTORS=10 run "$TEST_GO_SCRIPT" "$FILE_PATH"
+
+  local expected=("No file descriptors < 10 available; failed at:"
+    "  $TEST_GO_SCRIPT:7 main")
+  local IFS=$'\n'
+  assert_failure "${expected[*]}"
+}


### PR DESCRIPTION
This new module adds these functions to help with file descriptor-based I/O:

* `@go.open_file_or_duplicate_fd`
* `@go.fds_printf`
* `@go.close_fds`

`@go.open_file_or_duplicate_fd` will eventually be used in a forthcoming `@go.log_setup` function. The approach used by `@go.fds_printf` will eventually apply to `@go.log`, as it will eventually support output to multiple file descriptors.