### PR TITLE
Ensure `@go.log_command` output writes to fds

### DIFF
--- a/lib/log
+++ b/lib/log
@@ -139,10 +139,23 @@ export __GO_LOG_LEVELS_FORMATTED
 __GO_LOG_LEVELS_FORMATTED=()
 
 # Set by @go.critical_section_{begin,end}
-export __GO_LOG_CRITICAL_SECTION=0
+export __GO_LOG_CRITICAL_SECTION="${__GO_LOG_CRITICAL_SECTION:-0}"
 
 # DO NOT EDIT: Determines number of stack trace levels to skip for FATAL logs.
 export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
+
+# DO NOT EDIT: Used by `@go.log FATAL` to emit exit info when running a command
+# under `@go.log_command` and by `_@go.log_command_should_skip_file_descriptor`
+# to determine when to skip emitting a log message.
+export __GO_LOG_COMMAND_DEPTH="${__GO_LOG_COMMAND_DEPTH:-0}"
+
+# DO NOT EDIT: Every index corresponds to a descriptor for which
+# `_@go.log_command_should_skip_file_descriptor` should return true.
+export __GO_LOG_COMMAND_SKIP_FILE_DESCRIPTORS
+__GO_LOG_COMMAND_SKIP_FILE_DESCRIPTORS=()
+
+# Pattern `@go.log_command` uses to parse exit codes from command invocations.
+readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
 
 # Outputs a single log line that may contain terminal control characters.
 #
@@ -216,11 +229,10 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   _@go.log_level_file_descriptors "$__go_log_level_index"
 
   for level_fd in "${__go_log_level_file_descriptors[@]}"; do
-    if ! _@go.log_level_meets_priority "$__go_log_level_index" "$level_fd"; then
+    if ! _@go.log_level_meets_priority "$__go_log_level_index" "$level_fd" ||
+      _@go.log_command_should_skip_file_descriptor "$level_fd"; then
       continue
