### PR TITLE
Resolve several maintenance issues

### DIFF
--- a/lib/file
+++ b/lib/file
@@ -130,12 +130,10 @@ fi
 #   output_fds:  Comma-separated list of output file descriptors
 #   ...:         Arguments to pass to the `printf` builtin
 @go.fds_printf() {
-  local origIFS="$IFS"
-  local IFS=','
-  local output_fds=($1)
+  local output_fds=()
   local result=0
 
-  IFS="$origIFS"
+  IFS=',' read -ra output_fds <<<"$1"
   shift
 
   for output_fd in "${output_fds[@]}"; do

--- a/lib/log
+++ b/lib/log
@@ -7,7 +7,7 @@
 #     Outputs a log line; supports terminal formatting and format stripping
 #
 #   @go.log_timestamp
-#     Prints a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
+#     Generates a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
 #
 #   @go.add_or_update_log_level
 #     Modifies existing log level labels, formatting, and file descriptors
@@ -220,10 +220,12 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
     fi
   fi
 
-  log_msg="$(@go.log_timestamp) "
-  # Remove leading space if the timestamp is empty.
-  log_msg="${log_msg# }${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]}"
-  log_msg="${log_msg} ${args[*]}\\e[0m"
+  local __go_log_timestamp
+  if @go.log_timestamp; then
+    log_msg="$__go_log_timestamp "
+  fi
+  log_msg+="${__GO_LOG_LEVELS_FORMATTED[$__go_log_level_index]} "
+  log_msg+="${args[*]}\\e[0m"
 
   local __go_log_level_file_descriptors=()
   _@go.log_level_file_descriptors "$__go_log_level_index"
@@ -258,26 +260,33 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
   return "$exit_status"
 }
 
-# Prints a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
+# Generates a timestamp using _GO_LOG_TIMESTAMP_FORMAT (strftime format)
 #
-# Prints nothing if:
+# Generates nothing and returns an error if:
 #   - _GO_LOG_TIMESTAMP_FORMAT isn't set
 #   - _GO_LOG_TIMESTAMP_FORMAT is set, but both the builtin
 #     `printf '%(datefmt)T'` format and `date` command are missing
 #
 # Globals:
 #   _GO_LOG_TIMESTAMP_FORMAT:  A strftime-compatible format string
+#   __go_log_timestamp:        Variable into which timestamp will be stored
+#
+# Returns:
+#   zero if the timestamp was generated, nonzero otherwise
 @go.log_timestamp() {
   _@go.log_init
 
   case "$__GO_LOG_TIMESTAMP_IMPL" in
   printf)
-    printf "%($_GO_LOG_TIMESTAMP_FORMAT)T"
+    printf -v __go_log_timestamp "%($_GO_LOG_TIMESTAMP_FORMAT)T"
+    return "$?"
     ;;
   date)
-    date "+$_GO_LOG_TIMESTAMP_FORMAT"
+    __go_log_timestamp="$(date "+$_GO_LOG_TIMESTAMP_FORMAT")"
+    return "$?"
     ;;
   esac
+  return 1
 }
 
 # Adds a new log level or updates an existing one.
