### PR TITLE
Add input parameter validation to file module functions

### DIFF
--- a/lib/file
+++ b/lib/file
@@ -48,7 +48,7 @@ fi
   local file_path_or_fd="$1"
   local mode="$2"
   local fd_var_reference="$3"
-  local malicious_input_pattern='(\`|\$\(|[^\][";]|&&|\|\|)'
+  local malicious_input_pattern='([^\][`";]|\$\(|&&|\|\|)'
   local bash_mode
   local i
 

--- a/lib/file
+++ b/lib/file
@@ -19,7 +19,13 @@ declare -r _GO_MAX_FILE_DESCRIPTORS="${_GO_MAX_FILE_DESCRIPTORS:-256}"
 # DO NOT EDIT: First file descriptor attempted by @go.open_file_or_duplicate_fd
 declare -r __GO_START_FD='3'
 
-if [[ ! "$_GO_MAX_FILE_DESCRIPTORS" =~ ^[1-9][0-9]*$ ||
+# DO NOT EDIT: Pattern used to validate file descriptor parameters
+declare -r __GO_FILE_DESCRIPTOR_PATTERN='^[1-9][0-9]*$'
+
+# DO NOT EDIT: Pattern used to validate file path and variable name parameters
+declare -r __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n'$'\r'']'
+
+if [[ ! "$_GO_MAX_FILE_DESCRIPTORS" =~ $__GO_FILE_DESCRIPTOR_PATTERN ||
   "$_GO_MAX_FILE_DESCRIPTORS" -le "$__GO_START_FD" ]]; then
   printf "_GO_MAX_FILE_DESCRIPTORS is %s, must be a number greater than %d.\n" \
     "\"$_GO_MAX_FILE_DESCRIPTORS\"" "$__GO_START_FD" >&2
@@ -48,16 +54,15 @@ fi
   local file_path_or_fd="$1"
   local mode="$2"
   local fd_var_reference="$3"
-  local malicious_input_pattern='([^\][`";]|\$\(|&&|\|\|)'
   local bash_mode
   local i
 
-  if [[ "$file_path_or_fd" =~ $malicious_input_pattern ]]; then
+  if [[ "$file_path_or_fd" =~ $__GO_VALIDATE_INPUT_PATTERN ]]; then
     printf 'Bad file_path_or_fd argument \"%s\" to %s at:\n' \
       "$file_path_or_fd" "$FUNCNAME" >&2
     @go.print_stack_trace '1' >&2
     exit 1
-  elif [[ "$file_path_or_fd" =~ ^[0-9]+$ ]]; then
+  elif [[ "$file_path_or_fd" =~ $__GO_FILE_DESCRIPTOR_PATTERN ]]; then
     file_path_or_fd="&$file_path_or_fd"
   else
     file_path_or_fd="\"$file_path_or_fd\""
@@ -87,7 +92,7 @@ fi
     echo "No variable reference given for the resulting file descriptor." >&2
     @go.print_stack_trace '1' >&2
     exit 1
-  elif [[ "$fd_var_reference" =~ $malicious_input_pattern ]]; then
+  elif [[ "$fd_var_reference" =~ $__GO_VALIDATE_INPUT_PATTERN ]]; then
     printf 'Bad fd_var_reference argument \"%s\" to %s at:\n' \
       "$fd_var_reference" "$FUNCNAME" >&2
     @go.print_stack_trace '1' >&2
@@ -135,7 +140,7 @@ fi
   shift
 
   for output_fd in "${output_fds[@]}"; do
-    if [[ ! "$output_fd" =~ ^[1-9][0-9]*$ ]]; then
+    if [[ ! "$output_fd" =~ $__GO_FILE_DESCRIPTOR_PATTERN ]]; then
       echo "Invalid file descriptor value \"$output_fd\" for $FUNCNAME at:" >&2
       @go.print_stack_trace '1' >&2
       exit 1
@@ -167,7 +172,7 @@ fi
   fi
 
   for fd in "$@"; do
-    if [[ ! "$fd" =~ ^[1-9][0-9]*$ ]]; then
+    if [[ ! "$fd" =~ $__GO_FILE_DESCRIPTOR_PATTERN ]]; then
       echo "Bad file descriptor \"$fd\" at:" >&2
       @go.print_stack_trace '1' >&2
       return 1

--- a/lib/file
+++ b/lib/file
@@ -48,10 +48,16 @@ fi
   local file_path_or_fd="$1"
   local mode="$2"
   local fd_var_reference="$3"
+  local malicious_input_pattern='(\`|\$\(|[^\][";]|&&|\|\|)'
   local bash_mode
   local i
 
-  if [[ "$file_path_or_fd" =~ ^[0-9]+$ ]]; then
+  if [[ "$file_path_or_fd" =~ $malicious_input_pattern ]]; then
+    printf 'Bad file_path_or_fd argument \"%s\" to %s at:\n' \
+      "$file_path_or_fd" "$FUNCNAME" >&2
+    @go.print_stack_trace '1' >&2
+    exit 1
+  elif [[ "$file_path_or_fd" =~ ^[0-9]+$ ]]; then
     file_path_or_fd="&$file_path_or_fd"
   else
     file_path_or_fd="\"$file_path_or_fd\""
@@ -79,6 +85,11 @@ fi
 
   if [[ -z "$fd_var_reference" ]]; then
     echo "No variable reference given for the resulting file descriptor." >&2
+    @go.print_stack_trace '1' >&2
+    exit 1
+  elif [[ "$fd_var_reference" =~ $malicious_input_pattern ]]; then
+    printf 'Bad fd_var_reference argument \"%s\" to %s at:\n' \
+      "$fd_var_reference" "$FUNCNAME" >&2
     @go.print_stack_trace '1' >&2
     exit 1
   fi
@@ -156,12 +167,16 @@ fi
   fi
 
   for fd in "$@"; do
-    close_fd_strings+=("$fd>&-")
+    if [[ ! "$fd" =~ ^[1-9][0-9]*$ ]]; then
+      echo "Bad file descriptor \"$fd\" at:" >&2
+      @go.print_stack_trace '1' >&2
+      return 1
+    elif ! eval "exec $fd>&-"; then
+      # Believe it or not, this case seems impossible to trigger given the $fd
+      # check above. Keeping it despite not being able to cover it with a test.
+      echo "Failed to close file descriptor \"$fd\" at:" >&2
+      @go.print_stack_trace '1' >&2
+      return 1
+    fi
   done
-
-  if ! eval "exec ${close_fd_strings[*]}"; then
-    echo "Failed to close one or more file descriptors: $* at:" >&2
-    @go.print_stack_trace '1' >&2
-    return 1
-  fi
 }

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -27,7 +27,7 @@ create_file_open_test_go_script() {
     '@go.open_file_or_duplicate_fd "$file_path" "r" "read_fd"' \
     'read -r -u "$read_fd" file_content' \
     'printf "$file_content"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
   assert_success "$(< "$FILE_PATH")"
 }
 