-    fi
-
-    if [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
+    elif [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
       if [[ -z "$unformatted_log_msg" ]]; then
         unformatted_log_msg="${log_msg//\\e\[[0-9]m}"
         unformatted_log_msg="${unformatted_log_msg//\\e\[[0-9][0-9]m}"
@@ -238,6 +250,9 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
   done
 
   if [[ "$log_level" == 'FATAL' ]]; then
+    if [[ "$__GO_LOG_COMMAND_DEPTH" -ne '0' ]]; then
+      echo "@go.log_command fatal:$exit_status" >&2
+    fi
     exit "$exit_status"
   fi
   return "$exit_status"
@@ -388,24 +403,60 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 # Arguments:
 #   $@: The command and its arguments to log and execute
 @go.log_command() {
-  local args=("$@")
-  local cmd_string="${args[*]}"
-  local exit_status
+  # STACK TRACES FOR LOGGED COMMANDS will point at the above line, but the real
+  # line is `done < <(_@go.log_command_invoke)` closing the `while` loop below.
+  local __go_log_command_args=("$@")
+  local cmd_string="${__go_log_command_args[*]}"
+  local line
+  local exit_state
+  local exit_status=1
 
-  if [[ "${args[0]}" == '@go' ]]; then
-    cmd_string="$_GO_CMD ${args[*]:1}"
+  if [[ "${__go_log_command_args[0]}" == '@go' ]]; then
+    cmd_string="$_GO_CMD ${__go_log_command_args[*]:1}"
   fi
+
   @go.log RUN "$cmd_string"
 
   if [[ -n "$_GO_DRY_RUN" ]]; then
     return
   fi
 
-  "${args[@]}"
-  exit_status="$?"
+  local __go_log_level_index
+  _@go.log_level_index 'RUN'
+  local __go_log_level_file_descriptors
+  _@go.log_level_file_descriptors "$__go_log_level_index"
+
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+
+    if [[ "$line" =~ $__GO_LOG_COMMAND_EXIT_PATTERN ]]; then
+      # If the line immediately previous was fatal, keep the fatal state.
+      if [[ "$exit_state" != 'fatal' ]]; then
+        exit_state="${BASH_REMATCH[1]}"
+      fi
+      exit_status="${BASH_REMATCH[2]}"
+      continue
+    fi
+
+    # Ensure only the last line of output captures the exit state and status.
+    exit_state=''
+
+    for fd in "${__go_log_level_file_descriptors[@]}"; do
+      if _@go.log_command_should_skip_file_descriptor "$fd"; then
+        continue
+      elif [[ -t "$fd" || -n "$_GO_LOG_FORMATTING" ]]; then
+        printf '%b\n' "$line" >&"$fd"
+      else
+        printf '%s\n' "$line" >&"$fd"
+      fi
+    done
+  done < <(_@go.log_command_invoke)
 
   if [[ "$exit_status" -ne '0' ]]; then
-    if [[ "$__GO_LOG_CRITICAL_SECTION" -ne '0' ]]; then
+    # If the subprocess logged FATAL, don't add another stack trace.
+    if [[ "$exit_state" == 'fatal' ]]; then
+      exit "$exit_status"
+    elif [[ "$__GO_LOG_CRITICAL_SECTION" -ne '0' ]]; then
       ((++__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS))
       @go.log FATAL "$exit_status" "$cmd_string"
     fi
@@ -486,6 +537,8 @@ export __GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS=1
 #
 # May be called multiple times; initialization will only happen once.
 _@go.log_init() {
+  local run_fd
+
   if [[ -n "$__GO_LOG_INIT" ]]; then
     return
   fi
@@ -518,6 +571,16 @@ _@go.log_init() {
     else
       @go.log FATAL "Invalid _GO_LOG_CONSOLE_FILTER: $_GO_LOG_CONSOLE_FILTER"
     fi
+  fi
+
+  if _@go.log_level_index 'RUN'; then
+    while read -rd, run_fd; do
+      # Standard output (fd 1) and error (fd 2) should never be skipped since
+      # `@go.log_command` captures them.
+      if [[ "$run_fd" -gt '2' ]]; then
+        __GO_LOG_COMMAND_SKIP_FILE_DESCRIPTORS["$run_fd"]='true'
+      fi
+    done <<< "${__GO_LOG_LEVELS_FILE_DESCRIPTORS[__go_log_level_index]},"
   fi
 
   ((__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS-=2))
@@ -631,6 +694,21 @@ _@go.log_level_meets_priority() {
   fi
 
   [[ "$level" -ge "$priority" ]]
+}
+
+# Invoked by `@go.log_command` in a process substitution (subshell).
+_@go.log_command_invoke() {
+  ((++__GO_LOG_COMMAND_DEPTH))
+  trap 'echo "@go.log_command exit:$?"' EXIT
+  "${__go_log_command_args[@]}" 2>&1
+  # Bash 3.2 won't set $? in the EXIT trap without the following line.
+  exit "$?"
+}
+
+# Prevents echoing log lines to log files when running under `@go.log_command`
+_@go.log_command_should_skip_file_descriptor() {
+  [[ "$__GO_LOG_COMMAND_DEPTH" -ne '0' &&
+     -n "${__GO_LOG_COMMAND_SKIP_FILE_DESCRIPTORS[$1]}" ]]
 }
 
 # Sanity check that the __GO_LOG arrays are all of the same size

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -99,12 +99,17 @@ stack_trace_item() {
   "${BASH_SOURCE%/*}/stack-trace-item" "$@"
 }
 
-log_command_stack_trace_item() {
-  if [[ -z "$LOG_COMMAND_STACK_TRACE_ITEM" ]]; then
-    export LOG_COMMAND_STACK_TRACE_ITEM="$(stack_trace_item \
-      "$_GO_CORE_DIR/lib/log" '@go.log_command' '  "${args[@]}"')"
+set_log_command_stack_trace_items() {
+  if [[ "${#LOG_COMMAND_STACK_TRACE_ITEMS[@]}" -eq '0' ]]; then
+    export LOG_COMMAND_STACK_TRACE_ITEMS
+    LOG_COMMAND_STACK_TRACE_ITEMS=(
+      "$(stack_trace_item "$_GO_CORE_DIR/lib/log" '_@go.log_command_invoke' \
+        '  "${__go_log_command_args[@]}" 2>&1')"
+        # For some reason, with the process redirection at the end of the
+        # `while` loop, the stack trace reports the opening line of the function
+        # definition, not the actual `done < <(_@go.log_command_invoke)` line.
+      "$(stack_trace_item "$_GO_CORE_DIR/lib/log" '@go.log_command')")
   fi
-  echo "$LOG_COMMAND_STACK_TRACE_ITEM"
 }
 
 # Call this before using "${GO_CORE_STACK_TRACE_COMPONENTS[@]}" to inject

--- a/tests/log/helpers.bash
+++ b/tests/log/helpers.bash
@@ -2,13 +2,17 @@
 #
 # Helper functions for `lib/log` tests.
 
-run_log_script() {
+create_log_script(){
   create_test_go_script \
     ". \"\$_GO_USE_MODULES\" 'log'" \
     'if [[ -n "$TEST_LOG_FILE" ]]; then' \
     '  @go.log_add_output_file "$TEST_LOG_FILE"' \
     'fi' \
     "$@"
+}
+
+run_log_script() {
+  create_log_script "$@"
   run "$TEST_GO_SCRIPT"
 }
 

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -3,6 +3,11 @@
 load ../environment
 load helpers
 
+setup() {
+  # Test every case with a log file as well.
+  export TEST_LOG_FILE="$TEST_GO_ROOTDIR/run.log"
+}
+
 teardown() {
   remove_test_go_rootdir
 }
@@ -10,16 +15,79 @@ teardown() {
 @test "$SUITE: log single command" {
   run_log_script '@go.log_command echo Hello, World!'
   assert_success
-  assert_log_equals RUN 'echo Hello, World!' \
-    'Hello, World!'
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    'Hello, World!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
-@test "$SUITE: log single failing command" {
-  run_log_script 'failing_function() { return 127; }' \
-    '@go.log_command failing_function foo bar baz'
+@test "$SUITE: logging to a file doesn't repeat lines or skip other log files" {
+  local info_log="$TEST_GO_ROOTDIR/info.log"
+
+  run_log_script \
+    'function function_that_logs_info() {' \
+    '  @go.log INFO "$@"' \
+    '  "$@"' \
+    '}' \
+    "@go.log_add_output_file '$info_log' INFO" \
+    '@go.log INFO Invoking _GO_SCRIPT: $_GO_SCRIPT' \
+    '@go.log_command function_that_logs_info echo Hello, World!'
+  assert_success
+
+  local expected_log_lines=(
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT"
+    RUN  'function_that_logs_info echo Hello, World!'
+    INFO 'echo Hello, World!'
+    'Hello, World!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+  assert_log_file_equals "$info_log" \
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT" \
+    INFO 'echo Hello, World!'
+}
+
+@test "$SUITE: log single failing command to standard error" {
+  run_log_script \
+      'function failing_function() {' \
+      '  printf "%s\n" "\e[1m$*\e[0m" >&2' \
+      '  exit 127' \
+      '}' \
+      '@go.log_command failing_function foo bar baz'
   assert_failure
-  assert_log_equals RUN 'failing_function foo bar baz' \
-    ERROR 'failing_function foo bar baz (exit status 127)'
+
+  local expected_log_lines=(
+    RUN 'failing_function foo bar baz'
+    '\e[1mfoo bar baz\e[0m'
+    ERROR 'failing_function foo bar baz (exit status 127)')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+}
+
+@test "$SUITE: log failing command to standard error with formatting" {
+  local formatted_run_level_label="$(format_label RUN)"
+  local formatted_error_level_label="$(format_label ERROR)"
+
+  _GO_LOG_FORMATTING='true' run_log_script \
+      'function failing_function() {' \
+      '  printf "%s\n" "\e[1m$*\e[0m" >&2' \
+      '  exit 127' \
+      '}' \
+      '@go.log_command failing_function foo bar baz'
+  assert_failure
+
+  local expected_log_lines=(
+    "$formatted_run_level_label" 'failing_function foo bar baz'
+    "$(printf '%b' '\e[1mfoo bar baz\e[0m')"
+    "$formatted_error_level_label"
+      'failing_function foo bar baz (exit status 127)')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log single failing command in critical section" {
@@ -28,18 +96,25 @@ teardown() {
     '@go.log_command failing_function foo bar baz' \
     '@go.critical_section_end'
   assert_failure
-  assert_log_equals RUN 'failing_function foo bar baz' \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "$(test_script_stack_trace_item 1)"
+
+  local expected_log_lines=(
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "$(test_script_stack_trace_item 1)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log single failing command without executing during dry run" {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+  _GO_DRY_RUN='true' run_log_script \
     'failing_function() { return 127; }' \
     '@go.log_command failing_function foo bar baz'
-  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
   assert_success
+
   assert_log_equals RUN 'failing_function foo bar baz'
+  assert_log_file_equals "$TEST_LOG_FILE" \
+    RUN 'failing_function foo bar baz'
 }
 
 @test "$SUITE: log multiple commands" {
@@ -47,12 +122,17 @@ teardown() {
     "@go.log_command echo I don\'t know why you say goodbye," \
     '@go.log_command echo while I say hello...'
   assert_success
-  assert_log_equals RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN "echo I don't know why you say goodbye," \
-    "I don't know why you say goodbye," \
-    RUN "echo while I say hello..." \
-    "while I say hello..."
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN "echo I don't know why you say goodbye,"
+    "I don't know why you say goodbye,"
+    RUN "echo while I say hello..."
+    "while I say hello...")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log multiple commands, second one fails" {
@@ -61,12 +141,17 @@ teardown() {
     '@go.log_command failing_function foo bar baz' \
     '@go.log_command echo Goodbye, World!'
   assert_success
-  assert_log_equals RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN "failing_function foo bar baz" \
-    ERROR 'failing_function foo bar baz (exit status 127)' \
-    RUN "echo Goodbye, World!" \
-    "Goodbye, World!"
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN "failing_function foo bar baz"
+    ERROR 'failing_function foo bar baz (exit status 127)'
+    RUN "echo Goodbye, World!"
+    "Goodbye, World!")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log multiple commands, second one fails in critical section" {
@@ -77,24 +162,33 @@ teardown() {
     '@go.log_command echo Goodbye, World!' \
     '@go.critical_section_end'
   assert_failure
-  assert_log_equals RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN "failing_function foo bar baz" \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "$(test_script_stack_trace_item 2)"
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN "failing_function foo bar baz"
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "$(test_script_stack_trace_item 2)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log multiple commands without executing during dry run" {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+  _GO_DRY_RUN=true run_log_script \
     'failing_function() { return 127; }' \
     '@go.log_command echo Hello, World!' \
     '@go.log_command failing_function foo bar baz' \
     '@go.log_command echo Goodbye, World!'
-  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
   assert_success
-  assert_log_equals RUN 'echo Hello, World!' \
-    RUN "failing_function foo bar baz" \
-    RUN 'echo Goodbye, World!'
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    RUN "failing_function foo bar baz"
+    RUN 'echo Goodbye, World!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: critical section in function" {
@@ -111,13 +205,18 @@ teardown() {
     '@go.log_command failing_function foo bar baz' \
     '@go.log_command echo We made it!'
   assert_success
-  assert_log_equals RUN 'critical_subsection Hello, World!' \
-    RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN 'failing_function foo bar baz' \
-    ERROR 'failing_function foo bar baz (exit status 127)' \
-    RUN 'echo We made it!' \
-    'We made it!'
+
+  local expected_log_lines=(
+    RUN 'critical_subsection Hello, World!'
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN 'failing_function foo bar baz'
+    ERROR 'failing_function foo bar baz (exit status 127)'
+    RUN 'echo We made it!'
+    'We made it!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: nested critical sections" {
@@ -133,19 +232,24 @@ teardown() {
     '@go.log_command failing_function foo bar baz' \
     '@go.log_command echo We made it!'
   assert_success
-  assert_log_equals RUN 'critical_subsection Hello, World!' \
-    RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN 'failing_function foo bar baz' \
-    ERROR 'failing_function foo bar baz (exit status 127)' \
-    RUN 'echo We made it!' \
-    'We made it!'
+
+  local expected_log_lines=(
+    RUN 'critical_subsection Hello, World!'
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN 'failing_function foo bar baz'
+    ERROR 'failing_function foo bar baz (exit status 127)'
+    RUN 'echo We made it!'
+    'We made it!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: nested critical sections dry run" {
   # Note that `echo Hello, World!` inside `critical_subsection` isn't logged,
   # since `critical_subsection` is only logged but not executed.
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+  _GO_DRY_RUN='true' run_log_script \
     'failing_function() { return 127; }' \
     'critical_subsection() {' \
     '  @go.critical_section_begin' \
@@ -157,11 +261,15 @@ teardown() {
     '@go.critical_section_end' \
     '@go.log_command failing_function foo bar baz' \
     '@go.log_command echo We made it!'
-  run env _GO_DRY_RUN=true "$TEST_GO_SCRIPT"
   assert_success
-  assert_log_equals RUN 'critical_subsection Hello, World!' \
-    RUN 'failing_function foo bar baz' \
-    RUN 'echo We made it!'
+
+  local expected_log_lines=(
+    RUN 'critical_subsection Hello, World!'
+    RUN 'failing_function foo bar baz'
+    RUN 'echo We made it!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: critical section is reentrant" {
@@ -177,12 +285,17 @@ teardown() {
     '@go.critical_section_end' \
     "@go.log_command echo We shouldn\'t make it this far..."
   assert_failure
-  assert_log_equals RUN 'critical_subsection Hello, World!' \
-    RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN 'failing_function foo bar baz' \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "$(test_script_stack_trace_item 2)"
+
+  local expected_log_lines=(
+    RUN 'critical_subsection Hello, World!'
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "$(test_script_stack_trace_item 2)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: critical section counter does not go below zero" {
@@ -198,29 +311,39 @@ teardown() {
     '@go.log_command Should not get this far' \
     '@go.critical_section_end'
   assert_failure
-  assert_log_equals RUN 'echo Hello, World!' \
-    'Hello, World!' \
-    RUN 'failing_function foo bar baz' \
-    ERROR 'failing_function foo bar baz (exit status 127)' \
-    RUN 'failing_function foo bar baz' \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "$(test_script_stack_trace_item 2)"
+
+  local expected_log_lines=(
+    RUN 'echo Hello, World!'
+    'Hello, World!'
+    RUN 'failing_function foo bar baz'
+    ERROR 'failing_function foo bar baz (exit status 127)'
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "$(test_script_stack_trace_item 2)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: log and run command script using @go" {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+  create_log_script ". \"\$_GO_USE_MODULES\" 'log'" \
     '@go.log_command @go project-command-script "$@"'
 
   create_test_command_script 'project-command-script' 'echo $*'
 
   run test-go Hello, World!
   assert_success
-  assert_log_equals RUN 'test-go project-command-script Hello, World!' \
-    'Hello, World!'
+
+  local expected_log_lines=(
+    RUN 'test-go project-command-script Hello, World!'
+    'Hello, World!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
-@test "$SUITE: critical section in parent script applies to @go script" {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+@test "$SUITE: critical section in parent script applies to command script" {
+  create_log_script \
     '@go.critical_section_begin' \
     '@go.log_command @go project-command-script "$@"' \
     '@go.critical_section_end' \
@@ -233,17 +356,23 @@ teardown() {
   run test-go foo bar baz
   assert_failure
   set_go_core_stack_trace_components
-  assert_log_equals RUN 'test-go project-command-script foo bar baz' \
-    RUN 'failing_function foo bar baz' \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPTS_DIR/project-command-script:3 source" \
-    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}" \
-    "$(log_command_stack_trace_item)" \
-    "$(test_script_stack_trace_item 2)"
+  set_log_command_stack_trace_items
+
+  local expected_log_lines=(
+    RUN 'test-go project-command-script foo bar baz'
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "  $TEST_GO_SCRIPTS_DIR/project-command-script:3 source"
+    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}"
+    "${LOG_COMMAND_STACK_TRACE_ITEMS[@]}"
+    "$(test_script_stack_trace_item 2)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
 }
 
 @test "$SUITE: critical section in command script applies to parent script" {
-  create_test_go_script ". \"\$_GO_USE_MODULES\" 'log'" \
+  create_log_script \
     '@go.log_command @go project-command-script "$@"' \
     '@go.log_command Should not get this far.'
 
@@ -256,11 +385,186 @@ teardown() {
   run test-go foo bar baz
   assert_failure
   set_go_core_stack_trace_components
-  assert_log_equals RUN 'test-go project-command-script foo bar baz' \
-    RUN 'failing_function foo bar baz' \
-    FATAL 'failing_function foo bar baz (exit status 127)' \
-    "  $TEST_GO_SCRIPTS_DIR/project-command-script:4 source" \
-    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}" \
-    "$(log_command_stack_trace_item)" \
+  set_log_command_stack_trace_items
+
+  local expected_log_lines=(
+    RUN 'test-go project-command-script foo bar baz'
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "  $TEST_GO_SCRIPTS_DIR/project-command-script:4 source"
+    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}"
+    "${LOG_COMMAND_STACK_TRACE_ITEMS[@]}"
+    "$(test_script_stack_trace_item 1)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+}
+
+@test "$SUITE: exit/fatal status pattern applies only when last line printed" {
+  create_log_script '@go.log_command @go project-command-script "$@"'
+
+  create_test_command_script 'project-command-script' \
+    'echo @go.log_command fatal:127' \
+    'echo @go.log_command exit:127'
+
+  run test-go
+  assert_success
+  # Note that the "fake" exit status lines gets swallowed.
+  assert_log_equals RUN 'test-go project-command-script'
+  assert_log_file_equals "$TEST_LOG_FILE" RUN 'test-go project-command-script'
+}
+
+@test "$SUITE: capture sourced script exit status when not from @go.log FATAL" {
+  create_log_script \
+    '@go.critical_section_begin' \
+    "@go.log_command . '$TEST_GO_SCRIPTS_RELATIVE_DIR/sourced-script'" \
+    '@go.critical_section_end'
+
+  create_test_command_script 'sourced-script' \
+    'exit 127'
+
+  run test-go
+  assert_failure
+
+  # Note that the `@go.log_command` and `go-core.bash` items aren't in the stack
+  # trace.
+  local expected_log_lines=(
+    RUN ". $TEST_GO_SCRIPTS_RELATIVE_DIR/sourced-script"
+    FATAL ". $TEST_GO_SCRIPTS_RELATIVE_DIR/sourced-script (exit status 127)"
+    "$(test_script_stack_trace_item 1)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+}
+
+@test "$SUITE: exit status from subcommand in other language" {
+  if ! command -v perl &>/dev/null; then
+    skip 'perl not installed'
+  fi
+
+  create_log_script \
+    '@go.critical_section_begin' \
+    '@go.log_command @go "$@"' \
+    '@go.critical_section_end'
+
+  create_test_command_script 'perl-command-script' \
+    '#!/bin/perl' \
+    'print "@ARGV\n";' \
+    'exit 127;'
+
+  run test-go perl-command-script foo bar baz
+  assert_failure
+
+  local expected_log_lines=(
+    RUN "test-go perl-command-script foo bar baz"
+    'foo bar baz'
+    FATAL "test-go perl-command-script foo bar baz (exit status 127)"
+    "$(test_script_stack_trace_item 1)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+}
+
+@test "$SUITE: fatal status for subcommand of command in another language" {
+  if ! command -v perl &>/dev/null; then
+    skip 'perl not installed'
+  fi
+
+  create_log_script \
+    '@go.critical_section_begin' \
+    '@go.log_command @go "$@"' \
+    '@go.critical_section_end'
+
+  # For this to work, scripts in other languages have to take care to return the
+  # exit status from the failed command, especially if
+  # `__GO_LOG_CRITICAL_SECTION` is in effect.
+  create_test_command_script 'perl-command-script' \
+    '#!/bin/perl' \
+    'print "@ARGV\n";' \
+    "my @args = ('bash', \$ENV{'_GO_SCRIPT'}, 'bash-command-script');" \
+    'push @args, @ARGV;' \
+    "if (system(@args) != 0 && \$ENV{'__GO_LOG_CRITICAL_SECTION'} != 0) {" \
+    '  exit $? >> 8;' \
+    '}'
+
+  # Note that the critical section still applies, since
+  # `__GO_LOG_CRITICAL_SECTION` is exported.
+  create_test_command_script 'bash-command-script' \
+    'failing_function() { return 127; }' \
+    '@go.log_command failing_function "$@"' \
+
+  run test-go perl-command-script foo bar baz
+  assert_failure
+  set_go_core_stack_trace_components
+  set_log_command_stack_trace_items
+
+  # Notice there's two FATAL stack traces:
+  # - The first is from the bash-command-script, which is insulated from the
+  #   top-level `TEST_GO_SCRIPT` invocation by the perl-command-script.
+  # - The second is from the top-level `TEST_GO_SCRIPT`, based on the return
+  #   status from the perl-command-script.
+  local expected_log_lines=(
+    RUN "test-go perl-command-script foo bar baz"
+    'foo bar baz'
+    RUN "test-go bash-command-script foo bar baz"
+    RUN 'failing_function foo bar baz'
+    FATAL 'failing_function foo bar baz (exit status 127)'
+    "  $TEST_GO_SCRIPTS_DIR/bash-command-script:3 source"
+    "${GO_CORE_STACK_TRACE_COMPONENTS[@]}"
+    "${LOG_COMMAND_STACK_TRACE_ITEMS[@]}"
     "$(test_script_stack_trace_item 1)"
+    FATAL 'test-go perl-command-script foo bar baz (exit status 127)'
+    "$(test_script_stack_trace_item 1)")
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+}
+
+@test "$SUITE: subcommand of command in other language appends to all logs" {
+  if ! command -v perl &>/dev/null; then
+    skip 'perl not installed'
+  fi
+
+  local info_log="$TEST_GO_ROOTDIR/info.log"
+
+  create_log_script \
+    "@go.log_add_output_file '$info_log' INFO" \
+    '@go.log INFO Invoking _GO_SCRIPT: $_GO_SCRIPT' \
+    '@go.log_command @go "$@"' \
+
+  create_test_command_script 'perl-command-script' \
+    '#!/bin/perl' \
+    'print "@ARGV\n";' \
+    "my @args = ('bash', \$ENV{'_GO_SCRIPT'}, 'bash-command-script');" \
+    'push @args, @ARGV;' \
+    "if (system(@args) != 0) {" \
+    '  exit $? >> 8;' \
+    '}'
+
+  create_test_command_script 'bash-command-script' \
+    'function function_that_logs_info() {' \
+    '  @go.log INFO "$@"' \
+    '  "$@"' \
+    '}' \
+    '@go.log_command function_that_logs_info "$@"'
+
+  run test-go perl-command-script echo Hello, World!
+  assert_success
+
+  local expected_log_lines=(
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT"
+    RUN "test-go perl-command-script echo Hello, World!"
+    'echo Hello, World!'
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT"
+    RUN "test-go bash-command-script echo Hello, World!"
+    RUN 'function_that_logs_info echo Hello, World!'
+    INFO 'echo Hello, World!'
+    'Hello, World!')
+
+  assert_log_equals "${expected_log_lines[@]}"
+  assert_log_file_equals "$TEST_LOG_FILE" "${expected_log_lines[@]}"
+  assert_log_file_equals "$info_log" \
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT" \
+    INFO "Invoking _GO_SCRIPT: $TEST_GO_SCRIPT" \
+    INFO 'echo Hello, World!'
 }


### PR DESCRIPTION
Closes #53. Previously, `@go.log_command` only logged the command string itself to the `RUN` level file descriptors, not its output.

This implementation is notably more complex than the previous, but it does the right thing in practically every circumstance. See the test cases from `tests/log/log-command.bats` added in this commit for examples and details.

The process substitution + trap solution for duplicating output across file descriptors and detecting exit conditions was inspired by:

- https://unix.stackexchange.com/questions/128560/176683#176683
- https://stackoverflow.com/questions/5312266

Note that, on the one hand, `@go.log_command` must take care not to print duplicate lines to any file descriptors defined for the `RUN` log level. On the other, it must not prevent log messages for other levels from getting written to the appropriate files.

The way we do this is to ensure any messages written to standard output and standard error (file descriptors 1 and 2) always come through, but when running under `@go.log_command` (`__GO_LOG_COMMAND_DEPTH -ne 0`), messages are written only if the file descriptor is not one defined for the `RUN` log level.

Every test exercises the condition that `RUN` log file lines aren't duplicated, thanks to `export TEST_LOG_FILE="$TEST_GO_ROOTDIR/run.log"` in `setup()` and the `assert_log_file_equals "$TEST_LOG_FILE"` assertion in every test case. Writing to other log files is exercised by the test
cases:

- logging to a file doesn't repeat lines or skip other log files
- subcommand of command in other language appends to all logs

Also note the initialization of `__GO_LOG_CRITICAL_SECTION` and `__GO_LOG_COMMAND_DEPTH` at the top of the file, which allow for the correct tracking of `@go.log_command` invocations in subcommands that take place in completely new child processes rather than subshells. In a child processes, these variables will receive values exported from the parent process. This is exercised by the test cases:

- fatal status for subcommand of command in another language
- subcommand of command in other language appends to all logs