### PR TITLE
Updates to log test helpers

### DIFF
--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -128,3 +128,10 @@ set_go_core_stack_trace_components() {
     export GO_CORE_STACK_TRACE_COMPONENTS
   fi
 }
+
+# Prints the number of lines in `TEST_GO_SCRIPT`.
+num_test_script_lines() {
+  IFS=$'\n'
+  local test_script=($(< "$TEST_GO_SCRIPT"))
+  echo "${#test_script[@]}"
+}

--- a/tests/log/add-output-file.bats
+++ b/tests/log/add-output-file.bats
@@ -3,8 +3,6 @@
 load ../environment
 load helpers
 
-TEST_SCRIPT_LINES=
-
 teardown() {
   remove_test_go_rootdir
 }
@@ -26,14 +24,12 @@ run_log_script_and_assert_status_and_output() {
     return
   fi
 
-  TEST_SCRIPT_LINES="$(num_test_script_lines)"
-
   local expected=(INFO 'FYI'
     RUN   'echo foo'
     WARN  'watch out'
     ERROR 'uh-oh'
     FATAL 'oh noes!'
-    "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main")
+    "$(test_script_stack_trace_item)")
 
   if ! assert_log_equals "${expected[@]}"; then
     set +o functrace
@@ -90,7 +86,7 @@ run_log_script_and_assert_status_and_output() {
   assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
   assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'
   assert_matches '^FATAL +oh noes!$' "${error_log[1]}" 'FATAL log message'
-  assert_equal "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main" "${error_log[2]}" \
+  assert_equal "$(test_script_stack_trace_item)" "${error_log[2]}" \
     'FATAL stack trace'
 }
 
@@ -116,6 +112,6 @@ run_log_script_and_assert_status_and_output() {
   assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
   assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'
   assert_matches '^FATAL +oh noes!$' "${error_log[1]}" 'FATAL log message'
-  assert_equal "  $TEST_GO_SCRIPT:$TEST_SCRIPT_LINES main" "${error_log[2]}" \
+  assert_equal "$(test_script_stack_trace_item)" "${error_log[2]}" \
     'FATAL stack trace'
 }