@@ -40,7 +40,7 @@ create_file_open_test_go_script() {
     '@go.open_file_or_duplicate_fd "$read_fd" "r" "dup_read_fd"' \
     'read -r -u "$dup_read_fd" file_content' \
     'printf "$file_content"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
   assert_success "$(< "$FILE_PATH")"
 }
 
@@ -50,7 +50,7 @@ create_file_open_test_go_script() {
     'declare write_fd' \
     '@go.open_file_or_duplicate_fd "$file_path" "w" "write_fd"' \
     'echo "Goodbye, World!" >&"$write_fd"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
   assert_success
   assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
 }
@@ -62,7 +62,7 @@ create_file_open_test_go_script() {
     '@go.open_file_or_duplicate_fd "$file_path" "w" "write_fd"' \
     '@go.open_file_or_duplicate_fd "$write_fd" "w" "dup_write_fd"' \
     'echo "Goodbye, World!" >&"$dup_write_fd"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
   assert_success
   assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
 }
@@ -75,7 +75,7 @@ create_file_open_test_go_script() {
     'declare append_fd' \
     '@go.open_file_or_duplicate_fd "$file_path" "a" "append_fd"' \
     'echo "Goodbye, World!" >&"$append_fd"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
   assert_success
 
   local IFS=$'\n'
@@ -103,7 +103,7 @@ create_file_open_test_go_script() {
     'printf "$file_content\n"' \
     'echo " hello!" >&"$read_write_fd"' \
 
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
 
   local IFS=$'\n'
   local orig_content=("$first_line"
@@ -117,7 +117,7 @@ create_file_open_test_go_script() {
 
 @test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS is not an integer" {
   create_file_open_test_go_script
-  _GO_MAX_FILE_DESCRIPTORS='foobar' run "$TEST_GO_SCRIPT" "$TEST_FILE"
+  _GO_MAX_FILE_DESCRIPTORS='foobar' run "$TEST_GO_SCRIPT"
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "foobar", must be a number greater than 3.'
@@ -128,7 +128,7 @@ create_file_open_test_go_script() {
 
 @test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS isn't greater than 3" {
   create_file_open_test_go_script
-  _GO_MAX_FILE_DESCRIPTORS='3' run "$TEST_GO_SCRIPT" "$TEST_FILE"
+  _GO_MAX_FILE_DESCRIPTORS='3' run "$TEST_GO_SCRIPT"
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "3", must be a number greater than 3.'
@@ -137,37 +137,49 @@ create_file_open_test_go_script() {
   assert_failure "${expected[*]}"
 }
 
-try_malicious_file_path_argument() {
-  local malicious="$1"
-  create_file_open_test_go_script \
-    "@go.open_file_or_duplicate_fd '$malicious' 'r' 'read_fd'"
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+assert_validates_file_path_or_fd_argument() {
+  set +o functrace
+  local file_path_or_fd="$1"
 
-  local err_msg="Bad file_path_or_fd argument \"$malicious\" to "
+  if [[ ! -e "$TEST_GO_SCRIPT" ]]; then
+    create_file_open_test_go_script \
+      "@go.open_file_or_duplicate_fd \"\$FILE_PATH_OR_FD\" 'r' 'read_fd'"
+  fi
+  FILE_PATH_OR_FD="$file_path_or_fd" run "$TEST_GO_SCRIPT"
+
+  local err_msg="Bad file_path_or_fd argument \"$file_path_or_fd\" to "
   err_msg+='@go.open_file_or_duplicate_fd at:'
 
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
   local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  if ! assert_failure "${expected[*]}"; then
+    set +o functrace
+    return_from_bats_assertion "$BASH_SOURCE" 1
+  fi
 }
 
-@test "$SUITE: malicious file path contains \`" {
-  try_malicious_file_path_argument '`echo SURPRISE >&2; echo $file_path`'
-}
-
-@test "$SUITE: malicious file path contains \$(" {
-  try_malicious_file_path_argument '$(echo SURPRISE >&2; echo $file_path)'
-}
-
-@test "$SUITE: malicious file path contains unescaped \"" {
-  try_malicious_file_path_argument '$file_path"; echo "SURPRISE'
+@test "$SUITE: validates file_path_or_fd contains no meta or control chars" {
+  assert_validates_file_path_or_fd_argument 'foo`bar'
+  assert_validates_file_path_or_fd_argument 'foo"bar'
+  assert_validates_file_path_or_fd_argument 'foo;bar'
+  assert_validates_file_path_or_fd_argument 'foo$bar'
+  assert_validates_file_path_or_fd_argument 'foo(bar'
+  assert_validates_file_path_or_fd_argument 'foo)bar'
+  assert_validates_file_path_or_fd_argument 'foo&bar'
+  assert_validates_file_path_or_fd_argument 'foo|bar'
+  assert_validates_file_path_or_fd_argument 'foo<bar'
+  assert_validates_file_path_or_fd_argument 'foo>bar'
+  assert_validates_file_path_or_fd_argument 'foo'$'\n''bar'
+  assert_validates_file_path_or_fd_argument 'foo'$'\r''bar'
+  assert_validates_file_path_or_fd_argument "\`echo SURPRISE >&2\`$FILE_PATH"
+  assert_validates_file_path_or_fd_argument "$FILE_PATH\"; echo 'SURPRISE'"
 }
 
 @test "$SUITE: error if mode is unknown" {
   create_file_open_test_go_script \
     '@go.open_file_or_duplicate_fd "$file_path" "bogus" "bogus_fd"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
 
   local expected=('Unknown mode: bogus'
     "  $TEST_GO_SCRIPT:5 main")
@@ -178,7 +190,7 @@ try_malicious_file_path_argument() {
 @test "$SUITE: error if no file descriptor variable reference given" {
   create_file_open_test_go_script \
     '@go.open_file_or_duplicate_fd "$file_path" "r"'
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  run "$TEST_GO_SCRIPT"
 
   local expected=(
     'No variable reference given for the resulting file descriptor.'
@@ -187,59 +199,56 @@ try_malicious_file_path_argument() {
   assert_failure "${expected[*]}"
 }
 
-try_malicious_var_ref_argument() {
-  local malicious="$1"
-  create_file_open_test_go_script \
-    "@go.open_file_or_duplicate_fd \"\$file_path\" 'r' '$malicious'"
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+assert_validates_var_ref_argument() {
+  set +o functrace
+  local var_ref="$1"
 
-  local err_msg="Bad fd_var_reference argument \"$malicious\" to "
+  if [[ ! -e "$TEST_GO_SCRIPT" ]]; then
+    create_file_open_test_go_script \
+      "@go.open_file_or_duplicate_fd \"\$file_path\" 'r' \"\$VAR_REF\""
+  fi
+  VAR_REF="$var_ref" run "$TEST_GO_SCRIPT"
+
+  local err_msg="Bad fd_var_reference argument \"$var_ref\" to "
   err_msg+='@go.open_file_or_duplicate_fd at:'
 
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
   local IFS=$'\n'
-  assert_failure "${expected[*]}"
-}
-
-@test "$SUITE: malicious variable reference contains \`" {
-  try_malicious_var_ref_argument '`echo SURPRISE >&2; echo read_fd`'
-}
-
-@test "$SUITE: malicious variable reference contains \$(" {
-  try_malicious_var_ref_argument '$(echo SURPRISE >&2; echo read_fd)'
-}
-
-@test "$SUITE: malicious variable reference contains ;" {
-  try_malicious_var_ref_argument 'echo SURPRISE >&2; read_fd'
-}
-
-@test "$SUITE: malicious variable reference contains &&" {
-  try_malicious_var_ref_argument 'echo SURPRISE >&2 && read_fd'
-}
-
-@test "$SUITE: malicious variable reference contains ||" {
-  try_malicious_var_ref_argument '[[ 0 -eq 1 ]] || read_fd'
-}
-
-@test "$SUITE: error if the file descriptor can't be opened" {
-  if fs_missing_permission_support; then
-    skip "Can't trigger condition on this file system"
-  elif [[ "$EUID" -eq '0' ]]; then
-    skip "Can't trigger condition when run by superuser"
+  if ! assert_failure "${expected[*]}"; then
+    set +o functrace
+    return_from_bats_assertion "$BASH_SOURCE" 1
   fi
+}
 
+@test "$SUITE: validates variable reference contains no meta or control chars" {
+  assert_validates_var_ref_argument 'foo`bar'
+  assert_validates_var_ref_argument 'foo"bar'
+  assert_validates_var_ref_argument 'foo;bar'
+  assert_validates_var_ref_argument 'foo$bar'
+  assert_validates_var_ref_argument 'foo(bar'
+  assert_validates_var_ref_argument 'foo)bar'
+  assert_validates_var_ref_argument 'foo&bar'
+  assert_validates_var_ref_argument 'foo|bar'
+  assert_validates_var_ref_argument 'foo<bar'
+  assert_validates_var_ref_argument 'foo>bar'
+  assert_validates_var_ref_argument 'foo'$'\n''bar'
+  assert_validates_var_ref_argument 'foo'$'\r''bar'
+  assert_validates_var_ref_argument 'echo SURPRISE'$'\n''read_fd'
+}
+
+@test "$SUITE: error opening file path with escaped \`" {
+  # The point here is that meta and control characters pass validation when
+  # escaped, but the file still doesn't exist.
   create_file_open_test_go_script \
     'declare read_fd' \
-    '@go.open_file_or_duplicate_fd "$file_path" "r" "read_fd"'
-  chmod ugo-r "$FILE_PATH"
-  run "$TEST_GO_SCRIPT" "$FILE_PATH"
+    '@go.open_file_or_duplicate_fd "$file_path\\\`" "r" "read_fd"'
+  run "$TEST_GO_SCRIPT"
 
   assert_failure
   assert_line_matches '-2' \
-    "Failed to open fd [1-9][0-9]* for \"$FILE_PATH\" in mode 'r' at:"
-  assert_line_matches '-1' \
-    "  $TEST_GO_SCRIPT:6 main"
+    "Failed to open fd [1-9][0-9]* for \"$FILE_PATH[\\]\`\" in mode 'r' at:"
+  assert_line_matches '-1' "  $TEST_GO_SCRIPT:6 main"
 }
 
 @test "$SUITE: error if no file descriptors are available" {
@@ -248,7 +257,7 @@ try_malicious_var_ref_argument() {
     'while "true"; do' \
     '  @go.open_file_or_duplicate_fd "$file_path" "r" "read_fd_success"' \
     'done'
-  _GO_MAX_FILE_DESCRIPTORS=10 run "$TEST_GO_SCRIPT" "$FILE_PATH"
+  _GO_MAX_FILE_DESCRIPTORS=10 run "$TEST_GO_SCRIPT"
 
   local expected=("No file descriptors < 10 available; failed at:"
     "  $TEST_GO_SCRIPT:7 main")


### PR DESCRIPTION
Since these functions call `eval`, it's good to be a little paranoid and validate the parameters better _just in case_ someone writes a program that uses this module to do something based on external input from users one day.

I may extract the functionality into `go-core.bash` or a `validation` module in the very near future.

I'd actually pushed these commits to #30, but after merging #31, I rebased the branch on a different machine that hadn't pulled them yet, and pushed it back. The perils of working across multiple machines and environments.