### PR TITLE
Add demo-core command, log subcommand

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -53,6 +53,8 @@
 # script, and provides helpful hints on running the `./go` script upon success.
 #
 # See the function and variable comments from this file for further information.
+# Try the `{{go}} demo-core log` command to get a feel for the mechanisms
+# described above.
 
 # A strftime-compatible date/time format string used to prefix log messages with
 # a timestamp. E.g.: '%Y-%m-%d %H:%M:%S'

--- a/libexec/demo-core
+++ b/libexec/demo-core
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+#
+# Demo programs for core framework features
+#
+# Provides an interface to demonstration programs, while itself demonstrating
+# the subcommand architecture and the `subcommands` module of the framework.
+#
+# Note that the subcommands are stored in a directory with the same name as this
+# script, but with `.d` appended. The framework knows how to discover the
+# subcommands, execute them, and include them in the parent command's help text.
+
+. "$_GO_USE_MODULES" 'subcommands'
+
+@go.show_subcommands

--- a/libexec/demo-core.d/log
+++ b/libexec/demo-core.d/log
@@ -1,0 +1,107 @@
+#! /usr/bin/env bash
+#
+# Demonstration of `@go.log` capabilities
+#
+# Usage:
+#   [<env-var=VALUE>...] {{go}} {{cmd}} [-v|--verbose]...
+#
+# Where:
+#   <env-var=VALUE>  assignments to variables from `log` module or this script
+#   -v,--verbose     print arguments and variable values at beginning of demo
+#
+# This will repeat the args given on the command line, one per second at each
+# successive log level, until the `FATAL` log level is reached.
+#
+# Use this program to get a feel for how the `@go.log` function will work in
+# your application. Prefix the command line with variables from the 'log'
+# module to get a feel for how they influence the output; these variables can be
+# set in your main `./go` script to provide a uniform logging format across your
+# command scripts.
+#
+# Prefix the command line with the following variables specific to this command
+# for various effects:
+#
+#   `_GO_LOG_DEMO_DELAY`        number of seconds between each log message
+#   `_GO_LOG_DEMO_FILE`         append messages to a file in addition to
+#                                 standard output/error
+#   `_GO_LOG_DEMO_EXIT_STATUS`  exit status to use with `ERROR` and `FATAL`
+#                                 levels
+#
+# For the `RUN` log level, the `@go.log_command` will execute `echo` on the
+# command line arguments, unless `_GO_DRY_RUN` is set.
+#
+# Because this command calls `@go.log FATAL`, it will exit with an error status
+# by default. If `_GO_LOG_DEMO_EXIT_STATUS` is set, it will exit with that
+# status instead.
+#
+# As an example, start with the following command line, and edit it in various
+# ways to achieve different effects:
+#
+#   _GO_LOG_DEMO_DELAY=2 \
+#   _GO_LOG_DEMO_FILE='demo.log' \
+#   _GO_LOG_DEMO_EXIT_STATUS='127' \
+#   _GO_LOG_LEVEL_FILTER='DEBUG' \
+#   _GO_LOG_TIMESTAMP_FORMAT='%Y-%m-%d %H:%M:%S' \
+#   _GO_LOG_FORMATTING='true' \
+#   _GO_DRY_RUN='true' \
+#   {{go}} {{cmd}} This is my log message! 2>&1 | cat
+
+readonly _GO_LOG_DEMO_DELAY="${_GO_LOG_DEMO_DELAY:-1}"
+readonly _GO_LOG_DEMO_FILE="$_GO_LOG_DEMO_FILE"
+readonly _GO_LOG_DEMO_EXIT_STATUS="$_GO_LOG_DEMO_EXIT_STATUS"
+
+log_demo_print_environment() {
+  @go.printf "Demonstrating @go.log with message arguments:\n  %s\n\n" "$*"
+  @go.printf "and environment variable settings:\n"
+  declare -p '_GO_DRY_RUN' "${!_GO_LOG_@}"
+  echo
+}
+
+log_demo() {
+  local level
+  local log_args=('Hello,' 'World!')
+  local print_env
+
+  if [[ "$1" == '--complete' ]]; then
+    # Tab completions
+    if [[ "$2" -eq 0 ]]; then
+      echo "-v --verbose"
+    fi
+    return
+  fi
+
+  . "$_GO_USE_MODULES" 'log'
+
+  if [[ "$1" =~ ^-v|--verbose$ ]]; then
+    shift
+    print_env='true'
+  fi
+
+  if [[ "$#" -ne '0' ]]; then
+    log_args=("$@")
+  else
+    printf 'Using default log message "%s"; %s\n' \
+      "${log_args[*]}" 'you may supply your own on the command line.'
+  fi
+
+  if [[ -n "$print_env" ]]; then
+    log_demo_print_environment "${log_args[@]}"
+  fi
+
+  if [[ -n "$_GO_LOG_DEMO_FILE" ]]; then
+    @go.log_add_output_file "$_GO_LOG_DEMO_FILE"
+  fi
+
+  for level in "${_GO_LOG_LEVELS[@]}"; do
+    if [[ "$level" == 'RUN' ]]; then
+      @go.log_command echo "${log_args[@]}"
+    elif [[ "$level" =~ ERROR|FATAL && -n "$_GO_LOG_DEMO_EXIT_STATUS" ]]; then
+      @go.log "$level" "$_GO_LOG_DEMO_EXIT_STATUS" "${log_args[@]}"
+    else
+      @go.log "$level" "${log_args[@]}"
+    fi
+    sleep "$_GO_LOG_DEMO_DELAY"
+  done
+}
+
+log_demo "$@"

