### PR TITLE
Extract file permission test skip helper

### DIFF
--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -149,3 +149,15 @@ fs_missing_permission_support() {
 
   [[ "$FS_MISSING_PERMISSION_SUPPORT" == 'true' ]]
 }
+
+# Skip a test that depends on triggering file permission failures
+#
+# Will skip a test on a system where file permissions do not exist (at least not
+# in the traditional Unix sense), or when the test is run as the superuser.
+skip_if_cannot_trigger_file_permission_failure() {
+  if fs_missing_permission_support; then
+    skip "Can't trigger condition on this file system"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip "Can't trigger condition when run by superuser"
+  fi
+}

--- a/tests/command-descriptions/from-file.bats
+++ b/tests/command-descriptions/from-file.bats
@@ -50,12 +50,7 @@ teardown() {
 }
 
 @test "$SUITE: return error if there's an error reading" {
-  if fs_missing_permission_support; then
-    skip "Can't trigger condition on this file system"
-  elif [[ "$EUID" -eq '0' ]]; then
-    skip "Can't trigger condition when run by superuser"
-  fi
-
+  skip_if_cannot_trigger_file_permission_failure
   chmod ugo-r "$TEST_COMMAND_SCRIPT_PATH"
 
   run _@go.command_summary "$TEST_COMMAND_SCRIPT_PATH"

--- a/tests/core/set-scripts-dir.bats
+++ b/tests/core/set-scripts-dir.bats
@@ -35,13 +35,8 @@ teardown() {
   assert_failure "$expected"
 }
 
-@test "$SUITE: produce an error if the script dir isn't readable or executable" {
-  if fs_missing_permission_support; then
-    # Even using icacls to set permissions, the dir still seems accessible.
-    skip "Can't trigger condition on this file system"
-  elif [[ "$EUID" -eq '0' ]]; then
-    skip "Can't trigger condition when run by superuser"
-  fi
+@test "$SUITE: produce an error if the script dir can't be read or accessed" {
+  skip_if_cannot_trigger_file_permission_failure
 
   local expected="ERROR: you do not have permission to access the "
   expected+="$TEST_GO_SCRIPTS_DIR directory"

--- a/tests/modules/help.bats
+++ b/tests/modules/help.bats
@@ -46,11 +46,7 @@ teardown() {
 }
 
 @test "$SUITE: error if parsing description fails" {
-  if fs_missing_permission_support; then
-    skip "Can't trigger condition on this file system"
-  elif [[ "$EUID" -eq '0' ]]; then
-    skip "Can't trigger condition when run by superuser"
-  fi
+  skip_if_cannot_trigger_file_permission_failure
 
   local module_path="$TEST_GO_PLUGINS_DIR/_foo/lib/_plugh"
   chmod ugo-r "$module_path"

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -49,11 +49,7 @@ get_first_and_last_core_module_summaries() {
 }
 
 @test "$SUITE: error if parsing summary fails" {
-  if fs_missing_permission_support; then
-    skip "Can't trigger condition on this file system"
-  elif [[ "$EUID" -eq '0' ]]; then
-    skip "Can't trigger condition when run by superuser"
-  fi
+  skip_if_cannot_trigger_file_permission_failure
 
   local module_path="$TEST_GO_PLUGINS_DIR/_foo/lib/_plugh"
   chmod ugo-r "$module_path"


### PR DESCRIPTION
`skip_if_cannot_trigger_file_permission_failure` encapsulates a pair of conditions that have occurred across test files. Figured it was time to extract it before I repeat the same block of code again in tests for `assert_file_*`.