@@ -665,8 +674,7 @@ _@go.log_level_file_descriptors() {
 #   $1:  The log level label to look up
 #
 # Returns:
-#   0:  if the label exists
-#   1:  if the label does not exist
+#   zero if the label exists, nonzero otherwise
 _@go.log_level_index() {
   local i
   for ((i=0; i != "${#_GO_LOG_LEVELS[@]}"; ++i)); do
@@ -683,6 +691,7 @@ _@go.log_level_index() {
 # Arguments:
 #   level:     A log level index returned from _@go.log_level_index
 #   level_fd:  A file descriptor corresponding to the log level
+#
 # Returns:
 #   zero if the log level is of sufficient priority, nonzero otherwise
 _@go.log_level_meets_priority() {

--- a/lib/log
+++ b/lib/log
@@ -553,7 +553,7 @@ _@go.log_init() {
     readonly __GO_LOG_TIMESTAMP_IMPL='none'
   elif printf "%('%Y')T" &>/dev/null; then
     readonly __GO_LOG_TIMESTAMP_IMPL='printf'
-  elif command -v 'date' >/dev/null; then
+  elif command -v date >/dev/null; then
     readonly __GO_LOG_TIMESTAMP_IMPL='date'
   else
     readonly __GO_LOG_TIMESTAMP_IMPL='none'

--- a/lib/log
+++ b/lib/log
@@ -363,10 +363,7 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
   @go.open_file_or_duplicate_fd "$output_file" 'a' 'output_fd'
 
   if [[ -n "$log_level" ]]; then
-    local origIFS="$IFS"
-    local IFS=','
-    levels=($log_level)
-    IFS="$origIFS"
+    IFS=',' read -ra levels <<<"$log_level"
   else
     levels=("${_GO_LOG_LEVELS[@]}")
   fi
@@ -660,8 +657,8 @@ _@go.log_format_level_labels() {
 # Arguments:
 #   log_level_index:  A log level index returned from _@go.log_level_index
 _@go.log_level_file_descriptors() {
-  local IFS=','
-  __go_log_level_file_descriptors=(${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$1]})
+  IFS=',' read -ra __go_log_level_file_descriptors \
+    <<< "${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$1]}"
 }
 
 # Sets the index into the __GO_LOG arrays for the specified label

--- a/lib/log
+++ b/lib/log
@@ -657,7 +657,8 @@ _@go.log_format_level_labels() {
 # Arguments:
 #   log_level_index:  A log level index returned from _@go.log_level_index
 _@go.log_level_file_descriptors() {
-  IFS=',' read -ra __go_log_level_file_descriptors \
+  local IFS=','
+  read -ra __go_log_level_file_descriptors \
     <<< "${__GO_LOG_LEVELS_FILE_DESCRIPTORS[$1]}"
 }
 

--- a/lib/validation
+++ b/lib/validation
@@ -7,7 +7,7 @@
 #     Ensures input parameters do not contain control or metacharacters
 
 # Pattern used to validate file path and variable name parameters
-readonly __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n'$'\r'']'
+readonly __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n\r'']'
 
 # Ensures input parameters do not contain control or metacharacters
 #

--- a/lib/validation
+++ b/lib/validation
@@ -7,7 +7,7 @@
 #     Ensures input parameters do not contain control or metacharacters
 
 # Pattern used to validate file path and variable name parameters
-readonly __GO_VALIDATE_INPUT_PATTERN='[^\][`";$()&|<>'$'\n\r'']'
+readonly __GO_VALIDATE_INPUT_PATTERN=$'[^\][`";$()&|<>\n\r]'
 
 # Ensures input parameters do not contain control or metacharacters
 #

--- a/libexec/commands
+++ b/libexec/commands
@@ -42,8 +42,7 @@ _@go.summarize_commands() {
 }
 
 _@go.commands_parse_search_paths() {
-  local IFS=':'
-  read -r -a __go_commands_search_paths <<<"$1"
+  IFS=':' read -ra __go_commands_search_paths <<<"$1"
 
   local search_path
   for search_path in "${__go_commands_search_paths[@]}"; do

--- a/libexec/complete
+++ b/libexec/complete
@@ -42,7 +42,7 @@ _@go.complete_command() {
   local __go_complete_word_index
   local __go_cmd_path
   local __go_argv
-  local tab_completions_pattern='# [Tt]ab [Cc]ompletions['$'\n'$'\r'']'
+  local tab_completions_pattern='# [Tt]ab [Cc]ompletions['$'\n\r'']'
 
   . "$_GO_CORE_DIR/lib/internal/complete"
   exec 2>/dev/null

--- a/libexec/glob
+++ b/libexec/glob
@@ -226,7 +226,7 @@ _@go.glob_set_globignore() {
   if [[ -n "$globignore_spec" ]]; then
     local patterns=()
     local IFS=':'
-    read -r -a patterns <<<"$globignore_spec"
+    read -ra patterns <<<"$globignore_spec"
     GLOBIGNORE="${patterns[*]/#/$rootdir/}"
   fi
 }

--- a/libexec/help
+++ b/libexec/help
@@ -108,7 +108,7 @@ _@go.help_message_for_command() {
     return 1
   fi
 
-  local filter_pattern='# [Hh]elp [Ff]ilter['$'\n'$'\r'']'
+  local filter_pattern='# [Hh]elp [Ff]ilter['$'\n\r'']'
 
   if [[ "$(< "$__go_cmd_path")" =~ $filter_pattern ]]; then
     __go_cmd_desc="$(_@go.run_command_script "$__go_cmd_path" --help-filter \

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -495,7 +495,7 @@ export -f test_file_printf
   skip_if_cannot_trigger_file_permission_failure
 
   test_file_printf '\nfoo\n\nbar\n\nbaz\n\n'
-  chmod u-r "$TEST_OUTPUT_FILE"
+  chmod ugo-r "$TEST_OUTPUT_FILE"
   run set_bats_output_and_lines_from_file "$TEST_OUTPUT_FILE"
   assert_failure "You don't have permission to access '$TEST_OUTPUT_FILE'."
 }

--- a/tests/command-descriptions.bats
+++ b/tests/command-descriptions.bats
@@ -95,11 +95,11 @@ create_cmd_path_and_name_go_script() {
     "$((${#cmd_name} + 5))")"
 
   local expected
-  expected="  test-command       Summary for a command parsed"$'\n'
-  expected+="                       from the file header"$'\n'
-  expected+="                       comment that's a bit"$'\n'
-  expected+="                       longer than the current"$'\n'
-  expected+="                       column width"
+  expected=$'  test-command       Summary for a command parsed\n'
+  expected+=$'                       from the file header\n'
+  expected+=$'                       comment that\'s a bit\n'
+  expected+=$'                       longer than the current\n'
+  expected+=$'                       column width'
 
   assert_equal "$expected" "$formatted" 'formatted summary'
 }

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -52,14 +52,15 @@ teardown() {
   run "$TEST_GO_SCRIPT" complete 1 pushd ''
   assert_success 'scripts'
 
-  local prev_IFS="$IFS"
-  local IFS=$'\n'
-  local expected=($(compgen -d "$TEST_GO_SCRIPTS_DIR/"))
-  IFS="$prev_IFS"
-  expected=("${expected[@]#$TEST_GO_ROOTDIR/}")
+  local expected=()
+  local item
+
+  while IFS= read -r item; do
+    expected+=("${item#$TEST_GO_ROOTDIR/}")
+  done<<<"$(compgen -d "$TEST_GO_SCRIPTS_DIR/")"
 
   run "$TEST_GO_SCRIPT" complete 1 cd 'scripts/'
-  IFS=$'\n'
+  local IFS=$'\n'
   assert_success "${expected[*]}"
   run "$TEST_GO_SCRIPT" complete 1 pushd 'scripts/'
   assert_success "${expected[*]}"
@@ -71,13 +72,17 @@ teardown() {
   mkdir -p "${subdirs[@]/#/$TEST_GO_SCRIPTS_DIR/}"
   touch "${files[@]/#/$TEST_GO_SCRIPTS_DIR/}"
 
-  local prevIFS="$IFS"
-  local IFS=$'\n'
-  local top_level=($(compgen -f "$TEST_GO_ROOTDIR/"))
-  local all_scripts_entries=($(compgen -f "$TEST_GO_SCRIPTS_DIR/"))
-  IFS="$prevIFS"
-  top_level=("${top_level[@]#$TEST_GO_ROOTDIR/}")
-  all_scripts_entries=("${all_scripts_entries[@]#$TEST_GO_ROOTDIR/}")
+  local top_level=()
+  local all_scripts_entries=()
+  local item
+
+  while IFS= read -r item; do
+    top_level+=("${item#$TEST_GO_ROOTDIR/}")
+  done <<<"$(compgen -f "$TEST_GO_ROOTDIR/")"
+
+  while IFS= read -r item; do
+    all_scripts_entries+=("${item#$TEST_GO_ROOTDIR/}")
+  done <<<"$(compgen -f "$TEST_GO_SCRIPTS_DIR/")"
 
   run "$TEST_GO_SCRIPT" complete 1 edit ''
   local IFS=$'\n'

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -64,7 +64,7 @@ load environment
   local test_description="${BATS_TEST_DESCRIPTION/$SUITE/\$SUITE}"
   run ./go grep "$test_description" "$BATS_TEST_FILENAME" >&2
 
-  if command -v 'grep'; then
+  if command -v grep >/dev/null; then
     assert_success "@test \"$test_description\" {"
   else
     assert_failure

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -179,7 +179,7 @@ create_file_open_test_go_script() {
   create_file_open_test_go_script \
     "@go.open_file_or_duplicate_fd \"\$file_path\" 'r' \"\$VAR_REF\""
 
-  local var_ref='echo SURPRISE'$'\n''read_fd'
+  local var_ref=$'echo SURPRISE\nread_fd'
   VAR_REF="$var_ref" run "$TEST_GO_SCRIPT"
 
   local err_msg="Bad fd_var_reference argument \"$var_ref\" to "

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -156,9 +156,9 @@ teardown() {
 }
 
 @test "$SUITE: add subcommand summaries" {
-  local cmd_template='# Does {{CMD}} stuff'$'\n'
-  cmd_template+='#'$'\n'
-  cmd_template+='# Usage: {{go}} {{cmd}}'$'\n'
+  local cmd_template=$'# Does {{CMD}} stuff\n'
+  cmd_template+=$'#\n'
+  cmd_template+=$'# Usage: {{go}} {{cmd}}\n'
 
   create_test_command_script 'foo' "${cmd_template/\{\{CMD\}\}/foo}"
   mkdir "$TEST_GO_SCRIPTS_DIR/foo.d"

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -83,11 +83,8 @@ write_kcov_dummy() {
 }
 
 @test "$SUITE: clone and build" {
-  local go_script=(
-    '__check_kcov_dev_packages_installed() { return 1; }'
-    '__clone_and_build_kcov tests/kcov')
-  local IFS=$'\n'
-  write_kcov_go_script "${go_script[*]}"
+  write_kcov_go_script '__check_kcov_dev_packages_installed() { return 1; }' \
+    '__clone_and_build_kcov tests/kcov'
   echo 'mkdir -p "$3"' >> "$FAKE_BIN_DIR/git"
 
   run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
@@ -96,6 +93,7 @@ write_kcov_dummy() {
     "Cloning kcov repository from $__KCOV_URL..."
     'Installing dev packages to build kcov...'
     'Building kcov...')
+  local IFS=$'\n'
   assert_success "${expected_output[*]}"
 
   run cat "$FAKE_BIN_DIR/git.out"
@@ -169,11 +167,8 @@ write_kcov_dummy() {
 }
 
 @test "$SUITE: clone and build doesn't install dev packages on Travis" {
-  local go_script=(
-    '__check_kcov_dev_packages_installed() { return 1; }'
-    '__clone_and_build_kcov tests/kcov')
-  local IFS=$'\n'
-  write_kcov_go_script "${go_script[*]}"
+  write_kcov_go_script '__check_kcov_dev_packages_installed() { return 1; }' \
+    '__clone_and_build_kcov tests/kcov'
 
   mkdir -p "$TEST_GO_ROOTDIR/tests/kcov"
   run env TRAVIS_OS_NAME='linux' "$TEST_GO_SCRIPT"
@@ -218,21 +213,20 @@ write_kcov_dummy() {
     "${kcov_argv[@]:1}"
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
-  local IFS=$'\n'
 
   run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
 
 @test "$SUITE: success after building kcov" {
-  local go_script=(
-    '__clone_and_build_kcov() {'
-    "  mkdir -p '${KCOV_PATH%/*}'"
-    "  printf '#! /usr/bin/env bash\n' >'$KCOV_PATH'"
-    "  chmod 700 '$KCOV_PATH'"
-    '}'
-    "run_kcov ${RUN_KCOV_ARGV[*]} \"$TEST_GO_SCRIPT\" test foo bar/baz")
-  write_kcov_go_script "${go_script[@]}"
+  write_kcov_go_script \
+    '__clone_and_build_kcov() {' \
+    "  mkdir -p '${KCOV_PATH%/*}'" \
+    "  printf '#! /usr/bin/env bash\n' >'$KCOV_PATH'" \
+    "  chmod 700 '$KCOV_PATH'" \
+    '}' \
+    "run_kcov ${RUN_KCOV_ARGV[*]} \"$TEST_GO_SCRIPT\" test foo bar/baz"
 
   local kcov_argv=("${KCOV_ARGV_START[@]}" "$KCOV_COVERAGE_DIR"
     "$TEST_GO_SCRIPT" 'test' 'foo' 'bar/baz')
@@ -241,9 +235,9 @@ write_kcov_dummy() {
     "  ${kcov_argv[*]}"
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
-  local IFS=$'\n'
 
   run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
 
@@ -258,9 +252,9 @@ write_kcov_dummy() {
     'Starting coverage run:'
     "  ${kcov_argv[*]}"
     'kcov exited with errors.')
-  local IFS=$'\n'
 
   run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  local IFS=$'\n'
   assert_failure "${expected_output[*]}"
 }
 
@@ -277,9 +271,9 @@ write_kcov_dummy() {
     "  ${kcov_argv[*]}"
     'Coverage results sent to:'
     "  $KCOV_COVERALLS_URL")
-  local IFS=$'\n'
 
   run env TRAVIS_JOB_ID=666 "$TEST_GO_SCRIPT"
+  local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
 
@@ -301,8 +295,8 @@ write_kcov_dummy() {
     "  ${kcov_argv[*]}"
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
-  local IFS=$'\n'
 
   run env TRAVIS_JOB_ID=666 "$TEST_GO_SCRIPT"
+  local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }

--- a/tests/log/add-output-file.bats
+++ b/tests/log/add-output-file.bats
@@ -90,10 +90,11 @@ run_log_script_and_assert_status_and_output() {
   run_log_script_and_assert_status_and_output \
     "@go.log_add_output_file '$TEST_GO_ROOTDIR/error.log' 'ERROR,FATAL'"
 
-  local origIFS="$IFS"
-  local IFS=$'\n'
-  local error_log=($(< "$TEST_GO_ROOTDIR/error.log"))
-  IFS="$origIFS"
+  local error_log=()
+  local item
+  while IFS= read -r item; do
+    error_log+=("$item")
+  done <<<"$(< "$TEST_GO_ROOTDIR/error.log")"
 
   assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
   assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'
@@ -118,10 +119,11 @@ run_log_script_and_assert_status_and_output() {
   assert_matches "^FOOBAR +$msg$" \
     "$(< "$TEST_GO_ROOTDIR/foobar.log")" 'foobar.log'
 
-  local origIFS="$IFS"
-  local IFS=$'\n'
-  local error_log=($(< "$TEST_GO_ROOTDIR/error.log"))
-  IFS="$origIFS"
+  local error_log=()
+  local item
+  while IFS= read -r item; do
+    error_log+=("$item")
+  done <<<"$(< "$TEST_GO_ROOTDIR/error.log")"
 
   assert_equal '3' "${#error_log[@]}" 'Number of error log lines'
   assert_matches '^ERROR +uh-oh$' "${error_log[0]}" 'ERROR log message'

--- a/tests/log/log-command.bats
+++ b/tests/log/log-command.bats
@@ -402,7 +402,7 @@ teardown() {
 }
 
 @test "$SUITE: exit status from subcommand in other language" {
-  if ! command -v perl &>/dev/null; then
+  if ! command -v perl >/dev/null; then
     skip 'perl not installed'
   fi
 
@@ -428,7 +428,7 @@ teardown() {
 }
 
 @test "$SUITE: fatal status for subcommand of command in another language" {
-  if ! command -v perl &>/dev/null; then
+  if ! command -v perl >/dev/null; then
     skip 'perl not installed'
   fi
 
@@ -481,7 +481,7 @@ teardown() {
 }
 
 @test "$SUITE: subcommand of command in other language appends to all logs" {
-  if ! command -v perl &>/dev/null; then
+  if ! command -v perl >/dev/null; then
     skip 'perl not installed'
   fi
 

--- a/tests/log/timestamp.bats
+++ b/tests/log/timestamp.bats
@@ -26,16 +26,21 @@ setup() {
     'fi'
 
   create_test_go_script '. "$_GO_USE_MODULES" log' \
-    '@go.log_timestamp'
+    'declare __go_log_timestamp' \
+    'if @go.log_timestamp; then' \
+    "  printf '%s' \"\$__go_log_timestamp\"" \
+    'else' \
+    '  exit 1' \
+    'fi'
 }
 
 teardown() {
   remove_test_go_rootdir
 }
 
-@test "$SUITE: return empty value if _GO_LOG_TIMESTAMP_FORMAT not set" {
+@test "$SUITE: return error if _GO_LOG_TIMESTAMP_FORMAT not set" {
   _GO_LOG_TIMESTAMP_FORMAT= PATH="$TEST_PATH" run "$BASH" "$TEST_GO_SCRIPT"
-  assert_success ''
+  assert_failure
 
   if [[ -f "$DATE_CMD_FILE" ]]; then
     fail 'date command was called'
@@ -74,13 +79,13 @@ teardown() {
   fi
 }
 
-@test "$SUITE: return empty value if builtin format and date command missing" {
+@test "$SUITE: return error value if builtin format and date command missing" {
   if [[ -n "$HAS_TIMESTAMP_BUILTIN" ]]; then
     skip "Builtin format available in bash version $BASH_VERSION"
   fi
 
   _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH= run "$BASH" "$TEST_GO_SCRIPT"
-  assert_success
+  assert_failure
   assert_output_matches \
     '^WARN +Builtin timestamps not supported and date command not found.$'
 

--- a/tests/modules/helpers.bash
+++ b/tests/modules/helpers.bash
@@ -31,7 +31,7 @@ setup_test_modules() {
   for module in "${TEST_PLUGIN_MODULES[@]}"; do
     module_file="$TEST_GO_PLUGINS_DIR/${module/\///lib/}"
     mkdir -p "${module_file%/*}"
-    echo "# Summary for $module"$'\n' > "$module_file"
+    printf '# Summary for %s\n' "$module" > "$module_file"
     TEST_PLUGIN_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
     ((++TOTAL_NUM_MODULES))
   done
@@ -39,7 +39,7 @@ setup_test_modules() {
   for module in "${TEST_PROJECT_MODULES[@]}"; do
     module_file="$TEST_GO_SCRIPTS_DIR/lib/$module"
     mkdir -p "${module_file%/*}"
-    echo "# Summary for $module" > "$module_file"
+    printf '# Summary for %s\n' "$module" > "$module_file"
     TEST_PROJECT_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
     ((++TOTAL_NUM_MODULES))
   done

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -135,18 +135,18 @@ get_first_and_last_core_module_summaries() {
 
   # Note the two newlines at the end of each class section.
   assert_output_matches "  ${CORE_MODULES[0]} +${CORE_MODULES_PATHS[0]}"$'\n'
-  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MODULE_PATH"$'\n'$'\n'
+  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MODULE_PATH"$'\n\n'
 
   # Note the padding is relative to only the plugin modules. Use a variable to
   # keep the assertion lines under 80 columns.
   local plugins='scripts/plugins'
   assert_output_matches "  _bar/_plugh  $plugins/_bar/lib/_plugh"$'\n'
   assert_output_matches "  _foo/_quux   $plugins/_foo/lib/_quux"$'\n'
-  assert_output_matches "  _foo/_xyzzy  $plugins/_foo/lib/_xyzzy"$'\n'$'\n'
+  assert_output_matches "  _foo/_xyzzy  $plugins/_foo/lib/_xyzzy"$'\n\n'
 
   # Note the padding is relative to only the project modules. Bats trims
   # the last newline of the output.
-  assert_output_matches "  _frobozz  scripts/lib/_frobozz"$'\n'
+  assert_output_matches $'  _frobozz  scripts/lib/_frobozz\n'
   assert_output_matches "  _frotz    scripts/lib/_frotz$"
 
   # Since the 'lines' array doesn't contain blank lines, we only add '3' to
@@ -166,15 +166,15 @@ get_first_and_last_core_module_summaries() {
   assert_output_matches \
     $'\n'"$LAST_CORE_MODULE  +$LAST_CORE_MODULE_PATH"$'\n'
   assert_output_matches \
-    $'\n'"_bar/_plugh  +scripts/plugins/_bar/lib/_plugh"$'\n'
+    $'\n_bar/_plugh  +scripts/plugins/_bar/lib/_plugh\n'
   assert_output_matches \
-    $'\n'"_foo/_quux   +scripts/plugins/_foo/lib/_quux"$'\n'
+    $'\n_foo/_quux   +scripts/plugins/_foo/lib/_quux\n'
   assert_output_matches \
-    $'\n'"_foo/_xyzzy  +scripts/plugins/_foo/lib/_xyzzy"$'\n'
+    $'\n_foo/_xyzzy  +scripts/plugins/_foo/lib/_xyzzy\n'
   assert_output_matches \
-    $'\n'"_frobozz     +scripts/lib/_frobozz"$'\n'
+    $'\n_frobozz     +scripts/lib/_frobozz\n'
   assert_output_matches \
-    $'\n'"_frotz       +scripts/lib/_frotz$"
+    $'\n_frotz       +scripts/lib/_frotz$'
 
   assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
 }
@@ -186,16 +186,16 @@ get_first_and_last_core_module_summaries() {
   # Note the two newlines at the end of each class section.
   get_first_and_last_core_module_summaries
   assert_output_matches "  ${CORE_MODULES[0]} +$FIRST_CORE_MOD_SUMMARY"$'\n'
-  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MOD_SUMMARY"$'\n'$'\n'
+  assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MOD_SUMMARY"$'\n\n'
 
   # Note the padding is relative to only the plugin modules.
-  assert_output_matches "  _bar/_plugh  Summary for _bar/_plugh"$'\n'
-  assert_output_matches "  _foo/_quux   Summary for _foo/_quux"$'\n'
-  assert_output_matches "  _foo/_xyzzy  Summary for _foo/_xyzzy"$'\n'$'\n'
+  assert_output_matches $'  _bar/_plugh  Summary for _bar/_plugh\n'
+  assert_output_matches $'  _foo/_quux   Summary for _foo/_quux\n'
+  assert_output_matches $'  _foo/_xyzzy  Summary for _foo/_xyzzy\n\n'
 
   # Note the padding is relative to only the project modules. Bats trims
   # the last newline of the output.
-  assert_output_matches "  _frobozz  Summary for _frobozz"$'\n'
+  assert_output_matches $'  _frobozz  Summary for _frobozz\n'
   assert_output_matches "  _frotz    Summary for _frotz$"
 
   # Since the 'lines' array doesn't contain blank lines, we only add '3' to
@@ -212,12 +212,12 @@ get_first_and_last_core_module_summaries() {
   # delimited by back-to-back newlines. Bats trims the final newline.
   get_first_and_last_core_module_summaries
   assert_output_matches "${CORE_MODULES[0]}  +$FIRST_CORE_MOD_SUMMARY"$'\n'
-  assert_output_matches $'\n'"$LAST_CORE_MODULE  +$LAST_CORE_MOD_SUMMARY"$'\n'
-  assert_output_matches $'\n'"_bar/_plugh  +Summary for _bar/_plugh"$'\n'
-  assert_output_matches $'\n'"_foo/_quux   +Summary for _foo/_quux"$'\n'
-  assert_output_matches $'\n'"_foo/_xyzzy  +Summary for _foo/_xyzzy"$'\n'
-  assert_output_matches $'\n'"_frobozz     +Summary for _frobozz"$'\n'
-  assert_output_matches $'\n'"_frotz       +Summary for _frotz$"
+  assert_output_matches "$LAST_CORE_MODULE  +$LAST_CORE_MOD_SUMMARY"$'\n'
+  assert_output_matches $'_bar/_plugh  +Summary for _bar/_plugh\n'
+  assert_output_matches $'_foo/_quux   +Summary for _foo/_quux\n'
+  assert_output_matches $'_foo/_xyzzy  +Summary for _foo/_xyzzy\n'
+  assert_output_matches $'_frobozz     +Summary for _frobozz\n'
+  assert_output_matches $'_frotz       +Summary for _frotz$'
 
   assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
 }

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -46,8 +46,8 @@ assert_success_on_valid_input() {
   assert_error_on_invalid_input 'foo|bar'
   assert_error_on_invalid_input 'foo<bar'
   assert_error_on_invalid_input 'foo>bar'
-  assert_error_on_invalid_input 'foo'$'\n''bar'
-  assert_error_on_invalid_input 'foo'$'\r''bar'
+  assert_error_on_invalid_input $'foo\nbar'
+  assert_error_on_invalid_input $'foo\rbar'
   assert_error_on_invalid_input "\`echo SURPRISE >&2\`$FILE_PATH"
   assert_error_on_invalid_input "$FILE_PATH\"; echo 'SURPRISE'"
 }
@@ -64,8 +64,8 @@ assert_success_on_valid_input() {
   assert_success_on_valid_input 'foo\|bar'
   assert_success_on_valid_input 'foo\<bar'
   assert_success_on_valid_input 'foo\>bar'
-  assert_success_on_valid_input "foo\\'\\\$\\'\n''bar"
-  assert_success_on_valid_input "foo\\'\\\$\\'\r''bar"
+  assert_success_on_valid_input "\$'foo\nbar'"
+  assert_success_on_valid_input "\$'foo\nbar'"
   assert_success_on_valid_input '\`echo SURPRISE \>\&2\`\$FILE_PATH'
   assert_success_on_valid_input "\\\$FILE_PATH\\\"\\; echo 'SURPRISE'"
 }

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -96,7 +96,7 @@ quotify_expected() {
 # we use Perl to ensure they are are exported to new processes that run command
 # scripts in languages other than Bash.
 @test "$SUITE: run perl script; _GO_* variables are exported" {
-  if ! command -v perl; then
+  if ! command -v perl >/dev/null; then
     skip 'perl not installed'
   fi
 


### PR DESCRIPTION
Closes #59, which turned out not to be too much of an issue after all. In fact, I've set the redirection to `>/dev/null` instead of `&>/dev/null`, since `command -v` typically prints nothing when the command isn't found, and I'd like to see any error output if it ever comes to exist.

Closes #69. Note that in cases where the `\n` is concatenated with a string that contains a variable expansion, the single `$'\n'` must stand, because variable expansion does not take place within `$'...'`.

Closes #76.

Fixes a test failure on Cygwin. Because group read permission wasn't disabled, the test case `set_bats_output_and_lines_from_file fails if permission denied` failed on Cygwin. As a rule, it's probably best to always set `ugo-` in tests. (Also considering updating the octal `chmod` arguments to the `ugo-` variety. But not today.)

Fulfills part of #62. `@go.split` and `@go.join` may come in a future commit.