### PR TITLE
modules: Switch from `declare` to readonly, export

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ Linux for now.
 
 The following are intended to prevent too-compact code:
 
-- Declare only one variable per `declare` or `local` line.
+- Declare only one item per `declare`, `local`, `export`, or `readonly` call.
   - _Note:_ This also helps avoid subtle bugs, as trying to initialize one
     variable using the value of another declared in the same statement will
     not do what you may expect. The initialization of the first variable will
@@ -263,13 +263,26 @@ it easier to find, count, and possibly transform things.
 
 - Declare all constants near the top of the file using `declare -r`.
   - Exception: `declare` is not available in test files run using `bats`.
+  - Exception: In module code (i.e. code imported via `. "$_GO_USE_MODULES"`),
+    use `readonly` instead. Otherwise if a module is imported into a function,
+    variables declared with `declare` will go out of scope after the first
+    function call, and will not be redefined for subsequent calls, causing
+    errors.
 - Avoid globals; but if you must, declare all globals near the top of the file,
   outside of any function, using `declare`.
   - Exception: `declare` is not available in test files run using `bats`.
+  - Exception: In module code (i.e. code imported via `. "$_GO_USE_MODULES"`),
+    use `export` instead. See the note above regarding `declare -r` and
+    `readonly` for details.
 - Declare all variables inside functions using `local`.
   - Exception: If an internal function needs to return more than one distinct
     result value, or an array of values, it should use _undeclared_ variables
     prefixed with `__go_`, and all callers should declare these variables as
+    local variables.
+  - Exception: If a function needs to set a one-time initialization flag, it
+    may declare that value using `readonly`.
+- Declare temporary file-level variables using `declare`. Use `unset` to remove
+  them when finished.
 - Don't use `local -r`, as a readonly local variable in one scope can cause a
   conflict when it calls a function that declares a `local` variable of the same
   name.

--- a/lib/file
+++ b/lib/file
@@ -14,13 +14,13 @@
 
 # Maximum number of file descriptors to attempt opening. May be overridden by
 # the user.
-declare -r _GO_MAX_FILE_DESCRIPTORS="${_GO_MAX_FILE_DESCRIPTORS:-256}"
+readonly _GO_MAX_FILE_DESCRIPTORS="${_GO_MAX_FILE_DESCRIPTORS:-256}"
 
 # DO NOT EDIT: First file descriptor attempted by @go.open_file_or_duplicate_fd
-declare -r __GO_START_FD='3'
+readonly __GO_START_FD='3'
 
 # DO NOT EDIT: Pattern used to validate file descriptor parameters
-declare -r __GO_FILE_DESCRIPTOR_PATTERN='^[1-9][0-9]*$'
+readonly __GO_FILE_DESCRIPTOR_PATTERN='^[1-9][0-9]*$'
 
 if [[ ! "$_GO_MAX_FILE_DESCRIPTORS" =~ $__GO_FILE_DESCRIPTOR_PATTERN ||
   "$_GO_MAX_FILE_DESCRIPTORS" -le "$__GO_START_FD" ]]; then

--- a/lib/kcov-ubuntu
+++ b/lib/kcov-ubuntu
@@ -10,7 +10,7 @@
 # This may eventually be extracted into a plugin library of its own, which is
 # why its exported functions don't contain a `@go.` prefix.
 
