### PR TITLE
Add DEBUG log level and priority filter variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,6 +274,9 @@ it easier to find, count, and possibly transform things.
   - Exception: In module code (i.e. code imported via `. "$_GO_USE_MODULES"`),
     use `export` instead. See the note above regarding `declare -r` and
     `readonly` for details.
+  - _Gotcha:_ Never initialize an array on the same line as an `export` or
+    `declare -g` statement. See [the Gotchas section](#gotchas) below for more
+    details.
 - Declare all variables inside functions using `local`.
   - Exception: If an internal function needs to return more than one distinct
     result value, or an array of values, it should use _undeclared_ variables
@@ -333,6 +336,13 @@ it easier to find, count, and possibly transform things.
   variable on one line and perform the substitution on another. If you don't,
   the exit status will always indicate success, as it is the status of the
   `local` declaration, not the command substitution.
+- To work around a bug in some versions of Bash whereby arrays declared with
+  `declare -g` or `export` and initialized in the same statement eventually go
+  out of scope, always `export` the array name on one line and initialize it the
+  next line. See:
+  - https://lists.gnu.org/archive/html/bug-bash/2012-06/msg00068.html
+  - ftp://ftp.gnu.org/gnu/bash/bash-4.2-patches/bash42-025
+  - http://lists.gnu.org/archive/html/help-bash/2012-03/msg00078.html
 
 ## Open Source License
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -77,12 +77,19 @@ cd "$_GO_ROOTDIR" || exit 1
 #
 # NOTE:
 # ----
+# Though this variable is exported, _GO_IMPORTED_MODULES is not. This is because
+# bash scripts that are launched in a new process (such as Bats tests) may still
+# use the _GO_USE_MODULES mechanism, but will not share the same set of loaded
+# modules as the parent process.
+declare -r -x _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
+
+# Array of modules imported via _GO_USE_MODULES
+#
+# NOTE:
+# ----
 # This and some other variables are _not_ exported, since they are specific to
 # Bash command scripts, which are sourced into the ./go script process itself.
 # See `./go vars` and `./go help vars`.
-declare -r _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
-
-# Array of modules imported via _GO_USE_MODULES
 declare _GO_IMPORTED_MODULES=()
 
 # Path to the project's script directory

--- a/lib/log
+++ b/lib/log
@@ -33,6 +33,13 @@
 # `@go.log ERROR` will return an error code, so you may use it in conditional
 # statements. `@go.log FATAL` will exit the process.
 #
+# The `_GO_LOG_LEVEL_FILTER` variable sets the minimum priority for logged
+# messages (defaulting to `RUN`), and the `_GO_LOG_CONSOLE_FILTER` variable
+# allows users to set the minimum priority specific to console output without
+# affecting the priority for file output. These variables must be set before `.
+# "$_GO_IMPORT_MODULES" 'log'`, either within a file or on the command line.
+# They cannot be changed once the module is imported.
+#
 # You can pass entire commands to the `@go.log_command` function, which will
 # provide log messages upon startup and completion. Upon error, it will log the
 # status and return an error code, so you may use it in conditional statements.
@@ -53,6 +60,19 @@
 # If left undefined, log messages are not prefixed with timestamps.
 readonly _GO_LOG_TIMESTAMP_FORMAT="$_GO_LOG_TIMESTAMP_FORMAT"
 
+# The lowest level of log messages to send to the console
+#
+# This will override _GO_LOG_LEVEL_FILTER for console outputs, i.e. file
+# descriptors less than 2 or that output to a terminal. The reason for file
+# descriptors less than 2 is to support piping standard output and standard
+# error into another command.
+readonly _GO_LOG_CONSOLE_FILTER="${_GO_LOG_CONSOLE_FILTER}"
+
+# The lowest level of log messages to send to all outputs
+#
+# Overridden by _GO_LOG_CONSOLE_FILTER for console outputs.
+readonly _GO_LOG_LEVEL_FILTER="${_GO_LOG_LEVEL_FILTER:-RUN}"
+
 # Set this if you want to force terminal-formatted output from @go.log.
 #
 # @go.log will remove terminal formatting codes by default when the output file
@@ -67,26 +87,34 @@ readonly _GO_DRY_RUN="$_GO_DRY_RUN"
 
 # Default log level labels
 #
+# These are in priority order. The _GO_LOG_CONSOLE_FILTER and
+# _GO_LOG_LEVEL_FILTER variables determine the lowest-priority messages sent to
+# the console or to all outputs, respectively.
+#
+# FATAL messages are always the highest priority, and will always be emitted.
+#
 # DO NOT UPDATE DIRECTLY: Use @go.add_or_update_log_level instead.
 export _GO_LOG_LEVELS=(
-  'INFO'
+  'DEBUG'
   'RUN'
+  'START'
+  'FINISH'
+  'INFO'
   'WARN'
   'ERROR'
   'FATAL'
-  'START'
-  'FINISH'
 )
 
 # Default log level terminal format codes
 export __GO_LOG_LEVELS_FORMAT_CODES=(
-  '\e[1m\e[36m'
+  '\e[1m\e[30;47m'
   '\e[1m\e[35m'
+  '\e[1m\e[32m'
+  '\e[1m\e[32m'
+  '\e[1m\e[36m'
   '\e[1m\e[33m'
   '\e[1m\e[31m'
   '\e[1m\e[31m'
-  '\e[1m\e[32m'
-  '\e[1m\e[32m'
 )
 
 # Default log level output file descriptors
@@ -96,10 +124,11 @@ export __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
   '1'
   '1'
   '1'
-  '2'
-  '2'
   '1'
   '1'
+  '1'
+  '2'
+  '2'
 )
 
 # DO NOT EDIT: Initialized by @go.log
