### PR TITLE
log: Extract helper script to fix Windows breakage

### DIFF
--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -90,13 +90,10 @@ remove_test_go_rootdir() {
 #   function_name:  Function in which the line appears, 'main', or 'source'
 #   needle_line:    Line for which to produce a stack trace line
 stack_trace_item() {
-  # Seriously, it's faster to create a script containing a `for` or `while read`
-  # loop over a file and run it as a new process than it is to run it in-process
+  # Seriously, it's faster to run a script containing a `for` or `while read`
+  # loop over a file as a new process than it is to run the function in-process
   # under Bats. Haven't yet figured out why.
-  create_bats_test_script 'stack-trace-item' \
-    "$(declare -f __stack_trace_item_impl)" \
-    '__stack_trace_item_impl "$@"'
-  "$BATS_TEST_ROOTDIR/stack-trace-item" "$@"
+  "${BASH_SOURCE%/*}/stack-trace-item" "$@"
 }
 
 log_command_stack_trace_item() {
@@ -127,46 +124,4 @@ set_go_core_stack_trace_components() {
     done
     export GO_CORE_STACK_TRACE_COMPONENTS
   fi
-}
-
-__stack_trace_item_impl() {
-  local haystack_file="$1"
-  local function_name="$2"
-  local function_pattern="^$function_name\\(\\) ?{\$"
-  local needle="$3"
-  local skip
-  local inside_function
-  local lineno=0
-  local line
-  local result=1
-
-  if [[ "$function_name" == 'main' || "$function_name" == 'source' ]]; then
-    inside_function='false'
-  fi
-
-  local IFS=$'\n'
-  while read -r line; do
-    ((++lineno))
-    if [[ -n "$skip" ]]; then
-      if [[ "$line" == '}' ]]; then
-        skip=
-      fi
-    elif [[ -z "$inside_function" && "$line" =~ $function_pattern ]]; then
-      inside_function='true'
-    elif [[ "$line" =~ ()\ {$ ]]; then
-      skip='true'
-    elif [[ "$inside_function" == 'true' && "$line" == '}' ]]; then
-      break
-    elif [[ "$line" == "$needle" ]]; then
-      result=0
-      break
-    fi
-  done <"$haystack_file"
-
-  if [[ "$result" -eq '0' ]]; then
-    echo "  $haystack_file:$lineno $function_name"
-  else
-    printf "ERROR: Line not found in $function_name: \"$needle\"\nat:\n" >&2
-  fi
-  return "$result"
 }

--- a/tests/stack-trace-item
+++ b/tests/stack-trace-item
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+#
+# Implements the `stack_trace_item` function from environment.bash
+
+__stack_trace_item() {
+  local haystack_file="$1"
+  local function_name="$2"
+  local function_pattern="^$function_name\\(\\) ?{\$"
+  local needle="$3"
+  local skip
+  local inside_function
+  local lineno=0
+  local line
+
+  if [[ "$function_name" == 'main' || "$function_name" == 'source' ]]; then
+    inside_function='false'
+  fi
+
+  # For Windows compatibility, we have to set `IFS=` to preserve leading
+  # spaces, and then strip off the trailing carriage return (the newline is
+  # already chomped off).
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    ((++lineno))
+
+    if [[ -n "$skip" ]]; then
+      if [[ "$line" == '}' ]]; then
+        skip=
+      fi
+    elif [[ -z "$inside_function" && "$line" =~ $function_pattern ]]; then
+      inside_function='true'
+    elif [[ "$line" =~ ()\ {$ ]]; then
+      skip='true'
+    elif [[ "$inside_function" == 'true' && "$line" == '}' ]]; then
+      break
+    elif [[ "$line" == "$needle" ]]; then
+      echo "  $haystack_file:$lineno $function_name"
+      return
+    fi
+  done <"$haystack_file"
+
+  printf "ERROR: Line not found in $function_name: \"$needle\"\nat:\n" >&2
+  return 1
+}
+
+__stack_trace_item "$@"


### PR DESCRIPTION
PR #28 introduced the `stack_trace_item` test helper function so that tests could validate expected stack trace output without hardcoding line numbers. I failed to notice that this behavior was broken on Windows, due to leading whitespace getting stripped and CRLF line endings not being handled by the `while read -r line` loop.

The fix for the whitespace was easy. Per the following, setting `IFS=` did the trick:

https://stackoverflow.com/questions/29689172/bash-read-line-does-not-read-leading-spaces/29689199#2968919

However, adding the following as the first line of the loop by itself wasn't enough:

    line="${line%$'\r'}"

It turned out that when the `stack-trace-item` file was getting written, it would replace this line with:

    line="${line%^M}";

where `^M` was the literal carriage return character, not the Bash string. Somehow this was causing the line to continue to retain its trailing carriage return, causing the tests to continue to fail.

I only started to figure this out after adding some `echo` statements to print things to standard error, followed by one of:

    | sed -n l >&2
    | od -A n -vt c >&2

per:

https://unix.stackexchange.com/questions/213504/how-to-print-control-characters-with-escape-sequences/213510#213510

Eventually I realized it made sense to break out the script anyway, as it wasn't being customized by the `stack_trace_item` function. Now the tests all pass on Windows.