-declare -r __KCOV_DEV_PACKAGES=(
+readonly __KCOV_DEV_PACKAGES=(
   'binutils-dev'
   'cmake'
   'libcurl4-openssl-dev'
@@ -19,7 +19,7 @@ declare -r __KCOV_DEV_PACKAGES=(
   'libiberty-dev'
   'zlib1g-dev'
 )
-declare -r __KCOV_URL='https://github.com/SimonKagstrom/kcov'
+readonly __KCOV_URL='https://github.com/SimonKagstrom/kcov'
 
 # Downloads and compiles kcov if necessary, then runs tests under kcov
 #

--- a/lib/log
+++ b/lib/log
@@ -48,24 +48,24 @@
 # a timestamp. E.g.: '%Y-%m-%d %H:%M:%S'
 #
 # If left undefined, log messages are not prefixed with timestamps.
-declare _GO_LOG_TIMESTAMP_FORMAT
+readonly _GO_LOG_TIMESTAMP_FORMAT="$_GO_LOG_TIMESTAMP_FORMAT"
 
 # Set this if you want to force terminal-formatted output from @go.log.
 #
 # @go.log will remove terminal formatting codes by default when the output file
 # descriptor is not a terminal. Can be set either in the script or on the
 # command line.
-declare _GO_LOG_FORMATTING="$_GO_LOG_FORMATTING"
+readonly _GO_LOG_FORMATTING="$_GO_LOG_FORMATTING"
 
 # If not empty, @go.log_command will only print the command and not execute it.
 #
 # Can be set either in the script or on the command line.
-declare _GO_DRY_RUN="$_GO_DRY_RUN"
+readonly _GO_DRY_RUN="$_GO_DRY_RUN"
 
 # Default log level labels
 #
 # DO NOT UPDATE DIRECTLY: Use @go.add_or_update_log_level instead.
-declare _GO_LOG_LEVELS=(
+export _GO_LOG_LEVELS=(
   'INFO'
   'RUN'
   'WARN'
@@ -76,7 +76,7 @@ declare _GO_LOG_LEVELS=(
 )
 
 # Default log level terminal format codes
-declare __GO_LOG_LEVELS_FORMAT_CODES=(
+export __GO_LOG_LEVELS_FORMAT_CODES=(
   '\e[1m\e[36m'
   '\e[1m\e[35m'
   '\e[1m\e[33m'
@@ -89,7 +89,7 @@ declare __GO_LOG_LEVELS_FORMAT_CODES=(
 # Default log level output file descriptors
 #
 # '1' is standard output and '2' is standard error.
-declare __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
+export __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
   '1'
   '1'
   '1'
@@ -100,13 +100,13 @@ declare __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
 )
 
 # DO NOT EDIT: Initialized by @go.log
-declare __GO_LOG_LEVELS_FORMATTED=()
+export __GO_LOG_LEVELS_FORMATTED=()
 
 # Set by @go.critical_section_{begin,end}
-declare __GO_CRITICAL_SECTION=0
+export __GO_CRITICAL_SECTION=0
 
 # DO NOT EDIT: Determines number of stack trace levels to skip for FATAL logs.
-declare __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
+export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 
 # Outputs a single log line that may contain terminal control characters.
 #
@@ -404,18 +404,16 @@ _@go.log_init() {
 
   _@go.log_format_level_labels
 
-  if [[ -z "$__GO_LOG_TIMESTAMP_IMPL" ]]; then
-    if [[ -z "$_GO_LOG_TIMESTAMP_FORMAT" ]]; then
-      export __GO_LOG_TIMESTAMP_IMPL='none'
-    elif printf "%('%Y')T" &>/dev/null; then
-      export __GO_LOG_TIMESTAMP_IMPL='printf'
-    elif command -v 'date' >/dev/null; then
-      export __GO_LOG_TIMESTAMP_IMPL='date'
-    else
-      export __GO_LOG_TIMESTAMP_IMPL='none'
-      __GO_LOG_INIT='done' @go.log WARN \
-        Builtin timestamps not supported and date command not found.
-    fi
+  if [[ -z "$_GO_LOG_TIMESTAMP_FORMAT" ]]; then
+    readonly __GO_LOG_TIMESTAMP_IMPL='none'
+  elif printf "%('%Y')T" &>/dev/null; then
+    readonly __GO_LOG_TIMESTAMP_IMPL='printf'
+  elif command -v 'date' >/dev/null; then
+    readonly __GO_LOG_TIMESTAMP_IMPL='date'
+  else
+    readonly __GO_LOG_TIMESTAMP_IMPL='none'
+    __GO_LOG_INIT='done' @go.log WARN \
+      Builtin timestamps not supported and date command not found.
   fi
 
   readonly __GO_LOG_INIT='done'

--- a/lib/validation
+++ b/lib/validation
@@ -7,7 +7,7 @@
 #     Ensures input parameters do not contain control or metacharacters
 
 # Pattern used to validate file path and variable name parameters
-declare -r __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n'$'\r'']'
+readonly __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n'$'\r'']'
 
 # Ensures input parameters do not contain control or metacharacters
 #

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -16,15 +16,13 @@ COLUMNS=1000
 # function.
 unset -v _GO_CMD
 
-# Somehow the 'declare' command doesn't work with the bats 'load' command, so
-# contrary to the rules in CONTRIBUTING.md, we don't use it here. Also,
 # TEST_GO_ROOTDIR contains a space to help ensure that variables are quoted
 # properly in most places.
-TEST_GO_ROOTDIR="$BATS_TEST_ROOTDIR"
-TEST_GO_SCRIPT="$TEST_GO_ROOTDIR/go"
-TEST_GO_SCRIPTS_RELATIVE_DIR="scripts"
-TEST_GO_SCRIPTS_DIR="$TEST_GO_ROOTDIR/$TEST_GO_SCRIPTS_RELATIVE_DIR"
-TEST_GO_PLUGINS_DIR="$TEST_GO_SCRIPTS_DIR/plugins"
+readonly TEST_GO_ROOTDIR="$BATS_TEST_ROOTDIR"
+readonly TEST_GO_SCRIPT="$TEST_GO_ROOTDIR/go"
+readonly TEST_GO_SCRIPTS_RELATIVE_DIR="scripts"
+readonly TEST_GO_SCRIPTS_DIR="$TEST_GO_ROOTDIR/$TEST_GO_SCRIPTS_RELATIVE_DIR"
+readonly TEST_GO_PLUGINS_DIR="$TEST_GO_SCRIPTS_DIR/plugins"
 
 create_test_go_script() {
   create_bats_test_script 'go' \

--- a/tests/log/add-update.bats
+++ b/tests/log/add-update.bats
@@ -50,9 +50,8 @@ teardown() {
 }
 
 @test "$SUITE: add new log level" {
-  run_log_script 'exec 27>logfile' \
+  _GO_LOG_FORMATTING='true' run_log_script 'exec 27>logfile' \
     "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT' 27" \
-    '_GO_LOG_FORMATTING=true' \
     '@go.log FOOBAR Hello, World!'
   assert_success ''
 
@@ -61,23 +60,23 @@ teardown() {
 }
 
 @test "$SUITE: add new log level defaulting to standard output" {
-  run_log_script "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT'" \
-    '_GO_LOG_FORMATTING=true' \
+  _GO_LOG_FORMATTING='true' run_log_script \
+    "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT'" \
     '@go.log FOOBAR Hello, World!'
   assert_success "$(printf "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: update format of existing log level" {
-  run_log_script "@go.add_or_update_log_level INFO '$START_FORMAT' keep" \
-    '_GO_LOG_FORMATTING=true' \
+  _GO_LOG_FORMATTING='true' run_log_script \
+    "@go.add_or_update_log_level INFO '$START_FORMAT' keep" \
     '@go.log INFO Hello, World!'
   assert_success "$(printf "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: update file descriptor of existing log level" {
-  run_log_script 'exec 27>logfile' \
+  _GO_LOG_FORMATTING='true' run_log_script \
+    'exec 27>logfile' \
     '@go.add_or_update_log_level INFO keep 27' \
-    '_GO_LOG_FORMATTING=true' \
     '@go.log INFO Hello, World!'
   assert_success ''
   
@@ -86,9 +85,9 @@ teardown() {
 }
 
 @test "$SUITE: update format and file descriptor of existing log level" {
-  run_log_script 'exec 27>logfile' \
+  _GO_LOG_FORMATTING='true' run_log_script \
+    'exec 27>logfile' \
     "@go.add_or_update_log_level INFO '$START_FORMAT' 27" \
-    '_GO_LOG_FORMATTING=true' \
     '@go.log INFO Hello, World!'
   assert_success ''
 

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -17,8 +17,8 @@ format_label() {
   local label="$1"
 
   if [[ -z "$__GO_LOG_INIT" ]]; then
-    . "$_GO_CORE_DIR/lib/log"
     _GO_LOG_FORMATTING='true'
+    . "$_GO_CORE_DIR/lib/log"
     _@go.log_init
   fi
 
@@ -78,5 +78,7 @@ assert_log_equals() {
   if ! assert_lines_equal "${expected[@]}"; then
     set +o functrace
     return_from_bats_assertion "$BASH_SOURCE" 1
+  else
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }

--- a/tests/log/main.bats
+++ b/tests/log/main.bats
@@ -14,8 +14,7 @@ teardown() {
 }
 
 @test "$SUITE: log INFO with formatting" {
-  run_log_script "_GO_LOG_FORMATTING='true'" \
-    '@go.log INFO Hello, World!'
+  _GO_LOG_FORMATTING='true' run_log_script '@go.log INFO Hello, World!'
   assert_success
   assert_log_equals "$(format_label INFO)" 'Hello, World!'
 }

--- a/tests/log/timestamp.bats
+++ b/tests/log/timestamp.bats
@@ -90,8 +90,8 @@ teardown() {
 }
 
 @test "$SUITE: log messages prefixed with timestamp if supported" {
-  create_test_go_script '. "$_GO_USE_MODULES" log' \
-    '_GO_LOG_TIMESTAMP_FORMAT="%M:%S"' \
+  create_test_go_script '_GO_LOG_TIMESTAMP_FORMAT="%M:%S"' \
+    '. "$_GO_USE_MODULES" log' \
     '@go.log INFO Timestamp me!'
 
   # Force the timestamp to be unavailable if relying upon the date command.


### PR DESCRIPTION
Encountered in the course of implementing #36. While writing the upcoming `@go.log_add_output_file` function in the`log` module, which includes a call to `. "$_GO_USE_MODULES" 'file'`, a test that made multiple calls to this new function would fail with the message:

```
 ✗ log/add-output-file: add output files for a mix of levels
   (in test file tests/log/add-output-file.bats, line 83)
     `"@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log' 'INFO'" \' failed
   line 0 not equal to expected value:
     expected: 'INFO   FYI'
     actual:   'No file descriptors <  available; failed at:'
```

This error message is part of `@go.open_file_or_duplicate_fd`, and includes a reference to `$_GO_MAX_FILE_DESCRIPTORS`, which was previously declared as:

```bash
  declare -r _GO_MAX_FILE_DESCRIPTORS="${_GO_MAX_FILE_DESCRIPTORS:-256}"
```

The fact that no value appeared for "$_GO_MAX_FILE_DESCRIPTORS" was suspicous. Moving the `. "$_GO_USE_MODULES" 'file'` call outside of the function to the top level of the module got the test to pass; I understood this to be because:

- Top-level `declare` statements cause variables to be scoped to the
  function sourcing the file.
- When the function call ends, the declared variables go out of scope.
- Since "$_GO_USE_MODULES" ensures module files are imported only once,
  these variables aren't redeclared for subsequent calls.

After deciding that it should be permissible for a function to call `.  "$_GO_USE_MODULES"` and have it work across multiple calls, I eventually learned that substituing `readonly` for `declare -r` did what I originally intended. The same also holds for `export` vs `declare` or `declare -x`. Making these updates to the `file` module allowed the test to pass; only minor changes were required to other tests when applying the updates to every module.

For now, this update applies only to module code. I may look into how to apply `readonly` and `export` to other code as well, but an initial experiment with replacing values in `go-core.bash` caused `./go test vars` to fail.