@@ -180,6 +209,10 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   log_msg="${log_msg} ${args[*]}\\e[0m\\n"
 
   for level_fd in $(_@go.log_level_file_descriptors "$__go_log_level_index"); do
+    if ! _@go.log_level_meets_priority "$__go_log_level_index" "$level_fd"; then
+      continue
+    fi
+
     if [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
       if [[ -z "$unformatted_log_msg" ]]; then
         unformatted_log_msg="${log_msg//\\e\[[0-9]m}"
@@ -445,6 +478,8 @@ _@go.log_init() {
     return
   fi
 
+  readonly __GO_LOG_INIT='done'
+  ((__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS+=2))
   _@go.log_format_level_labels
 
   if [[ -z "$_GO_LOG_TIMESTAMP_FORMAT" ]]; then
@@ -455,11 +490,25 @@ _@go.log_init() {
     readonly __GO_LOG_TIMESTAMP_IMPL='date'
   else
     readonly __GO_LOG_TIMESTAMP_IMPL='none'
-    __GO_LOG_INIT='done' @go.log WARN \
-      Builtin timestamps not supported and date command not found.
+    @go.log WARN Builtin timestamps not supported and date command not found.
   fi
 
-  readonly __GO_LOG_INIT='done'
+  local __go_log_level_index
+  if _@go.log_level_index "$_GO_LOG_LEVEL_FILTER"; then
+    readonly __GO_LOG_PRIORITY="$__go_log_level_index"
+  else
+    @go.log FATAL "Invalid _GO_LOG_LEVEL_FILTER: $_GO_LOG_LEVEL_FILTER"
+  fi
+
+  if [[ -n "$_GO_LOG_CONSOLE_FILTER" ]]; then
+    if _@go.log_level_index "$_GO_LOG_CONSOLE_FILTER"; then
+      readonly __GO_LOG_CONSOLE_PRIORITY="$__go_log_level_index"
+    else
+      @go.log FATAL "Invalid _GO_LOG_CONSOLE_FILTER: $_GO_LOG_CONSOLE_FILTER"
+    fi
+  fi
+
+  ((__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS-=2))
 }
 
 # Assigns formatted log level labels to __GO_LOG_LEVELS_FORMATTED.
@@ -544,6 +593,26 @@ _@go.log_level_index() {
     fi
   done
   return 1
+}
+
+# Checks whether the log message is of sufficient priority to emit
+#
+# Arguments:
+#   level:     A log level index returned from _@go.log_level_index
+#   level_fd:  A file descriptor corresponding to the log level
+# Returns:
+#   zero if the log level is of sufficient priority, nonzero otherwise
+_@go.log_level_meets_priority() {
+  local level="$1"
+  local level_fd="$2"
+  local priority="$__GO_LOG_PRIORITY"
+
+  if [[ ( "$level_fd" -le 2 || -t "$level_fd" ) &&
+        -n "$__GO_LOG_CONSOLE_PRIORITY" ]]; then
+    priority="$__GO_LOG_CONSOLE_PRIORITY"
+  fi
+
+  [[ "$level" -ge "$priority" ]]
 }
 
 # Sanity check that the __GO_LOG arrays are all of the same size

--- a/lib/log
+++ b/lib/log
@@ -106,7 +106,7 @@ export __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
 export __GO_LOG_LEVELS_FORMATTED=()
 
 # Set by @go.critical_section_{begin,end}
-export __GO_CRITICAL_SECTION=0
+export __GO_LOG_CRITICAL_SECTION=0
 
 # DO NOT EDIT: Determines number of stack trace levels to skip for FATAL logs.
 export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
@@ -313,13 +313,13 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 
 # Sets @go.log_command to log FATAL when its command exits with an error status.
 @go.critical_section_begin() {
-  ((++__GO_CRITICAL_SECTION))
+  ((++__GO_LOG_CRITICAL_SECTION))
 }
 
 # Sets @go.log_command to log ERROR when its command exits with an error status.
 @go.critical_section_end() {
-  if [[ "$__GO_CRITICAL_SECTION" -ne '0' ]]; then
-    ((--__GO_CRITICAL_SECTION))
+  if [[ "$__GO_LOG_CRITICAL_SECTION" -ne '0' ]]; then
+    ((--__GO_LOG_CRITICAL_SECTION))
     return 0
   fi
 }
@@ -337,8 +337,8 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 # scripts.
 #
 # Globals:
-#   _GO_DRY_RUN:           Will log commands without running them
-#   __GO_CRITICAL_SECTION: Will log FATAL on error
+#   _GO_DRY_RUN:                 Will log commands without running them
+#   __GO_LOG_CRITICAL_SECTION:   Will log FATAL on error
 #
 # Arguments:
 #   $@: The command and its arguments to log and execute
@@ -360,7 +360,7 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   exit_status="$?"
 
   if [[ "$exit_status" -ne '0' ]]; then
-    if [[ "$__GO_CRITICAL_SECTION" -ne '0' ]]; then
+    if [[ "$__GO_LOG_CRITICAL_SECTION" -ne '0' ]]; then
       ((++__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS))
       @go.log FATAL "$exit_status" "$cmd_string"
     fi

--- a/lib/log
+++ b/lib/log
@@ -94,7 +94,8 @@ readonly _GO_DRY_RUN="$_GO_DRY_RUN"
 # FATAL messages are always the highest priority, and will always be emitted.
 #
 # DO NOT UPDATE DIRECTLY: Use @go.add_or_update_log_level instead.
-export _GO_LOG_LEVELS=(
+export _GO_LOG_LEVELS
+_GO_LOG_LEVELS=(
   'DEBUG'
   'RUN'
   'START'
@@ -106,7 +107,8 @@ export _GO_LOG_LEVELS=(
 )
 
 # Default log level terminal format codes
-export __GO_LOG_LEVELS_FORMAT_CODES=(
+export __GO_LOG_LEVELS_FORMAT_CODES
+__GO_LOG_LEVELS_FORMAT_CODES=(
   '\e[1m\e[30;47m'
   '\e[1m\e[35m'
   '\e[1m\e[32m'
@@ -120,7 +122,8 @@ export __GO_LOG_LEVELS_FORMAT_CODES=(
 # Default log level output file descriptors
 #
 # '1' is standard output and '2' is standard error.
-export __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
+export __GO_LOG_LEVELS_FILE_DESCRIPTORS
+__GO_LOG_LEVELS_FILE_DESCRIPTORS=(
   '1'
   '1'
   '1'
@@ -132,7 +135,8 @@ export __GO_LOG_LEVELS_FILE_DESCRIPTORS=(
 )
 
 # DO NOT EDIT: Initialized by @go.log
-export __GO_LOG_LEVELS_FORMATTED=()
+export __GO_LOG_LEVELS_FORMATTED
+__GO_LOG_LEVELS_FORMATTED=()
 
 # Set by @go.critical_section_{begin,end}
 export __GO_LOG_CRITICAL_SECTION=0

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -16,6 +16,11 @@ COLUMNS=1000
 # function.
 unset -v _GO_CMD
 
+# Clear all user-definable `readonly` variables (and potentially user-definable
+# `export` variables) module variables to avoid interference with test
+# conditions.
+unset -v _GO_MAX_FILE_DESCRIPTORS "${!_GO_LOG@}" "${!__GO_LOG@}"
+
 # TEST_GO_ROOTDIR contains a space to help ensure that variables are quoted
 # properly in most places.
 readonly TEST_GO_ROOTDIR="$BATS_TEST_ROOTDIR"

--- a/tests/log/filters.bats
+++ b/tests/log/filters.bats
@@ -1,0 +1,116 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+run_log_script_and_assert_success() {
+  set +o functrace
+  local result=0
+
+  run_log_script "$@" \
+    '@go.log DEBUG  debug 0' \
+    '@go.log START  testing filter' \
+    '@go.log DEBUG  debug 1' \
+    '@go.log RUN    echo Hello, World!' \
+    '@go.log INFO   Hello, World!' \
+    '@go.log DEBUG  debug 2' \
+    '@go.log FINISH testing filter' \
+    '@go.log DEBUG  debug 3' \
+    '@go.log INFO   Goodbye, World!'
+
+  if ! assert_success; then
+    result=1
+  fi
+  set +o functrace
+  return_from_bats_assertion "$BASH_SOURCE" "$result"
+}
+
+@test "$SUITE: default _GO_LOG_LEVEL_FILTER is RUN" {
+  run_log_script_and_assert_success
+  assert_log_equals \
+    START  'testing filter' \
+    RUN    'echo Hello, World!' \
+    INFO   'Hello, World!' \
+    FINISH 'testing filter' \
+    INFO   'Goodbye, World!'
+}
+
+@test "$SUITE: set _GO_LOG_LEVEL_FILTER to DEBUG" {
+  _GO_LOG_LEVEL_FILTER='DEBUG' run_log_script_and_assert_success
+  assert_log_equals \
+    DEBUG  'debug 0' \
+    START  'testing filter' \
+    DEBUG  'debug 1' \
+    RUN    'echo Hello, World!' \
+    INFO   'Hello, World!' \
+    DEBUG  'debug 2' \
+    FINISH 'testing filter' \
+    DEBUG  'debug 3' \
+    INFO   'Goodbye, World!'
+}
+
+@test "$SUITE: set _GO_LOG_LEVEL_FILTER to INFO" {
+  _GO_LOG_LEVEL_FILTER='INFO' run_log_script_and_assert_success
+  assert_log_equals \
+    INFO   'Hello, World!' \
+    INFO   'Goodbye, World!'
+}
+
+@test "$SUITE: error if _GO_LOG_LEVEL_FILTER doesn't match a valid level" {
+  _GO_LOG_LEVEL_FILTER='FOOBAR' run_log_script '@go.log FOOBAR fubarred'
+  assert_failure
+  assert_log_equals \
+    FATAL 'Invalid _GO_LOG_LEVEL_FILTER: FOOBAR' \
+    "  $TEST_GO_SCRIPT:4 main"
+}
+
+@test "$SUITE: error if _GO_LOG_CONSOLE_FILTER doesn't match a valid level" {
+  _GO_LOG_CONSOLE_FILTER='FOOBAR' run_log_script '@go.log FOOBAR fubarred'
+  assert_failure
+  assert_log_equals \
+    FATAL 'Invalid _GO_LOG_CONSOLE_FILTER: FOOBAR' \
+    "  $TEST_GO_SCRIPT:4 main"
+}
+
+@test "$SUITE: _GO_LOG_CONSOLE_FILTER lower priority override" {
+  _GO_LOG_CONSOLE_FILTER='DEBUG' run_log_script_and_assert_success \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log'"
+
+  assert_log_equals \
+    DEBUG  'debug 0' \
+    START  'testing filter' \
+    DEBUG  'debug 1' \
+    RUN    'echo Hello, World!' \
+    INFO   'Hello, World!' \
+    DEBUG  'debug 2' \
+    FINISH 'testing filter' \
+    DEBUG  'debug 3' \
+    INFO   'Goodbye, World!'
+
+  assert_log_file_equals "$TEST_GO_ROOTDIR/info.log" \
+    START  'testing filter' \
+    RUN    'echo Hello, World!' \
+    INFO   'Hello, World!' \
+    FINISH 'testing filter' \
+    INFO   'Goodbye, World!'
+}
+
+@test "$SUITE: _GO_LOG_CONSOLE_FILTER higher priority override" {
+  _GO_LOG_CONSOLE_FILTER='INFO' run_log_script_and_assert_success \
+    "@go.log_add_output_file '$TEST_GO_ROOTDIR/info.log'"
+
+  assert_log_equals \
+    INFO   'Hello, World!' \
+    INFO   'Goodbye, World!'
+
+  assert_log_file_equals "$TEST_GO_ROOTDIR/info.log" \
+    START  'testing filter' \
+    RUN    'echo Hello, World!' \
+    INFO   'Hello, World!' \
+    FINISH 'testing filter' \
+    INFO   'Goodbye, World!'
+}

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -43,7 +43,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
-    "declare -r _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
+    "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
   assert_lines_equal "${expected[@]}"
@@ -86,7 +86,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
-    "declare -r _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
+    "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
   assert_lines_equal "${expected[@]}"
@@ -116,5 +116,6 @@ quotify_expected() {
     "_GO_CORE_URL: $_GO_CORE_URL" \
     "_GO_CORE_VERSION: $_GO_CORE_VERSION" \
     "_GO_ROOTDIR: $TEST_GO_ROOTDIR" \
-    "_GO_SCRIPT: $TEST_GO_SCRIPT"
+    "_GO_SCRIPT: $TEST_GO_SCRIPT" \
+    "_GO_USE_MODULES: $_GO_USE_MODULES"
 }


### PR DESCRIPTION
Closes #36.

Now the log levels are ordered by priority within `_GO_LOG_LEVELS`, with a new `DEBUG` level at the lowest priority. Some existing levels have been rearranged as well.

The `_GO_LOG_LEVEL_FILTER` variable sets the minimum priority for logged messages (defaulting to `RUN`), and the `_GO_LOG_CONSOLE_FILTER` variable allows users to set the minimum priority specific to console output without affecting the priority for file output.

These variables must be set before `. "$_GO_IMPORT_MODULES" 'log'`, either within a file or on the command line. They cannot be changed once the module is imported.

That's just commit b764e8913601b5aaa53005c2e2b7454a72e45273. All of the other commits are test helper fixes and improvements, and a Bash bug workaround.

