### PR TITLE
Improve `return_from_bats_assertion`

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -32,7 +32,7 @@
 # and then make sure every return path ends with the following (possibly
 # followed by a `return` statement, if not at the end of the function):
 #
-#   return_from_bats_assertion "$return_status" "$BASH_SOURCE"
+#   return_from_bats_assertion "$BASH_SOURCE" "$return_status"
 #
 # Also note that if your assertion function calls other assertion functions, you
 # should call `set +o functrace` after every one of them. See the implementation
@@ -144,14 +144,14 @@ assert_equal() {
   local expected="$1"
   local actual="$2"
   local label="$3"
+  local result='0'
 
   if [[ "$expected" != "$actual" ]]; then
     printf '%s not equal to expected value:\n  %s\n  %s\n' \
       "$label" "expected: '$expected'" "actual:   '$actual'" >&2
-    return_from_bats_assertion "$BASH_SOURCE" '1'
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
+    result='1'
   fi
+  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Validates whether a value matches a regular expression
@@ -165,14 +165,14 @@ assert_matches() {
   local pattern="$1"
   local value="$2"
   local label="$3"
+  local result='0'
 
   if [[ ! "$value" =~ $pattern ]]; then
     printf '%s does not match expected pattern:\n  %s\n  %s\n' \
       "$label" "pattern: '$pattern'" "value:   '$value'" >&2
-    return_from_bats_assertion "$BASH_SOURCE" '1'
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
+    result='1'
   fi
+  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Validates that the Bats $output value is equal to the expected value
@@ -420,6 +420,7 @@ __assert_line() {
   local assertion="$1"
   local lineno="$2"
   local constraint="$3"
+  local result='0'
 
   # Implement negative indices for Bash 3.x.
   if [[ "${lineno:0:1}" == '-' ]]; then
@@ -430,10 +431,9 @@ __assert_line() {
     if [[ -z "$__bats_assert_line_suppress_output" ]]; then
       printf 'OUTPUT:\n%s\n' "$output" >&2
     fi
-    return_from_bats_assertion "$BASH_SOURCE" 1
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
+    result='1'
   fi
+  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Common implementation for assertions that evaluate every element of `$lines`
@@ -480,10 +480,9 @@ __assert_lines() {
 
   if [[ "$num_errors" -ne '0' ]]; then
     printf 'OUTPUT:\n%s\n' "$output" >&2
-    return_from_bats_assertion "$BASH_SOURCE" '1'
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
+    result='1'
   fi
+  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Common implementation for assertions that evaluate a file's contents
@@ -504,6 +503,7 @@ __assert_file() {
     if [[ "$#" -ne '1' ]]; then
       echo "ERROR: ${FUNCNAME[1]} takes exactly two arguments" >&2
       return_from_bats_assertion "$BASH_SOURCE" '1'
+      return
     fi
     constraints=("$1" "$output" "The content of '$file_path'")
   fi

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -34,9 +34,6 @@
 #
 #   return_from_bats_assertion "$return_status" "$BASH_SOURCE"
 #
-# You may wish to wrap `return_from_bats_assertion` in a local helper function
-# to avoid having to specify `$BASH_SOURCE` everywhere.
-#
 # Also note that if your assertion function calls other assertion functions, you
 # should call `set +o functrace` after every one of them. See the implementation
 # of `__assert_lines` for an example.
@@ -60,7 +57,7 @@ fail() {
   if [[ -z "$__bats_fail_suppress_output" ]]; then
     printf 'STATUS: %d\nOUTPUT:\n%b\n' "$status" "$output" >&2
   fi
-  __return_from_bats_assertion 1
+  return_from_bats_assertion "$BASH_SOURCE" '1'
 }
 
 # Negates the expected outcome of an assertion from this file.
@@ -119,13 +116,13 @@ fail_if() {
     ;;
   *)
     printf "Unknown assertion: '%s'\n" "$assertion" >&2
-    __return_from_bats_assertion '1'
+    return_from_bats_assertion "$BASH_SOURCE" '1'
     return 1
   esac
 
   if ! "$assertion" "$@" &>/dev/null; then
     set +o functrace
-    __return_from_bats_assertion '0'
+    return_from_bats_assertion "$BASH_SOURCE"
     return
   fi
   set +o functrace
@@ -151,9 +148,9 @@ assert_equal() {
   if [[ "$expected" != "$actual" ]]; then
     printf '%s not equal to expected value:\n  %s\n  %s\n' \
       "$label" "expected: '$expected'" "actual:   '$actual'" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" '1'
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -172,9 +169,9 @@ assert_matches() {
   if [[ ! "$value" =~ $pattern ]]; then
     printf '%s does not match expected pattern:\n  %s\n  %s\n' \
       "$label" "pattern: '$pattern'" "value:   '$value'" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" '1'
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -217,7 +214,7 @@ assert_success() {
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -233,7 +230,7 @@ assert_failure() {
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -339,8 +336,9 @@ return_from_bats_assertion() {
   local assertion_source_file="$1"
   local result="${2:-0}"
 
-  # Bats sets its `BATS_ERROR_STACK_TRACE` using `BATS_PREVIOUS_STACK_TRACE`
-  # whenever its `ERR` trap fires.
+  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+    unset 'BATS_CURRENT_STACK_TRACE[0]'
+  fi
   if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
   fi
@@ -367,11 +365,11 @@ set_bats_output_and_lines_from_file() {
 
   if [[ ! -f "$file_path" ]]; then
     printf "'%s' doesn't exist or isn't a regular file." "$file_path" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" 1
     return
   elif [[ ! -r "$file_path" ]]; then
     printf "You don't have permission to access '%s'." "$file_path" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" 1
     return
   fi
 
@@ -406,7 +404,7 @@ __assert_output() {
 
   if [[ "$#" -ne 2 ]]; then
     echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" 1
   else
     "$assertion" "$constraint" "$output" 'output'
   fi
@@ -432,9 +430,9 @@ __assert_line() {
     if [[ -z "$__bats_assert_line_suppress_output" ]]; then
       printf 'OUTPUT:\n%s\n' "$output" >&2
     fi
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" 1
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -482,9 +480,9 @@ __assert_lines() {
 
   if [[ "$num_errors" -ne '0' ]]; then
     printf 'OUTPUT:\n%s\n' "$output" >&2
-    __return_from_bats_assertion 1
+    return_from_bats_assertion "$BASH_SOURCE" '1'
   else
-    __return_from_bats_assertion
+    return_from_bats_assertion "$BASH_SOURCE"
   fi
 }
 
@@ -505,20 +503,10 @@ __assert_file() {
   if [[ "$assertion" == 'assert_matches' ]]; then
     if [[ "$#" -ne '1' ]]; then
       echo "ERROR: ${FUNCNAME[1]} takes exactly two arguments" >&2
-      __return_from_bats_assertion 1
+      return_from_bats_assertion "$BASH_SOURCE" '1'
     fi
     constraints=("$1" "$output" "The content of '$file_path'")
   fi
 
   "$assertion" "${constraints[@]}"
-}
-
-# Scrubs the Bats stacks of references to functions from this file
-#
-# See the comment for return_from_bats_assertion for details.
-#
-# Arguments:
-#   $1:  Return value of the calling assertion; defaults to 0
-__return_from_bats_assertion() {
-  return_from_bats_assertion "$BASH_SOURCE" "$1"
 }

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -2,9 +2,27 @@
 #
 # Assertions for Bats tests
 #
-# Provides detailed output for assertion failures, which is especially helpful
-# when running as part of a continuous integration suite.
+# These functions provide detailed output for assertion failures, which is
+# especially helpful when running as part of a continuous integration suite.
+# Compare the output from the typical `[ "$output" == 'bar' ]` statement:
 #
+#   ✗ actual output matches expected
+#     (in test file test.bats, line 7)
+#       `[ "$output" == 'bar' ]' failed
+#
+# with that from `assert_output 'bar'`, which shows the `$output` that failed:
+#
+#   ✗ actual output matches expected
+#     (in test file test.bats, line 7)
+#       `assert_output 'bar'' failed
+#     output not equal to expected value:
+#       expected: 'bar'
+#       actual:   'foo'
+#
+# These assertions borrow inspiration from rbenv/test/test_helper.bash.
+#
+# Usage:
+# -----
 # The recommended way to make these assertions available is to create an
 # 'environment.bash' file in the top-level test directory containing the
 # following line:
@@ -15,30 +33,67 @@
 # can contain any other custom helper functions or assertions to fit your
 # project.
 #
-# If none of the assertions suit your needs, you can use the fail() function to
-# provide a custom error message. For example, to validate that the command
-# output does _not_ match a regular expression:
+# If none of the assertions suit your needs (including their negations provided
+# by `fail_if`), you can use the `fail` function to provide a custom error
+# message.
 #
-#   local pattern="what is this i don't even"
-#   if [[ "$output" =~ $pattern ]]; then
-#     fail "output should not match: '$pattern'"
-#   fi
-#
+# Defining new assertions:
+# -----------------------
 # Alternatively, write your own assertion function with the following as the
 # first line:
 #
-#   set +o functrace
+#   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
 #
-# and then make sure every return path ends with the following (possibly
-# followed by a `return` statement, if not at the end of the function):
+# and then make sure every return path ends with the following (followed by a
+# `return` statement, if not at the very end of the function):
 #
-#   return_from_bats_assertion "$BASH_SOURCE" "$return_status"
+#   return_from_bats_assertion "$return_status"
 #
-# Also note that if your assertion function calls other assertion functions, you
-# should call `set +o functrace` after every one of them. See the implementation
-# of `__assert_lines` for an example.
+# These two steps ensure that your assertion will pinpoint the line in the test
+# case at which it was called, and that it may be reused to compose new
+# assertions. For the deep technical details, see the function comment for
+# `return_from_bats_assertion`.
 #
-# The assertions borrow inspiration from rbenv/test/test_helper.bash.
+# Assertions should generally follow the pattern:
+#
+#   assert_some_condition() {
+#     set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+#     if [[ "$actual" != "$expected" ]]; then
+#       printf "Something's wrong:\n  expected: '%s'\n  actual:   '%s'\n" \
+#         "$expected" "$actual" >&2
+#       return_from_bats_assertion '1'
+#     else
+#       return_from_bats_assertion
+#     fi
+#   }
+#
+# Assertions that wrap a single existing assertion should follow the pattern:
+#
+#   assert_with_more_context() {
+#     set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+#     # ...set up context...
+#     assert_using_an_existing_assertion "$with_more_context"
+#     return_from_bats_assertion "$?"
+#   }
+#
+# For assertions that check multiple error conditions before exiting:
+#
+#   assert_some_stuff() {
+#     set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+#     local num_errors=0
+#
+#     # ...check conditions, print errors, increment num_errors...
+#
+#     if [[ "$num_errors" -ne '0' ]]; then
+#       return_from_bats_assertion '1'
+#     else
+#       return_from_bats_assertion
+#     fi
+#   }
+
+# The first line of every Bats assertion must call `set` with this argument.
+# See the function comments for `return_from_bats_assertion` for details.
+readonly BATS_ASSERTION_DISABLE_SHELL_OPTIONS='+eET'
 
 # Unconditionally returns a failing status
 #
@@ -48,7 +103,7 @@
 # Arguments:
 #   $1:  (optional) Reason to include in the failure output
 fail() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local reason="$1"
 
   if [[ -n "$reason" ]]; then
@@ -57,7 +112,7 @@ fail() {
   if [[ -z "$__bats_fail_suppress_output" ]]; then
     printf 'STATUS: %d\nOUTPUT:\n%b\n' "$status" "$output" >&2
   fi
-  return_from_bats_assertion "$BASH_SOURCE" '1'
+  return_from_bats_assertion '1'
 }
 
 # Negates the expected outcome of an assertion from this file.
@@ -76,7 +131,7 @@ fail() {
 #   assertion:  The name of the assertion to negate minus the `_assert_` prefix
 #   ...:        The arguments to the assertion being negated
 fail_if() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local assertion="assert_${1}"
   shift
   local label
@@ -116,21 +171,20 @@ fail_if() {
     ;;
   *)
     printf "Unknown assertion: '%s'\n" "$assertion" >&2
-    return_from_bats_assertion "$BASH_SOURCE" '1'
-    return 1
+    return_from_bats_assertion '1'
+    return
   esac
 
   if ! "$assertion" "$@" &>/dev/null; then
-    set +o functrace
-    return_from_bats_assertion "$BASH_SOURCE"
+    return_from_bats_assertion
     return
   fi
-  set +o functrace
 
   for ((i=0; i != ${#constraints[@]}; ++i)); do
     constraint+=$'\n'"  '${constraints[$i]}'"
   done
   fail "Expected $label not to $operation:$constraint"
+  return_from_bats_assertion "$?"
 }
 
 # Compares two values for equality
@@ -140,18 +194,18 @@ fail_if() {
 #   $2: The actual value to evaluate
 #   $3: A label explaining the value being evaluated
 assert_equal() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local expected="$1"
   local actual="$2"
   local label="$3"
-  local result='0'
 
   if [[ "$expected" != "$actual" ]]; then
     printf '%s not equal to expected value:\n  %s\n  %s\n' \
       "$label" "expected: '$expected'" "actual:   '$actual'" >&2
-    result='1'
+    return_from_bats_assertion '1'
+  else
+    return_from_bats_assertion
   fi
-  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Validates whether a value matches a regular expression
@@ -161,18 +215,18 @@ assert_equal() {
 #   $2: The value to match
 #   $3: A label explaining the value being matched
 assert_matches() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local pattern="$1"
   local value="$2"
   local label="$3"
-  local result='0'
 
   if [[ ! "$value" =~ $pattern ]]; then
     printf '%s does not match expected pattern:\n  %s\n  %s\n' \
       "$label" "pattern: '$pattern'" "value:   '$value'" >&2
-    result='1'
+    return_from_bats_assertion '1'
+  else
+    return_from_bats_assertion
   fi
-  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Validates that the Bats $output value is equal to the expected value
@@ -180,8 +234,9 @@ assert_matches() {
 # Arguments:
 #   $1: The expected value for $output
 assert_output() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_output 'assert_equal' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that the Bats $output value matches a regular expression
@@ -189,8 +244,9 @@ assert_output() {
 # Arguments:
 #   $1: The regular expression to match against $output
 assert_output_matches() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_output 'assert_matches' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that the Bats $status value is equal to the expected value
@@ -198,8 +254,9 @@ assert_output_matches() {
 # Arguments:
 #   $1: The expected value for $status
 assert_status() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   assert_equal "$1" "$status" "exit status"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that 'run' returned success and $output equals the expected value
@@ -207,15 +264,15 @@ assert_status() {
 # Arguments:
 #   $1: The regular expression to match against $output
 assert_success() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+
   if [[ "$status" -ne '0' ]]; then
     printf 'expected success, but command failed\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
   fi
+  return_from_bats_assertion "$?"
 }
 
 # Validates that 'run' returned an error and $output equals the expected value
@@ -223,15 +280,15 @@ assert_success() {
 # Arguments:
 #   $1: The regular expression to match against $output
 assert_failure() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+
   if [[ "$status" -eq '0' ]]; then
     printf 'expected failure, but command succeeded\n' >&2
     fail
   elif [[ "$#" -ne 0 ]]; then
     assert_output "$@"
-  else
-    return_from_bats_assertion "$BASH_SOURCE"
   fi
+  return_from_bats_assertion "$?"
 }
 
 # Validates that a specific line from $line equals the expected value
@@ -240,8 +297,9 @@ assert_failure() {
 #   $1: The index into $line identifying the line to evaluate
 #   $2: The expected value for ${line[$1]}
 assert_line_equals() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_line 'assert_equal' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that a specific line from $line matches the expected value
@@ -250,8 +308,9 @@ assert_line_equals() {
 #   $1: The index into $line identifying the line to match
 #   $2: The regular expression to match against ${line[$1]}
 assert_line_matches() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_line 'assert_matches' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that each output line equals each corresponding argument
@@ -261,8 +320,9 @@ assert_line_matches() {
 # Arguments:
 #   $@: Values to compare to each element of `${lines[@]}` for equality
 assert_lines_equal() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_lines 'assert_equal' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that each output line matches each corresponding argument
@@ -272,8 +332,9 @@ assert_lines_equal() {
 # Arguments:
 #   $@: Values to compare to each element of `${lines[@]}` for equality
 assert_lines_match() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_lines 'assert_matches' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that a file contains exactly the specified output
@@ -282,8 +343,9 @@ assert_lines_match() {
 #   file_path:  Path to file to evaluate
 #    ...:       Exact lines expected to appear in the file
 assert_file_equals() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_file 'assert_lines_equal' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that a file matches a single regular expression
@@ -292,8 +354,9 @@ assert_file_equals() {
 #   file_path:  Path to the file to examine
 #   pattern:    Regular expression used to validate the contents of the file
 assert_file_matches() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_file 'assert_matches' "$@"
+  return_from_bats_assertion "$?"
 }
 
 # Validates that every line in a file matches a corresponding regular expression
@@ -302,47 +365,61 @@ assert_file_matches() {
 #   file_path:  Path to the file to examine
 #   ...:        Regular expressions used to validate each line of the file
 assert_file_lines_match() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   __assert_file 'assert_lines_match' "$@"
+  return_from_bats_assertion "$?"
 }
 
-# Scrubs the Bats stacks of functions from the assertion source file
+# Ensures Bats assertion failures point to the assertion call, not its internals
 #
-# You must ensure that `set +o functrace` is in effect prior to calling this
-# function. If you write an assertion function that uses an assertion from this
-# file, or which uses any other assertion that evantually calls this function,
-# you will need to call `set +o functrace` again following those assertions.
+# You must ensure that `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"` is in
+# effect prior to calling this function. See the comments at the top of this
+# file for usage instructions and patterns.
 #
-# This helps ensure that Bats failure messages only contain the location at
-# which an assertion was called, rather than containing stack trace information
-# about the assertion implementation itself.
+# Notice that each public assertion starts with:
 #
-# Bats sets 'functrace' to make sure failing commands are pinpointed. This is
-# almost always the desired behavior, except that we don't actually want a stack
-# trace showing assertion implementation details. When it does, it produces a
-# bit of mental overhead when reviewing test failures to identify the location
-# of the failing assertion in the test case itself.
+#   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"`
 #
-# Notice that each public assertion function starts with 'set +o functrace', and
-# this function ends with 'set -o functrace'. However, just calling 'set +o
-# functrace' still leaves the function, file, and line number where the
-# assertion was defined in the Bats failure output. Plus, we want to ensure that
-# 'set -o functrace' goes back into effect once the assertion has finished.
+# and that `BATS_ASSERTION_DISABLE_SHELL_OPTIONS` is defined as `set +eET`. Bats
+# uses `set -e`, `set -E`, and `set -T` (in `tests/bats/libexec/bats-exec-test`)
+# to make sure failing commands are pinpointed and their stack traces are
+# collected. This is almost always the desired behavior.
+#
+# When it comes to test assertions, however, we want the stack trace to point to
+# the assertion call itself, not the line within its implementation at which a
+# condition triggered the failure. Otherwise, it produces a bit of mental strain
+# when reviewing test failures to identify the location of the failing assertion
+# in the test case itself.
+#
+# Starting an assertion with `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"` (i.e.
+# `set +eET`) disables the `set -e`, `set -E`, and `set -T` shell options, which
+# prevents the functions and commands it calls from updating the Bats stack
+# traces. However, by itself, this still leaves the function, file, and line
+# number where the assertion was defined in the Bats stack traces. It's also
+# important to reinstate `set -eET` upon returning, but we want to make it easy
+# to write new assertions composed from existing assertions by reinstating these
+# options only when returning from the outermost assertion.
+#
+# This function solves both aspects of the problem by removing the immediate
+# caller from the Bats stack traces and reinstating `set -eET` if it is the
+# outermost assertion function, which will be the only one pushed onto the Bats
+# stacks prior to its calling `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"`.
 #
 # Arguments:
 #   $1:  The $BASH_SOURCE value from the assertion source file
 #   $2:  Return value of the calling assertion; defaults to 0
 return_from_bats_assertion() {
-  local assertion_source_file="$1"
-  local result="${2:-0}"
+  local result="${1:-0}"
+  local target_stack_item_pattern=" ${FUNCNAME[1]} ${BASH_SOURCE[1]}$"
 
-  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+  if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $target_stack_item_pattern ]]; then
     unset 'BATS_CURRENT_STACK_TRACE[0]'
+    set -eET
   fi
-  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $assertion_source_file ]]; then
+  if [[ "${BATS_PREVIOUS_STACK_TRACE[0]}" =~ $target_stack_item_pattern ]]; then
     unset 'BATS_PREVIOUS_STACK_TRACE[0]'
+    set -eET
   fi
-  set -o functrace
   return "$result"
 }
 
@@ -360,31 +437,30 @@ return_from_bats_assertion() {
 # Arguments:
 #   file_path:  Path to file from which `output` and `lines` will be filled
 set_bats_output_and_lines_from_file() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local file_path="$1"
 
   if [[ ! -f "$file_path" ]]; then
     printf "'%s' doesn't exist or isn't a regular file." "$file_path" >&2
-    return_from_bats_assertion "$BASH_SOURCE" 1
-    return
+    return_from_bats_assertion 1
   elif [[ ! -r "$file_path" ]]; then
     printf "You don't have permission to access '%s'." "$file_path" >&2
-    return_from_bats_assertion "$BASH_SOURCE" 1
-    return
+    return_from_bats_assertion 1
+  else
+    lines=()
+    output=''
+
+    # This loop preserves leading and trailing blank lines. We need to chomp the
+    # last newline off of `output` though, to make it consistent with the
+    # conventional `output` format.
+    while IFS= read -r line; do
+      line="${line%$'\r'}"
+      lines+=("$line")
+      output+="$line"$'\n'
+    done <"$file_path"
+    output="${output%$'\n'}"
+    return_from_bats_assertion
   fi
-
-  lines=()
-  output=''
-
-  # This loop preserves leading and trailing blank lines. We need to chomp the
-  # last newline off of `output` though, to make it consistent with the
-  # conventional `output` format.
-  while IFS= read -r line; do
-    line="${line%$'\r'}"
-    lines+=("$line")
-    output+="$line"$'\n'
-  done <"$file_path"
-  output="${output%$'\n'}"
 }
 
 # --------------------------------
@@ -404,10 +480,9 @@ __assert_output() {
 
   if [[ "$#" -ne 2 ]]; then
     echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
-    return_from_bats_assertion "$BASH_SOURCE" 1
-  else
-    "$assertion" "$constraint" "$output" 'output'
+    return '1'
   fi
+  "$assertion" "$constraint" "$output" 'output'
 }
 
 # Common implementation for assertions that evaluate a single `$lines` element
@@ -420,7 +495,6 @@ __assert_line() {
   local assertion="$1"
   local lineno="$2"
   local constraint="$3"
-  local result='0'
 
   # Implement negative indices for Bash 3.x.
   if [[ "${lineno:0:1}" == '-' ]]; then
@@ -431,9 +505,8 @@ __assert_line() {
     if [[ -z "$__bats_assert_line_suppress_output" ]]; then
       printf 'OUTPUT:\n%s\n' "$output" >&2
     fi
-    result='1'
+    return '1'
   fi
-  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Common implementation for assertions that evaluate every element of `$lines`
@@ -455,7 +528,6 @@ __assert_lines() {
     if ! __assert_line "$assertion" "$i" "${expected[$i]}"; then
       ((++num_errors))
     fi
-    set +o functrace
   done
 
   if [[ "$lines_diff" -gt '0' ]]; then
@@ -480,9 +552,8 @@ __assert_lines() {
 
   if [[ "$num_errors" -ne '0' ]]; then
     printf 'OUTPUT:\n%s\n' "$output" >&2
-    result='1'
+    return '1'
   fi
-  return_from_bats_assertion "$BASH_SOURCE" "$result"
 }
 
 # Common implementation for assertions that evaluate a file's contents
@@ -502,8 +573,7 @@ __assert_file() {
   if [[ "$assertion" == 'assert_matches' ]]; then
     if [[ "$#" -ne '1' ]]; then
       echo "ERROR: ${FUNCNAME[1]} takes exactly two arguments" >&2
-      return_from_bats_assertion "$BASH_SOURCE" '1'
-      return
+      return '1'
     fi
     constraints=("$1" "$output" "The content of '$file_path'")
   fi

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -17,31 +17,24 @@ teardown() {
 expect_success() {
   local command="$1"
   local assertion="$2"
+  local __assertion_output
+  local __assertion_status
 
-  eval run $command
-  eval run $assertion
+  run_command_then_run_assertion_in_subshell "$command" "$assertion"
 
-  if [[ "$status" -ne 0 ]]; then
-    printf "In process: expected passing status, actual %d\nOutput:\n%s\n" \
-      "$status" "$output" >&2
+  if [[ "$__assertion_status" -ne '0' ]]; then
+    printf "In subshell: expected passing status, actual %d\nOutput:\n%s\n" \
+      "$__assertion_status" "$__assertion_output" >&2
     return 1
   fi
+  check_expected_output "$__assertion_output"
+  check_sets_functrace "$assertion"
 
-  run_test_script "  run $command" "  $assertion"
-
-  if [[ "$status" -ne 0 ]]; then
-    printf "In script: expected passing status, actual %d\nOutput:\n%s\n" \
-      "$status" "$output" >&2
-    return 1
-  fi
-
-  local __expected_output=('1..1' "ok 1 $BATS_TEST_DESCRIPTION")
-  check_expected_output
-
-  # Redundant checks that the assertion sets `set -o functrace` upon returning,
-  # so that later failures don't show the passing assertion's stack, per issue
-  # #48. Comment out the `check_sets_functrace` call to see the effect.
-  check_sets_functrace "$command" "$assertion"
+  # Although we expect the assertion under test to pass, this script injects a
+  # failing assertion after it as a redundant check that the assertion under
+  # test sets `set -o functrace` upon returning. If it doesn't, the failing
+  # assertion will show the passing assertion's stack, per issue #48. Comment
+  # out the `check_sets_functrace` call to see the effect.
   run_test_script \
     "  run $command" \
     "  $assertion" \
@@ -53,39 +46,28 @@ expect_success() {
     "# (from function \`assert_equal_numbers' in file $TEST_SCRIPT, line 6,"
     "#  in test file $TEST_SCRIPT, line 7)"
     "#   \`assert_equal_numbers 0 1' failed")
-  check_expected_output
+  check_expected_output "$output"
 }
 
 expect_failure() {
   local command="$1"
   local assertion="$2"
   shift 2
+  local __assertion_output
+  local __assertion_status
   local i
 
-  eval run $command
-  eval run $assertion
+  run_command_then_run_assertion_in_subshell "$command" "$assertion"
 
-  if [[ "$status" -eq '0' ]]; then
-    printf "In process: expected failure, but succeeded\nOutput:\n%s\n" \
-      "$output" >&2
+  if [[ "$__assertion_status" -eq '0' ]]; then
+    printf "In subshell: expected failure, but succeeded\nOutput:\n%s\n" \
+      "$__assertion_output" >&2
     return 1
   fi
 
-  # Since an in-process "run" will chomp trailing whitespace off of `$output`,
-  # we have to add it back here to avoid spurious failures.
-  #
-  # If the whitespace is really missing, the call to `check_expected_output` at
-  # the end of the function will catch it, since the test script assertion
-  # failure will get called directly (instead of under `run`) and will keep all
-  # of the whitespace.
   local __expected_output=("$@")
-  for ((i=${#__expected_output[@]} - 1; i != -1; --i)); do
-    if [[ -n "${__expected_output[$i]}" ]]; then
-      break
-    fi
-    output+=$'\n'
-  done
-  check_expected_output
+  check_expected_output "$__assertion_output"
+  check_sets_functrace "$assertion"
 
   run_test_script "  run $command" "  $assertion"
 
@@ -100,8 +82,30 @@ expect_failure() {
     "# (in test file $TEST_SCRIPT, line 5)"
     "#   \`$assertion' failed"
     "${__expected_output[@]/#/# }")
-  check_expected_output
-  check_sets_functrace "$command" "$assertion"
+  check_expected_output "$output"
+}
+
+# The `command` is executed in-process to set `output`, `status`, and `lines`.
+# The `assertion` is executed in a process substitution (subshell) so that its
+# __assertion_output and __assertion_status can be captured and evaluated while
+# leaving `output`, `status`, and `lines` intact for later checks.
+run_command_then_run_assertion_in_subshell() {
+  local command="$1"
+  local assertion="$2"
+  local line
+
+  eval run $command
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [[ "$line" =~ ^exit:([0-9]+)$ ]]; then
+      __assertion_status="${BASH_REMATCH[1]}"
+    else
+      __assertion_output+="$line"$'\n'
+    fi
+  done < <(trap 'echo exit:$?' EXIT; eval $assertion 2>&1; exit "$?")
+
+  # Trim trailing newline to match typical `output` behavior.
+  __assertion_output="${__assertion_output%$'\n'}"
 }
 
 run_test_script() {
@@ -121,12 +125,10 @@ write_failing_test_script() {
 
 # If an assertion fails to `set -o functrace` upon returning, it may cause later
 # assertions to show the earlier assertion in the stack trace. See issue #48.
+#
+# `eval run $command` must be executed before calling this function.
 check_sets_functrace() {
-  local command="$1"
-  local assertion="$2"
-
-  eval run $command
-  set +o functrace
+  local assertion="$1"
   eval $assertion &>/dev/null || :
 
   if [[ ! "$-" =~ T ]]; then
@@ -137,11 +139,12 @@ check_sets_functrace() {
 }
 
 check_expected_output() {
+  local actual_output="$1"
   local IFS=$'\n'
 
-  if [[ "$output" != "${__expected_output[*]}" ]]; then
+  if [[ "$actual_output" != "${__expected_output[*]}" ]]; then
     printf 'EXPECTED:\n%s\n-------\nACTUAL:\n%s\n' \
-      "${__expected_output[*]}" "$output" >&2
+      "${__expected_output[*]}" "$actual_output" >&2
     return 1
   fi
 }

--- a/tests/commands/find.bats
+++ b/tests/commands/find.bats
@@ -25,17 +25,13 @@ teardown() {
   remove_test_go_rootdir
 }
 
-__assert_command_scripts_equal() {
-  unset "BATS_PREVIOUS_STACK_TRACE[0]"
+assert_command_scripts_equal() {
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local result
   local IFS=$'\n'
   unset 'lines[0]' 'lines[1]'
   assert_equal "$*" "${lines[*]#$_GO_ROOTDIR/}" "command scripts"
-}
-
-assert_command_scripts_equal() {
-  set +o functrace
-  __assert_command_scripts_equal "$@"
+  return_from_bats_assertion "$?"
 }
 
 @test "$SUITE: return only builtin commands" {

--- a/tests/log/filters.bats
+++ b/tests/log/filters.bats
@@ -8,7 +8,7 @@ teardown() {
 }
 
 run_log_script_and_assert_success() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   local result=0
 
   run_log_script "$@" \
@@ -22,11 +22,8 @@ run_log_script_and_assert_success() {
     '@go.log DEBUG  debug 3' \
     '@go.log INFO   Goodbye, World!'
 
-  if ! assert_success; then
-    result=1
-  fi
-  set +o functrace
-  return_from_bats_assertion "$BASH_SOURCE" "$result"
+  assert_success
+  return_from_bats_assertion "$?"
 }
 
 @test "$SUITE: default _GO_LOG_LEVEL_FILTER is RUN" {

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -12,22 +12,26 @@ teardown() {
 }
 
 assert_error_on_invalid_input() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   run "$TEST_GO_SCRIPT" "$1"
 
   if [[ "$status" -eq '0' ]]; then
     echo "Expected input to fail validation: $1" >&2
-    return_from_bats_assertion "$BASH_SOURCE" 1
+    return_from_bats_assertion 1
+  else
+    return_from_bats_assertion
   fi
 }
 
 assert_success_on_valid_input() {
-  set +o functrace
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
   run "$TEST_GO_SCRIPT" "$1"
 
   if [[ "$status" -ne '0' ]]; then
     echo "Expected input to pass validation: $1" >&2
-    return_from_bats_assertion "$BASH_SOURCE" 1
+    return_from_bats_assertion 1
+  else
+    return_from_bats_assertion
   fi
 }
 


### PR DESCRIPTION
Closes #51. The short answer is yes, `set -o functrace` can be (and now is) conditional in `return_from_bats_assertion`.

The fuller answer is that all assertions need to `set +eET` as the first line (via the `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"` convention), and `return_from_bats_assertion` will automatically restore these options upon exit from the outermost assertion function. It no longer requires the `$BASH_SOURCE` argument, either, as it can do the right thing based upon the immediate caller's information as provided by Bash.

It's now much easier to compose robust new assertions, even from existing ones, using the `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"` and `return_from_bats_assertions` conventions.

The function comments for `return_from_bats_assertion` contain meticulous details regarding how and why it works, and the file comments for `lib/bats/assertions` now contain sample assertion patterns.

This change also updates a number of assertions from the `tests/` directory to:

- replace `set +o functrace` in the first line with `set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"`
- update their calls to `return_from_bats_assertion`
- remove the no longer necessary `set +o functrace` calls in the rest of the function

Also of note, with greater detail in the commit messages:

- `run_command_then_run_assertion_in_subshell` uses the same process substitution pattern as `@go.log_command` to capture the assertion's results without contaminating the Bats `output`, `status`, and `lines` variables. This helps avoid calling `eval run $command` redundantly, and eliminates the hack from #75 to tack extra newlines onto `output`.

- I was mistaken in #74 when I removed the scrubbing of `BATS_CURRENT_STACK_TRACE[0]`. It turns out that when calling `return_from_bats_assertion` directly, this value will need to be removed. This became apparent after removing `__return_from_bats_assertion` as a step towards making `set -o functrace` conditional upon the immediate caller per #51.

Developing this PR also enhanced my understanding of traps, inspired #77, and introduced me to a particular trap-related Bash bug that led to the removal of `check_sets_functrace` from `tests/assertions.bats`: the `eval $assertion &>/dev/null || :` line for failing assertions would succeed on Bash 4, but cause tests to exit immediately on Bash 3.2. This is due to `bats_teardown_trap` and `bats_exit_trap` from `tests/bats/libexec/bats-exec-test` executing, which I'm pretty sure is due to the following (from the Bash release notes at https://tiswww.case.edu/php/chet/bash/CHANGES):

```
  This document details the changes between this version,
  bash-4.0-alpha, and the previous version, bash-3.2-release.

  ppp. Fixed a bug that caused the `-e' option to be inherited when
       sourcing a file or evaluating a command with `eval' even if the
       return value of the command was supposed to be ignored.
```

The output checks in `expect_success` and `expect_failure` are capable of detecting when an assertion doesn't call `return_from_bats_assertion` to reset `set -eET` anyway.