### PR TITLE
Fix `%` characters in log messages, minor refactoring

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -207,10 +207,10 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
     fi
   fi
 
-  # Remove leading space if the timestamp is empty.
   log_msg="$(@go.log_timestamp) "
+  # Remove leading space if the timestamp is empty.
   log_msg="${log_msg# }${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]}"
-  log_msg="${log_msg} ${args[*]}\\e[0m\\n"
+  log_msg="${log_msg} ${args[*]}\\e[0m"
 
   local __go_log_level_file_descriptors=()
   _@go.log_level_file_descriptors "$__go_log_level_index"
@@ -226,9 +226,9 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
         unformatted_log_msg="${unformatted_log_msg//\\e\[[0-9][0-9]m}"
         unformatted_log_msg="${unformatted_log_msg//\\e\[[0-9][0-9][0-9]m}"
       fi
-      printf "$unformatted_log_msg" >&"$level_fd"
+      printf '%b\n' "$unformatted_log_msg" >&"$level_fd"
     else
-      printf "$log_msg" >&"$level_fd"
+      printf '%b\n' "$log_msg" >&"$level_fd"
     fi
 
     if [[ "$log_level" == 'FATAL' ]]; then

--- a/lib/log
+++ b/lib/log
@@ -212,7 +212,10 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   log_msg="${log_msg# }${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]}"
   log_msg="${log_msg} ${args[*]}\\e[0m\\n"
 
-  for level_fd in $(_@go.log_level_file_descriptors "$__go_log_level_index"); do
+  local __go_log_level_file_descriptors=()
+  _@go.log_level_file_descriptors "$__go_log_level_index"
+
+  for level_fd in "${__go_log_level_file_descriptors[@]}"; do
     if ! _@go.log_level_meets_priority "$__go_log_level_index" "$level_fd"; then
       continue
     fi
@@ -557,7 +560,10 @@ _@go.log_format_level_labels() {
     log_level="${_GO_LOG_LEVELS[$i]}"
     padding_len="$((${#padding} - ${#log_level}))"
 
-    for level_fd in $(_@go.log_level_file_descriptors "$i"); do
+    local __go_log_level_file_descriptors=()
+    _@go.log_level_file_descriptors "$i"
+
+    for level_fd in "${__go_log_level_file_descriptors[@]}"; do
       if [[ -n "$_GO_LOG_FORMATTING" || -t "$level_fd" ]]; then
         log_level="${__GO_LOG_LEVELS_FORMAT_CODES[$i]}$log_level\e[0m"
         break
@@ -569,11 +575,14 @@ _@go.log_format_level_labels() {
 
 # Returns the set of file descriptors for the specified log level index.
 #
+# Globals:
+#   __go_log_level_file_descriptors:  Variable into which fds will be stored
+#
 # Arguments:
-#   index:  A log level index returned from _@go.log_level_index
+#   log_level_index:  A log level index returned from _@go.log_level_index
 _@go.log_level_file_descriptors() {
   local IFS=','
-  echo ${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$1]}
+  __go_log_level_file_descriptors=(${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$1]})
 }
 
 # Sets the index into the __GO_LOG arrays for the specified label

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -46,10 +46,10 @@ __expected_log_line() {
     stripped_level="${stripped_level//\\e\[[0-9][0-9]m}"
     stripped_level="${stripped_level//\\e\[[0-9][0-9][0-9]m}"
     level="${level}${padding:0:$((${#padding} - ${#stripped_level}))}"
-    printf "$level $message\e[0m\n"
+    printf '%b\n' "$level $message\e[0m"
   else
     level="${level}${padding:0:$((${#padding} - ${#level}))}"
-    echo "$level $message"
+    printf '%b\n' "$level $message"
   fi
 }
 

--- a/tests/log/main.bats
+++ b/tests/log/main.bats
@@ -13,10 +13,30 @@ teardown() {
   assert_log_equals INFO 'Hello, World!'
 }
 
-@test "$SUITE: log INFO with formatting" {
-  _GO_LOG_FORMATTING='true' run_log_script '@go.log INFO Hello, World!'
+@test "$SUITE: log INFO with formatting and proper termination at end of line" {
+  _GO_LOG_FORMATTING='true' run_log_script \
+    '@go.log INFO "\e[1m\e[36mHello, World!"' \
+    'echo Goodbye, World!'
   assert_success
-  assert_log_equals "$(format_label INFO)" 'Hello, World!'
+  assert_log_equals \
+    "$(format_label INFO)" '\e[1m\e[36mHello, World!' \
+    'Goodbye, World!'
+}
+
+@test "$SUITE: log INFO with message formatting stripped" {
+  run_log_script \
+    '@go.log INFO "\e[1m\e[36mHello, World!"' \
+    'echo Goodbye, World!'
+  assert_success
+  assert_log_equals \
+    INFO 'Hello, World!' \
+    'Goodbye, World!'
+}
+
+@test "$SUITE: log INFO handle '%' in message arguments (issues 47, 55)" {
+  run_log_script '@go.log INFO Timestamp is "%Y-%m-%d %H:%M:%S"'
+  assert_success
+  assert_log_equals INFO 'Timestamp is %Y-%m-%d %H:%M:%S'
 }
 
 @test "$SUITE: log WARN and return error if log level is unknown" {


### PR DESCRIPTION
Closes #47 and closes #55. Previously these were interpreted by `printf` as format specifiers. The fix is to use `'%b\n'` as the format specifier, rather than passing the log message as the only argument to `printf`.

Also includes a test to ensure that messages containing formatting characters are properly terminated at the end of the log line, and a refactoring of the internal-only API to `_@go.log_level_file_descriptors` to return a value via a variable rather than standard output.