### PR TITLE
Properly assert `functrace` is always reset by Bats assertions

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -295,6 +295,8 @@ assert_lines_equal() {
 
   if [[ "$num_errors" -ne '0' ]]; then
     __return_from_bats_assertion 1
+  else
+    __return_from_bats_assertion
   fi
 }
 
@@ -328,14 +330,11 @@ return_from_bats_assertion() {
   local assertion_source_file="$1"
   local result="${2:-0}"
 
-  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
-    unset 'BATS_CURRENT_STACK_TRACE[0]'
-  fi
-
+  # Bats sets its `BATS_ERROR_STACK_TRACE` using `BATS_PREVIOUS_STACK_TRACE`
+  # whenever its `ERR` trap fires.
   if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
-
   set -o functrace
   return "$result"
 }


### PR DESCRIPTION
Closes #48.

The `[[ ! "$-" =~ T ]]` check after the `eval $assertion` call in `expect_success` was never validating the success case. Because the `$output` variable was last set by the `eval run $assertion` invocation (not by `eval run $command`), the `eval $assertion` call would always fail and exercise the failure case instead.

The solution was to add `check_sets_functrace`, which runs `eval run $command` again, then `eval $assertion`. As a redundant check, I also added a second `run_test_script` invocation where the passing assertion is followed by a failing one. This reproduces the case described in #48 in which a failing assertion shows the stack trace for an earlier passing assertion.

Using both of these methods, I confirmed that `assert_lines_equal` was not calling `return_from_bats_assertion` (which invokes `set -o functrace`) in the success case, and reproduced the "previous stack trace" condition. Consequently, both methods verify that the bug is now fixed.