### PR TITLE
Refactor `@go.printf`, `@go.print_stack_trace`

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -170,18 +170,18 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
 # from the resulting stack trace.
 #
 # Arguments:
-#   skip_callers: The number of callers to skip over when printing the stack
+#   skip_callers:  The number of callers to skip over when printing the stack
 @go.print_stack_trace() {
   local skip_callers="$1"
   local result=0
   local i
 
   if [[ -n "$skip_callers" && ! "$skip_callers" =~ ^[1-9][0-9]*$ ]]; then
-    @go.printf '%s argument %s not a positive integer; printing full stack\n' \
+    printf '%s argument %s not a positive integer; printing full stack\n' \
       "$FUNCNAME" "'$skip_callers'" >&2
     result=1
   elif [[ "$skip_callers" -ge "${#FUNCNAME[@]}" ]]; then
-    @go.printf '%s argument %d exceeds stack size %d; printing full stack\n' \
+    printf '%s argument %d exceeds stack size %d; printing full stack\n' \
       "$FUNCNAME" "$skip_callers" "$((${#FUNCNAME[@]} - 1))" >&2
     result=1
   fi
@@ -191,7 +191,7 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
   fi
 
   for ((i=$skip_callers + 1; i != ${#FUNCNAME[@]}; ++i)); do
-    @go.printf '  %s:%s %s\n' "${BASH_SOURCE[$i]}" "${BASH_LINENO[$((i-1))]}" \
+    printf '  %s:%s %s\n' "${BASH_SOURCE[$i]}" "${BASH_LINENO[$((i-1))]}" \
       "${FUNCNAME[$i]}"
   done
   return "$result"

--- a/go-core.bash
+++ b/go-core.bash
@@ -134,6 +134,7 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
   local result
   local line
   local prefix
+  local IFS=
 
   if [[ "$#" -eq 0 ]]; then
     format="${format//\%/%%}"
@@ -141,7 +142,7 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
   # If `format` ends with a newline, chomp it, since the loop will add one.
   printf -v result "${format%\\n}" "$@"
 
-  while IFS= read -r line; do
+  while read -r line; do
     line="${line%$'\r'}"
 
     while [[ "${#line}" -gt "$COLUMNS" ]]; do
@@ -149,10 +150,10 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
       prefix="${prefix% *}"
       line="${line#$prefix}"
 
-      if [[ "$prefix" =~ \ +$ ]]; then
+      if [[ "$prefix" =~ [[:space:]]+$ ]]; then
         prefix="${prefix%${BASH_REMATCH[0]}}"
       fi
-      if [[ "$line" =~ ^\ + ]]; then
+      if [[ "$line" =~ ^[[:space:]]+ ]]; then
         line="${line#${BASH_REMATCH[0]}}"
       fi
       printf '%s\n' "$prefix"


### PR DESCRIPTION
Couple of very minor touch-ups done while developing `@go.split` and `@go.join` per #62 and #81.