### PR TITLE
Add optional timestamp prefix to log messages

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -6,6 +6,9 @@
 #   @go.log
 #     Outputs a log line; supports terminal formatting and format stripping
 #
+#   @go.log_timestamp
+#     Prints a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
+#
 #   @go.add_or_update_log_level
 #     Modifies existing log level labels, formatting, and file descriptors
 #
@@ -40,6 +43,12 @@
 # script, and provides helpful hints on running the `./go` script upon success.
 #
 # See the function and variable comments from this file for further information.
+
+# A strftime-compatible date/time format string used to prefix log messages with
+# a timestamp. E.g.: '%Y-%m-%d %H:%M:%S'
+#
+# If left undefined, log messages are not prefixed with timestamps.
+declare _GO_LOG_TIMESTAMP_FORMAT
 
 # Set this if you want to force terminal-formatted output from @go.log.
 #
@@ -140,6 +149,7 @@ declare __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   local level_fd=1
   local exit_status=0
   local close_code='\e[0m'
+  local log_msg
 
   unset 'args[0]'
   _@go.log_init
@@ -172,13 +182,38 @@ declare __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
     close_code=''
   fi
 
-  printf "$formatted_log_level ${args[*]}$close_code\n" >&"$level_fd"
+  # Remove leading space if the timestamp is empty.
+  log_msg="$(@go.log_timestamp) $formatted_log_level ${args[*]}$close_code\n"
+  log_msg="${log_msg# }"
+  printf "$log_msg" >&"$level_fd"
 
   if [[ "$log_level" == 'FATAL' ]]; then
     @go.print_stack_trace "$__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS" >&2
     exit "$exit_status"
   fi
   return "$exit_status"
+}
+
+# Prints a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
+#
+# Prints nothing if:
+#   - _GO_LOG_TIMESTAMP_FORMAT isn't set
+#   - _GO_LOG_TIMESTAMP_FORMAT is set, but both the builtin
+#     `printf '%(datefmt)T'` format and `date` command are missing
+#
+# Globals:
+#   _GO_LOG_TIMESTAMP_FORMAT:  A strftime-compatible format string
+@go.log_timestamp() {
+  _@go.log_init
+
+  case "$__GO_LOG_TIMESTAMP_IMPL" in
+  printf)
+    printf "%($_GO_LOG_TIMESTAMP_FORMAT)T"
+    ;;
+  date)
+    date "+$_GO_LOG_TIMESTAMP_FORMAT"
+    ;;
+  esac
 }
 
 # Adds a new log level or updates an existing one.
@@ -357,10 +392,27 @@ declare __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 #
 # May be called multiple times; initialization will only happen once.
 _@go.log_init() {
-  if [[ -z "$__GO_LOG_INIT" ]]; then
-    _@go.log_format_level_labels
-    readonly __GO_LOG_INIT='done'
+  if [[ -n "$__GO_LOG_INIT" ]]; then
+    return
   fi
+
+  _@go.log_format_level_labels
+
+  if [[ -z "$__GO_LOG_TIMESTAMP_IMPL" ]]; then
+    if [[ -z "$_GO_LOG_TIMESTAMP_FORMAT" ]]; then
+      export __GO_LOG_TIMESTAMP_IMPL='none'
+    elif printf "%('%Y')T" &>/dev/null; then
+      export __GO_LOG_TIMESTAMP_IMPL='printf'
+    elif command -v 'date' >/dev/null; then
+      export __GO_LOG_TIMESTAMP_IMPL='date'
+    else
+      export __GO_LOG_TIMESTAMP_IMPL='none'
+      __GO_LOG_INIT='done' @go.log WARN \
+        Builtin timestamps not supported and date command not found.
+    fi
+  fi
+
+  readonly __GO_LOG_INIT='done'
 }
 
 # Assigns formatted log level labels to __GO_LOG_LEVELS_FORMATTED.

