### PR TITLE
Add @go.log_add_output_file

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -12,6 +12,9 @@
 #   @go.add_or_update_log_level
 #     Modifies existing log level labels, formatting, and file descriptors
 #
+#   @go.log_add_output_file
+#     Add an additional output file for log messages
+#
 #   @go.log_command
 #     Logs a command and its outcome
 #
@@ -266,6 +269,46 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   if [[ "$level_fd" != 'keep' ]]; then
     __GO_LOG_LEVELS_FILE_DESCRIPTORS[$__go_log_level_index]="$level_fd"
   fi
+}
+
+# Add an additional output file for log messages.
+#
+# If `log_levels` is not specified, the file will be opened for all existing log
+# levels. If it is specified:
+#
+#   - any levels not yet in `_GO_LOG_LEVELS` will be created
+#   - each level will write to `output_file` in addition to existing output fds
+#
+# Arguments:
+#   output_file:  Path to the additional log file; will be opened for appending
+#   log_level:    Comma-separated log levels to send output to output_file
+@go.log_add_output_file() {
+  local output_file="$1"
+  local log_level="$2"
+  local output_fd
+  local levels=()
+  local level
+  local __go_log_level_index
+
+  . "$_GO_USE_MODULES" 'file'
+  @go.open_file_or_duplicate_fd "$output_file" 'a' 'output_fd'
+
+  if [[ -n "$log_level" ]]; then
+    local origIFS="$IFS"
+    local IFS=','
+    levels=($log_level)
+    IFS="$origIFS"
+  else
+    levels=("${_GO_LOG_LEVELS[@]}")
+  fi
+
+  for level in "${levels[@]}"; do
+    if _@go.log_level_index "$level"; then
+      __GO_LOG_LEVELS_FILE_DESCRIPTORS[$__go_log_level_index]+=",$output_fd"
+    else
+      @go.add_or_update_log_level "$level" '' "$output_fd"
+    fi
+  done
 }
 
 # Sets @go.log_command to log FATAL when its command exits with an error status.

--- a/tests/log/add-output-file.bats
+++ b/tests/log/add-output-file.bats
@@ -1,0 +1,125 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+TEST_SCRIPT_LINES=
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+run_log_script_and_assert_status_and_output() {
+  set +o functrace
+  local num_errors
+
+  run_log_script "$@" \
+    '@go.log INFO  FYI' \
+    '@go.log RUN   echo foo' \
+    '@go.log WARN  watch out' \
+    '@go.log ERROR uh-oh' \
+    '@go.log FATAL oh noes!'
+
+  if ! assert_failure; then
+    set +o functrace
+    return_from_bats_assertion "$BASH_SOURCE" 1
+    return
+  fi
+
+  local origIFS="$IFS"
+  IFS=$'\n'
+  local test_script=($(< "$TEST_GO_SCRIPT"))
+  IFS="$origIFS"
+  TEST_SCRIPT_LINES="${#test_script[@]}"
+
+  local expected=(INFO 'FYI'
+    RUN   'echo foo'
+    WARN  'watch out'
+    ERROR 'uh-oh'
+    FATAL 'oh noes!'
+    "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main")
+
+  if ! assert_log_equals "${expected[@]}"; then
+    set +o functrace
+    return_from_bats_assertion "$BASH_SOURCE" 1
+  else
+    return_from_bats_assertion "$BASH_SOURCE"
+  fi
+}
+
+@test "$SUITE: add an output file for all log levels" {
+  run_log_script_and_assert_status_and_output \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/all.log'"
+  assert_equal "$output" "$(< "$TEST_GO_ROOTDIR/all.log")" 'all.log'
+}
+
+@test "$SUITE: add an output file for an existing log level" {
+  run_log_script_and_assert_status_and_output \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log' 'INFO'"
+  assert_matches "^INFO +FYI$" "$(< "$TEST_GO_ROOTDIR/info.log")" 'info.log'
+}
+
+@test "$SUITE: force formatted output in log file" {
+  _GO_LOG_FORMATTING='true' run_log_script \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log' 'INFO'" \
+    "@go.log INFO Hello, World!"
+  assert_success
+  assert_log_equals "$(format_label INFO)" 'Hello, World!'
+  assert_equal "$output" "$(< "$TEST_GO_ROOTDIR/info.log")" 'info.log'
+}
+
+@test "$SUITE: add an output file for a new log level" {
+  local msg="This shouldn't appear in standard output or error."
+
+  # Note that FOOBAR has the same number of characters as FINISH, currently the
+  # longest log label name. If FINISH is ever removed without another
+  # six-character label taking its place, the test may fail because of changes
+  # in label padding. The fix would be to replace FOOBAR with a new name no
+  # longer than the longest built-in log label.
+  run_log_script_and_assert_status_and_output \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/foobar.log' 'FOOBAR'" \
+    "@go.log FOOBAR \"$msg\""
+
+  assert_matches "^FOOBAR +$msg$" \
+    "$(< "$TEST_GO_ROOTDIR/foobar.log")" 'foobar.log'
+}
+
+@test "$SUITE: add output files for multiple log levels" {
+  run_log_script_and_assert_status_and_output \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/error.log' 'ERROR,FATAL'"
+
+  local IFS=$'\n'
+  local error_log=($(< "$TEST_GO_ROOTDIR/error.log"))
+
+  assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
+  assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'
+  assert_matches '^FATAL +oh noes!$' "${error_log[1]}" 'FATAL log message'
+  assert_equal "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main" "${error_log[2]}" \
+    'FATAL stack trace'
+}
+
+@test "$SUITE: add output files for a mix of levels" {
+  local msg="This shouldn't appear in standard output or error."
+
+  # Same note regarding FOOBAR from the earlier test case applies.
+  run_log_script_and_assert_status_and_output \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log' 'INFO'" \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/all.log'" \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/error.log' 'ERROR,FATAL'" \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/foobar.log' 'FOOBAR'" \
+    "@go.log FOOBAR \"$msg\""
+
+  assert_equal "$output" "$(< "$TEST_GO_ROOTDIR/all.log")" 'all.log'
+  assert_matches "^INFO +FYI$" "$(< "$TEST_GO_ROOTDIR/info.log")" 'info.log'
+  assert_matches "^FOOBAR +$msg$" \
+    "$(< "$TEST_GO_ROOTDIR/foobar.log")" 'foobar.log'
+
+  local IFS=$'\n'
+  local error_log=($(< "$TEST_GO_ROOTDIR/error.log"))
+
+  assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
+  assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'
+  assert_matches '^FATAL +oh noes!$' "${error_log[1]}" 'FATAL log message'
+  assert_equal "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main" "${error_log[2]}" \
+    'FATAL stack trace'
+}


### PR DESCRIPTION
Implements #36, except for the priority filtering. That will come in a future commit.

With `@go.log_add_output_file`, you can add an output file to:

- all existing log levels at once
- a new log level that this function will create for you
- a subset of log levels, existing or new

The infrastructure needed to support the multiple-destination log output was added in #43 (commit b61556bfe516fa4b0878cb93964221e3c3466ded).