### PR TITLE
Prevent `@go.log_add_output_file` after init

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -330,6 +330,11 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   local level
   local __go_log_level_index
 
+  if [[ -n "$__GO_LOG_INIT" ]]; then
+    @go.log FATAL "Can't add new output file $output_file;" \
+      "logging already initialized"
+  fi
+
   . "$_GO_USE_MODULES" 'file'
   @go.open_file_or_duplicate_fd "$output_file" 'a' 'output_fd'
 

--- a/tests/log/add-output-file.bats
+++ b/tests/log/add-output-file.bats
@@ -39,6 +39,21 @@ run_log_script_and_assert_status_and_output() {
   fi
 }
 
+@test "$SUITE: exit if adding output file after logging already initiaized" {
+  local log_file="$TEST_GO_ROOTDIR/all.log"
+
+  run_log_script \
+    "@go.log INFO Hello, World!" \
+    "@go.log_add_output_file '$log_file'"
+  assert_failure
+  assert_log_equals \
+    INFO 'Hello, World!' \
+    FATAL "Can't add new output file $log_file; logging already initialized" \
+    "$(stack_trace_item "$_GO_CORE_DIR/lib/log" '@go.log_add_output_file' \
+      "    @go.log FATAL \"Can't add new output file \$output_file;\" \\")" \
+    "$(test_script_stack_trace_item)"
+}
+
 @test "$SUITE: add an output file for all log levels" {
   run_log_script_and_assert_status_and_output \
     "@go.log_add_output_file '$TEST_GO_ROOTDIR/all.log'"


### PR DESCRIPTION
Though this wouldn't really create any problems when adding a file for a new level, for consistency's sake, it seems best to ensure this fails just like `@go.add_or_update_log_level` when called after the first `@go.log` call.