--- a/tests/log/timestamp.bats
+++ b/tests/log/timestamp.bats
@@ -1,0 +1,108 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+HAS_TIMESTAMP_BUILTIN=
+DATE_CMD=
+DATE_CMD_FILE=
+TEST_PATH=
+
+setup() {
+  if printf '%(%Y)T' &>/dev/null; then
+    HAS_TIMESTAMP_BUILTIN='true'
+  fi
+
+  DATE_CMD="$(command -v date)"
+  DATE_CMD_FILE="$TEST_GO_ROOTDIR/date-cmd-called"
+  TEST_PATH="$TEST_GO_ROOTDIR/bin:$PATH"
+
+  create_bats_test_script "${TEST_GO_ROOTDIR#$BATS_TEST_ROOTDIR}/bin/date" \
+    "declare -r DATE_CMD='$DATE_CMD'" \
+    "touch '$DATE_CMD_FILE'" \
+    "if [[ -n '$DATE_CMD' ]]; then" \
+    '  "$DATE_CMD" "$1"' \
+    'else' \
+    '  exit 1' \
+    'fi'
+
+  create_test_go_script '. "$_GO_USE_MODULES" log' \
+    '@go.log_timestamp'
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: return empty value if _GO_LOG_TIMESTAMP_FORMAT not set" {
+  _GO_LOG_TIMESTAMP_FORMAT= PATH="$TEST_PATH" run "$BASH" "$TEST_GO_SCRIPT"
+  assert_success ''
+
+  if [[ -f "$DATE_CMD_FILE" ]]; then
+    fail 'date command was called'
+  fi
+}
+
+@test "$SUITE: use builtin format if supported" {
+  if [[ -z "$HAS_TIMESTAMP_BUILTIN" ]]; then
+    skip "Builtin format not available in bash version $BASH_VERSION"
+  fi
+
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH="$TEST_PATH" \
+    run "$BASH" "$TEST_GO_SCRIPT"
+  assert_success
+  assert_output_matches '^[0-5][0-9]:[0-5][0-9]$'
+
+  if [[ -f "$DATE_CMD_FILE" ]]; then
+    fail 'date command was called'
+  fi
+}
+
+@test "$SUITE: use date command if builtin format supported" {
+  if [[ -n "$HAS_TIMESTAMP_BUILTIN" ]]; then
+    skip "Builtin format available in bash version $BASH_VERSION"
+  elif [[ -z "$DATE_CMD" ]]; then
+    skip "`date` command not found in \$PATH: $PATH"
+  fi
+
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH="$TEST_PATH" \
+    run "$BASH" "$TEST_GO_SCRIPT"
+  assert_success
+  assert_output_matches '^[0-5][0-9]:[0-5][0-9]$'
+
+  if [[ ! -f "$DATE_CMD_FILE" ]]; then
+    fail 'date command was not called'
+  fi
+}
+
+@test "$SUITE: return empty value if builtin format and date command missing" {
+  if [[ -n "$HAS_TIMESTAMP_BUILTIN" ]]; then
+    skip "Builtin format available in bash version $BASH_VERSION"
+  fi
+
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH= run "$BASH" "$TEST_GO_SCRIPT"
+  assert_success
+  assert_output_matches \
+    '^WARN +Builtin timestamps not supported and date command not found.$'
+
+  if [[ -f "$DATE_CMD_FILE" ]]; then
+    fail 'date command was called'
+  fi
+}
+
+@test "$SUITE: log messages prefixed with timestamp if supported" {
+  create_test_go_script '. "$_GO_USE_MODULES" log' \
+    '_GO_LOG_TIMESTAMP_FORMAT="%M:%S"' \
+    '@go.log INFO Timestamp me!'
+
+  # Force the timestamp to be unavailable if relying upon the date command.
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH= run "$BASH" "$TEST_GO_SCRIPT"
+  assert_success
+
+  if [[ -n "$HAS_TIMESTAMP_BUILTIN" ]]; then
+    assert_output_matches "^[0-5][0-9]:[0-5][0-9] INFO +Timestamp me!$"
+  else
+    assert_line_matches 0 \
+      '^WARN +Builtin timestamps not supported and date command not found.$'
+    assert_line_matches 1 '^INFO +Timestamp me!$'
+  fi
+}


### PR DESCRIPTION
Closes #34. Tested on macOS 10.12.2 under bash 4.4.5(1) from Homebrew and the bash 3.2.57(1) that ships with the system, and confirmed that the right tests execute and pass, and that the right tests are skipped for each version.

Required the envisioned assignment of `__GO_LOG_TIMESTAMP_IMPL` to take place in `_@go.log_init` instead, as the `WARN` message in the case of unavailable timestamps was emitted into the first `@go.log` call otherwise (caught by the "log/timestamp: log messages prefixed with timestamp if supported" test case when testing with bash 3.2.57(1)).