--- a/tests/demo-core.bats
+++ b/tests/demo-core.bats
@@ -1,0 +1,14 @@
+#! /usr/bin/env bats
+
+load environment
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: show available demo subcommands" {
+  create_test_go_script '@go "$@"'
+  run "$TEST_GO_SCRIPT" demo-core
+  assert_success
+  assert_line_equals 0 'Available subcommands of "demo-core" are:'
+}

--- a/tests/demo-core/log.bats
+++ b/tests/demo-core/log.bats
@@ -1,0 +1,99 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  create_test_go_script '@go "$@"'
+  export _GO_LOG_DEMO_DELAY='0'
+}
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: tab completion" {
+  run "$TEST_GO_SCRIPT" demo-core log --complete
+  assert_success '-v --verbose'
+
+  run "$TEST_GO_SCRIPT" demo-core log --complete 1
+  assert_success ''
+}
+
+@test "$SUITE: default output" {
+  run "$TEST_GO_SCRIPT" demo-core log
+  assert_status '1'
+
+  local first_line='Using default log message "Hello, World!"; '
+  first_line+='you may supply your own on the command line.'
+
+  assert_line_equals 0 "$first_line"
+  assert_output_matches $'\nRUN +echo Hello, World!\nHello, World!\n'
+  assert_output_matches $'\nINFO +Hello, World!\n'
+  assert_output_matches $'\nFATAL +Hello, World!\n'
+
+  set_go_core_stack_trace_components
+  local stack_trace_pattern=(''
+    "  $_GO_CORE_DIR/libexec/demo-core.d/log:[0-9]+ log_demo"
+    "  $_GO_CORE_DIR/libexec/demo-core.d/log:[0-9]+ source"
+    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}"
+    "  $TEST_GO_SCRIPT:[0-9] main")
+
+  local IFS=$'\n'
+  assert_output_matches "${stack_trace_pattern[*]}"
+}
+
+@test "$SUITE: verbose output" {
+  run "$TEST_GO_SCRIPT" demo-core log -v
+  assert_status '1'
+
+  local first_line='Using default log message "Hello, World!"; '
+  first_line+='you may supply your own on the command line.'
+
+  local verbose_pattern=$'\nDemonstrating @go\.log with message arguments:\n'
+  verbose_pattern+=$'  Hello, World!\n\nand environment variable settings:\n'
+
+  assert_line_equals 0 "$first_line"
+  assert_output_matches "$verbose_pattern"
+  assert_output_matches "declare -ax _GO_LOG_LEVELS="
+  assert_output_matches $'\nINFO +Hello, World!\n'
+
+  local orig_output="$output"
+  run "$TEST_GO_SCRIPT" demo-core log --verbose
+  assert_equal "$orig_output" "$output" 'output from --verbose run'
+}
+
+@test "$SUITE: command line log message" {
+  run "$TEST_GO_SCRIPT" demo-core log Goodbye, World!
+  assert_status '1'
+  fail_if line_matches 0 'Using default log message'
+  assert_output_matches $'^RUN +echo Goodbye, World!\nGoodbye, World!\n'
+}
+
+@test "$SUITE: set exit status" {
+  _GO_LOG_DEMO_EXIT_STATUS='127' run "$TEST_GO_SCRIPT" demo-core log
+  assert_status '127'
+  assert_output_matches $'\nERROR +Hello, World! \(exit status 127\)\n'
+  assert_output_matches $'\nFATAL +Hello, World! \(exit status 127\)\n'
+}
+
+@test "$SUITE: set log file" {
+  local log_file="$TEST_GO_ROOTDIR/demo.log"
+  rm -f "$log_file"
+
+  # Setting the message on the command line eliminates the "Using default log
+  # message" line printed only to standard output, so the console and file
+  # output should be identical.
+  _GO_LOG_DEMO_FILE="$log_file" run "$TEST_GO_SCRIPT" demo-core log foo bar baz
+  assert_status '1'
+  assert_output_matches $'\nINFO +foo bar baz\n'
+
+  # Hmm, this could become "split_bats_output_into_lines". Filed #92.
+  local console_output=()
+  local line
+
+  while IFS= read -r line; do
+    console_output+=("${line%$'\r'}")
+  done <<<"$output"
+
+  assert_file_equals "$log_file" "${console_output[@]}"
+}

--- a/tests/path/list-available-commands.bats
+++ b/tests/path/list-available-commands.bats
@@ -15,8 +15,14 @@ teardown() {
 @test "$SUITE: list available commands" {
   # Since we aren't creating any new commands, and _@go.find_commands is already
   # thoroughly tested in isolation, we only check that builtins are available.
-  local expected=("$_GO_ROOTDIR"/libexec/*)
-  expected=("${expected[@]##*/}")
+  local builtin_cmd
+  local expected=()
+
+  for builtin_cmd in "$_GO_ROOTDIR"/libexec/*; do
+    if [[ -f "$builtin_cmd" && -x "$builtin_cmd" ]]; then
+      expected+=("${builtin_cmd[@]##*/}")
+    fi
+  done
 
   run "$TEST_GO_SCRIPT" "$_GO_ROOTDIR/libexec"
   assert_success


### PR DESCRIPTION
Per #57 and #58, seems like another useful method for documenting the logging features. May prove a useful model for documenting module and command features in general, by providing an easy way to experiment with parameters on the command line.

Though I'm creating the PR with a working implementation, I still need to move `scripts/demo` to `libexec/demo-core` to make it a builtin. That way, the hope would be that framework users will discover and reproduce the `./go demo` functionality in their own plugins and applications.

I also still need to add tests. All of this will be done before merging.