### PR TITLE
Add `fail_if` to negate assertions

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -63,6 +63,74 @@ fail() {
   __return_from_bats_assertion 1
 }
 
+# Negates the expected outcome of an assertion from this file.
+#
+# The first argument should be the name of an assertion from this file _without_
+# the `assert_` prefix. For example:
+#
+#   fail_if equal 'foo' 'bar' "Some values we don't expect to be equal"
+#
+# This is essentially the same as the following, but `fail_if` provides more
+# context for the failure:
+#
+#   ! assert_equal 'foo' 'bar' "Some values we don't expect to be equal"
+#
+# Arguments:
+#   assertion:  The name of the assertion to negate minus the `_assert_` prefix
+#   ...:        The arguments to the assertion being negated
+fail_if() {
+  set +o functrace
+  local assertion="assert_${1}"
+  shift
+  local label
+  local operation='equal'
+  local constraints=()
+  local constraint
+  local i
+  local __bats_fail_suppress_output='true'
+
+  if [[ "$assertion" =~ _match ]]; then
+    operation='match'
+  fi
+
+  case "$assertion" in
+  assert_equal|assert_matches)
+    label="$3"
+    constraints=("$1")
+    ;;
+  assert_output*|assert_status)
+    label="${assertion#assert_}"
+    label="${label%_*}"
+    constraints=("$1")
+    ;;
+  assert_line_*)
+    label="line $1"
+    constraints=("$2")
+    ;;
+  assert_lines_*)
+    __bats_fail_suppress_output=
+    label="lines"
+    constraints=("${@}")
+    ;;
+  *)
+    printf "Unknown assertion: '%s'\n" "$assertion" >&2
+    __return_from_bats_assertion '1'
+    return 1
+  esac
+
+  if ! "$assertion" "$@" &>/dev/null; then
+    set +o functrace
+    __return_from_bats_assertion '0'
+    return
+  fi
+  set +o functrace
+
+  for ((i=0; i != ${#constraints[@]}; ++i)); do
+    constraint+=$'\n'"  '${constraints[$i]}'"
+  done
+  fail "Expected $label not to $operation:$constraint"
+}
+
 # Compares two values for equality
 #
 # Arguments:

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -392,3 +392,112 @@ check_expected_output() {
     "  actual:   ''" \
     'There are 3 fewer lines of output than expected.'
 }
+
+@test "$SUITE: fail_if fails when assertion unknown" {
+  expect_failure "echo 'Hello, world!'" \
+    'fail_if foobar "$output" "echo result"' \
+    "Unknown assertion: 'assert_foobar'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_equal fails" {
+  expect_success "echo 'Hello, world!'" \
+    'fail_if equal "Goodbye, world!" "$output" "echo result"'
+}
+
+@test "$SUITE: fail_if fails when assert_equal succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    'fail_if equal "Hello, world!" "$output" "echo result"' \
+    'Expected echo result not to equal:' \
+    "  'Hello, world!'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_matches fails" {
+  expect_success "echo 'Hello, world!'" \
+    'fail_if matches "Goodbye" "$output" "echo result"'
+}
+
+@test "$SUITE: fail_if fails when assert_matches succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    'fail_if matches "Hello" "$output" "echo result"' \
+    'Expected echo result not to match:' \
+    "  'Hello'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_output fails" {
+  expect_success "echo 'Hello, world!'" \
+    "fail_if output 'Goodbye, world!'"
+}
+
+@test "$SUITE: fail_if fails when assert_output succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    "fail_if output 'Hello, world!'" \
+    'Expected output not to equal:' \
+    "  'Hello, world!'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_output_matches fails" {
+  expect_success "echo 'Hello, world!'" \
+    "fail_if output_matches 'Goodbye'"
+}
+
+@test "$SUITE: fail_if fails when assert_output_matches succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    "fail_if output_matches 'Hello'" \
+    'Expected output not to match:' \
+    "  'Hello'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_status fails" {
+  expect_success "echo 'Hello, world!'" \
+    "fail_if status '1'"
+}
+
+@test "$SUITE: fail_if fails when assert_status succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    "fail_if status '0'" \
+    'Expected status not to equal:' \
+    "  '0'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_line_equals fails" {
+  expect_success "echo 'Hello, world!'" \
+    "fail_if line_equals '0' 'Goodbye, world!'"
+}
+
+@test "$SUITE: fail_if fails when assert_line_equals succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    "fail_if line_equals '0' 'Hello, world!'" \
+    'Expected line 0 not to equal:' \
+    "  'Hello, world!'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_line_matches fails" {
+  expect_success "echo 'Hello, world!'" \
+    "fail_if line_matches '0' 'Goodbye'"
+}
+
+@test "$SUITE: fail_if fails when assert_line_matches succeeds" {
+  expect_failure "echo 'Hello, world!'" \
+    "fail_if line_matches '0' 'Hello'" \
+    'Expected line 0 not to match:' \
+    "  'Hello'"
+}
+
+@test "$SUITE: fail_if succeeds when assert_lines_equal fails" {
+  expect_success "printf 'foo\nbar\nbaz\n'" \
+    "fail_if lines_equal 'foo' 'quux' 'baz'"
+}
+
+@test "$SUITE: fail_if fails when assert_lines_equal succeeds" {
+  expect_failure "printf 'foo\nbar\nbaz\n'" \
+    "fail_if lines_equal 'foo' 'bar' 'baz'" \
+    'Expected lines not to equal:' \
+    "  'foo'" \
+    "  'bar'" \
+    "  'baz'" \
+    'STATUS: 0' \
+    'OUTPUT:' \
+    'foo' \
+    'bar' \
+    'baz'
+}


### PR DESCRIPTION
`fail_if foo ...` is equivalent to `! assert_foo ...`, but provides more context.