--- a/tests/log/add-output-file.bats
+++ b/tests/log/add-output-file.bats
@@ -26,11 +26,7 @@ run_log_script_and_assert_status_and_output() {
     return
   fi
 
-  local origIFS="$IFS"
-  IFS=$'\n'
-  local test_script=($(< "$TEST_GO_SCRIPT"))
-  IFS="$origIFS"
-  TEST_SCRIPT_LINES="${#test_script[@]}"
+  TEST_SCRIPT_LINES="$(num_test_script_lines)"
 
   local expected=(INFO 'FYI'
     RUN   'echo foo'

--- a/tests/log/add-update.bats
+++ b/tests/log/add-update.bats
@@ -16,21 +16,21 @@ teardown() {
   assert_failure
   assert_log_equals INFO 'Hello, World!' \
     FATAL "Can't set logging level INFO; already initialized" \
-    "  $TEST_GO_SCRIPT:5 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: fail if file descriptor isn't a positive integer" {
   run_log_script '@go.add_or_update_log_level INFO keep 0'
   assert_failure
   assert_log_equals FATAL "File descriptor 0 for INFO must be > 0" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: fail if file descriptor isn't open" {
   run_log_script '@go.add_or_update_log_level INFO keep 27'
   assert_failure
   assert_log_equals FATAL "File descriptor 27 for INFO isn't open" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: fail if keeping the format code for a nonexistent level" {
@@ -38,7 +38,7 @@ teardown() {
   assert_failure
   assert_log_equals \
     FATAL "Can't keep defaults for nonexistent log level FOOBAR" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: fail if keeping the file descriptor for a nonexistent level" {
@@ -46,7 +46,7 @@ teardown() {
   assert_failure
   assert_log_equals \
     FATAL "Can't keep defaults for nonexistent log level FOOBAR" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: add new log level" {

--- a/tests/log/filters.bats
+++ b/tests/log/filters.bats
@@ -65,7 +65,7 @@ run_log_script_and_assert_success() {
   assert_failure
   assert_log_equals \
     FATAL 'Invalid _GO_LOG_LEVEL_FILTER: FOOBAR' \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: error if _GO_LOG_CONSOLE_FILTER doesn't match a valid level" {
@@ -73,7 +73,7 @@ run_log_script_and_assert_success() {
   assert_failure
   assert_log_equals \
     FATAL 'Invalid _GO_LOG_CONSOLE_FILTER: FOOBAR' \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: _GO_LOG_CONSOLE_FILTER lower priority override" {

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -3,7 +3,12 @@
 # Helper functions for `lib/log` tests.
 
 run_log_script() {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" "$@"
+  create_test_go_script \
+    ". \"\$_GO_USE_MODULES\" 'log'" \
+    'if [[ -n "$TEST_LOG_FILE" ]]; then' \
+    '  @go.log_add_output_file "$TEST_LOG_FILE"' \
+    'fi' \
+    "$@"
   run "$TEST_GO_SCRIPT"
 }
 

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -30,7 +30,7 @@ teardown() {
   assert_failure
   assert_log_equals RUN 'failing_function foo bar baz' \
     FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPT:6 main"
+    "$(test_script_stack_trace_item 1)"
 }
 
 @test "$SUITE: log single failing command without executing during dry run" {
@@ -81,7 +81,7 @@ teardown() {
     'Hello, World!' \
     RUN "failing_function foo bar baz" \
     FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPT:7 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: log multiple commands without executing during dry run" {
@@ -182,7 +182,7 @@ teardown() {
     'Hello, World!' \
     RUN 'failing_function foo bar baz' \
     FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPT:12 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: critical section counter does not go below zero" {
@@ -204,7 +204,7 @@ teardown() {
     ERROR 'failing_function foo bar baz (exit status 127)' \
     RUN 'failing_function foo bar baz' \
     FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPT:12 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: log and run command script using @go" {
@@ -239,7 +239,7 @@ teardown() {
     "  $TEST_GO_SCRIPTS_DIR/project-command-script:3 source" \
     "${GO_CORE_STACK_TRACE_COMPONENTS[@]}" \
     "$(log_command_stack_trace_item)" \
-    "  $TEST_GO_SCRIPT:5 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: critical section in command script applies to parent script" {
@@ -262,5 +262,5 @@ teardown() {
     "  $TEST_GO_SCRIPTS_DIR/project-command-script:4 source" \
     "${GO_CORE_STACK_TRACE_COMPONENTS[@]}" \
     "$(log_command_stack_trace_item)" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item 1)"
 }

--- a/tests/log/main.bats
+++ b/tests/log/main.bats
@@ -73,7 +73,7 @@ teardown() {
     'fi'
   assert_failure
   assert_log_equals FATAL 'Hello, World!' \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: show status on FATAL if supplied" {
@@ -83,7 +83,7 @@ teardown() {
     'fi'
   assert_failure
   assert_log_equals FATAL 'Hello, World! (exit status 127)' \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item 2)"
 }
 
 @test "$SUITE: exit with error if num format codes != num log levels" {

--- a/tests/log/setup-project.bats
+++ b/tests/log/setup-project.bats
@@ -14,7 +14,7 @@ teardown() {
   local setup_script="$TEST_GO_SCRIPTS_DIR/setup"
   assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
     FATAL "Create $setup_script before invoking @go.setup_project." \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: fail if the 'setup' script isn't executable" {
@@ -29,7 +29,7 @@ teardown() {
   assert_failure
   assert_log_equals START "Project setup in $TEST_GO_ROOTDIR" \
     FATAL "$TEST_GO_SCRIPTS_DIR/setup is not executable." \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: setup project successfully using ./go script directly" {
@@ -73,7 +73,7 @@ teardown() {
     RUN    "${TEST_GO_SCRIPTS_RELATIVE_DIR}/setup foo bar baz" \
     ERROR  'foo bar baz (exit status 127)' \
     FATAL  'Project setup failed (exit status 127)' \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }
 
 @test "$SUITE: Bash setup script exits directly due to @go.log FATAL" {
@@ -97,5 +97,5 @@ teardown() {
     "  $TEST_GO_SCRIPTS_DIR/setup:2 source" \
     "$run_command_script_stack_trace_item" \
     "$setup_project_stack_trace_item" \
-    "  $TEST_GO_SCRIPT:4 main"
+    "$(test_script_stack_trace_item)"
 }

--- a/tests/stack-trace-item
+++ b/tests/stack-trace-item
@@ -5,8 +5,8 @@
 __stack_trace_item() {
   local haystack_file="$1"
   local function_name="$2"
-  local function_pattern="^$function_name\\(\\) ?{\$"
-  local needle="$3"
+  local function_opening="$function_name() {"
+  local needle="${3:-$function_opening}"
   local skip
   local inside_function
   local lineno=0
@@ -27,7 +27,11 @@ __stack_trace_item() {
       if [[ "$line" == '}' ]]; then
         skip=
       fi
-    elif [[ -z "$inside_function" && "$line" =~ $function_pattern ]]; then
+    elif [[ -z "$inside_function" && "$line" == $function_opening ]]; then
+      if [[ "$line" == "$needle" ]]; then
+        echo "  $haystack_file:$lineno $function_name"
+        return
+      fi
       inside_function='true'
     elif [[ "$line" =~ ()\ {$ ]]; then
       skip='true'


### PR DESCRIPTION
Updating `@go.log_command` to capture command output per #53 turned out to be more subtle and complex than anticipated. In the process, I extracted, refactored, and enhanced a few log test helper functions. Rather than clutter the PR that will contain the implementation of #53 with all these updates, I'm merging them now.

Eventually I'll have to properly test and package these utilities, so others who may want to write logging-focused tests can use them.