### PR TITLE
Add identifier validation, fatal funcs

### DIFF
--- a/lib/file
+++ b/lib/file
@@ -50,18 +50,15 @@ fi
 #   mode:              File operation mode: r, w, a, or rw
 #   fd_var_reference:  Name of variable to which to assign new fd value
 @go.open_file_or_duplicate_fd() {
+  @go.validate_input_or_die 'file_path_or_fd' "$1"
+  @go.validate_identifier_or_die 'fd_var_reference' "$3"
   local file_path_or_fd="$1"
   local mode="$2"
   local fd_var_reference="$3"
   local bash_mode
   local i
 
-  if ! @go.validate_input "$file_path_or_fd"; then
-    printf 'Bad file_path_or_fd argument \"%s\" to %s at:\n' \
-      "$file_path_or_fd" "$FUNCNAME" >&2
-    @go.print_stack_trace '1' >&2
-    exit 1
-  elif [[ "$file_path_or_fd" =~ $__GO_FILE_DESCRIPTOR_PATTERN ]]; then
+  if [[ "$file_path_or_fd" =~ $__GO_FILE_DESCRIPTOR_PATTERN ]]; then
     file_path_or_fd="&$file_path_or_fd"
   else
     file_path_or_fd="\"$file_path_or_fd\""
@@ -86,17 +83,6 @@ fi
     exit 1
     ;;
   esac
-
-  if [[ -z "$fd_var_reference" ]]; then
-    echo "No variable reference given for the resulting file descriptor." >&2
-    @go.print_stack_trace '1' >&2
-    exit 1
-  elif ! @go.validate_input "$fd_var_reference"; then
-    printf 'Bad fd_var_reference argument \"%s\" to %s at:\n' \
-      "$fd_var_reference" "$FUNCNAME" >&2
-    @go.print_stack_trace '1' >&2
-    exit 1
-  fi
 
   for ((i=_GO_START_FD; i != _GO_MAX_FILE_DESCRIPTORS; ++i)); do
     if [[ ! -e "/dev/fd/$i" ]]; then

--- a/lib/validation
+++ b/lib/validation
@@ -1,23 +1,102 @@
 #! /usr/bin/env bash
 #
-# Input validation
+# Input validation for `eval`, `declare`, etc. arguments
 #
 # Exports:
 #   @go.validate_input
-#     Ensures input parameters do not contain control or metacharacters
-
-# Pattern used to validate file path and variable name parameters
-readonly __GO_VALIDATE_INPUT_PATTERN=$'[^\][`";$()&|<>\n\r]'
-
-# Ensures input parameters do not contain control or metacharacters
+#     Ensures an input value does not contain control or metacharacters
 #
-# This is useful to prevent `eval` from either throwing errors or executing
-# code from malicious input values. 
+#   @go.validate_input_or_die
+#     Wraps `@go.validate_input` to print an error and exit on failure
+#
+#   @go.validate_identifier
+#     Ensures the value is a valid identifier name
+#
+#   @go.validate_identifier_or_die
+#     Wraps `@go.validate_identifier` to print an error and exit on failure
+#
+# These functions should be used to validate function parameters or other input
+# values before using them as arguments to `eval`, `declare`, `local`, `global`,
+# or `readonly`, to prevent them from either throwing errors or executing code
+# from malicious input values.
+
+# Set of characters that must be escaped to be considered valid input
+readonly __GO_DANGEROUS_INPUT_CHARACTERS=$'`";$()&|<>\n\r'
+
+# Pattern used to validate input values to ensure they're safe
+readonly __GO_VALIDATE_INPUT_PATTERN=$'[^\]'"[$__GO_DANGEROUS_INPUT_CHARACTERS]"
+
+# Pattern used to validate identifier names passed as function arguments
+readonly __GO_VALID_IDENTIFIER_PATTERN='^[[:alpha:]_][[:alnum:]_]*$'
+
+# Ensures an input value does not contain control or metacharacters
 #
 # Arguments:
-#   input_value:  The value to examine for invalid characters
+#   value:  The value to examine for invalid characters
 # Returns:
 #   0 on success; nonzero on failure
 @go.validate_input() {
   [[ ! "$1" =~ $__GO_VALIDATE_INPUT_PATTERN ]]
+}
+
+# Wraps `@go.validate_input` to print an error and exit on failure
+#
+# Arguments:
+#   description:   Description of the value to use in the error message
+#   value:         The value to examine for invalid characters
+#   skip_callers:  The number of callers to skip over when printing the stack;
+#                    defaults to 2 (to show the caller's caller at the top)
+@go.validate_input_or_die() {
+  local description="$1"
+  local value="$2"
+  local skip_callers="${3:-2}"
+
+  if ! @go.validate_input "$value"; then
+    printf '%s "%s" for %s contains invalid characters at:\n' \
+      "$description" "$value" "${FUNCNAME[$((skip_callers - 1))]}" >&2
+    @go.print_stack_trace "$skip_callers" >&2
+    exit 1
+  fi
+}
+
+# Ensures the value is a valid identifier name
+#
+# Specifically useful for implementing functions that return values using a
+# caller-specified variable, using `eval "$variable=\$value"` to assign to it.
+#
+# Arguments:
+#   value:  The value to examine for invalid identifier characters
+# Returns:
+#   0 on success; nonzero on failure
+@go.validate_identifier() {
+  [[ "$1" =~ $__GO_VALID_IDENTIFIER_PATTERN ]]
+}
+
+# Wraps `@go.validate_identifier` to print an error and exit on failure
+#
+# Arguments:
+#   description:   Description of the value to use in the error message
+#   value:         The value to examine for invalid identifier characters
+#   skip_callers:  The number of callers to skip over when printing the stack;
+#                    defaults to 2 (to show the caller's caller at the top)
+@go.validate_identifier_or_die() {
+  local description="$1"
+  local value="$2"
+  local skip_callers="${3:-2}"
+  local err_msg
+  local called_func="${FUNCNAME[$((skip_callers - 1))]}"
+
+  if ! @go.validate_identifier "$value"; then
+    if [[ -z "$value" ]]; then
+      err_msg='must not be empty'
+    elif [[ "$value" =~ ^[0-9] ]]; then
+      err_msg='must not start with a number'
+    else
+      err_msg='contains invalid identifier characters'
+    fi
+    printf '%s "%s" for %s %s at:\n' \
+      "$description" "$value" "$called_func" "$err_msg" >&2
+    @go.print_stack_trace "$skip_callers" >&2
+    exit 1
+  fi
 }

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -144,8 +144,9 @@ create_file_open_test_go_script() {
   local file_path_or_fd="\`echo SURPRISE >&2\`$FILE_PATH"
   FILE_PATH_OR_FD="$file_path_or_fd" run "$TEST_GO_SCRIPT"
 
-  local err_msg="Bad file_path_or_fd argument \"$file_path_or_fd\" to "
-  err_msg+='@go.open_file_or_duplicate_fd at:'
+  local err_msg="file_path_or_fd \"$file_path_or_fd\" "
+  err_msg+='for @go.open_file_or_duplicate_fd contains invalid characters at:'
+
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
   local IFS=$'\n'
@@ -168,8 +169,10 @@ create_file_open_test_go_script() {
     '@go.open_file_or_duplicate_fd "$file_path" "r"'
   run "$TEST_GO_SCRIPT"
 
-  local expected=(
-    'No variable reference given for the resulting file descriptor.'
+  local err_msg='fd_var_reference "" for @go.open_file_or_duplicate_fd '
+  err_msg+='must not be empty at:'
+
+  local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
   local IFS=$'\n'
   assert_failure "${expected[*]}"
@@ -182,8 +185,10 @@ create_file_open_test_go_script() {
   local var_ref=$'echo SURPRISE\nread_fd'
   VAR_REF="$var_ref" run "$TEST_GO_SCRIPT"
 
-  local err_msg="Bad fd_var_reference argument \"$var_ref\" to "
-  err_msg+='@go.open_file_or_duplicate_fd at:'
+  local err_msg="fd_var_reference \"$var_ref\" "
+  err_msg+='for @go.open_file_or_duplicate_fd '
+  err_msg+='contains invalid identifier characters at:'
+
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
   local IFS=$'\n'


### PR DESCRIPTION
It seems the more common validation case I need so far is for validating that callers are passing in the correct variable name for an `eval "$var=\$value"` assignment. It also seemed like a good idea to include fatal versions of these functions, since in many cases it is a programmer error when validation fails and the program should crash loudly.

Also updates `@go.open_file_or_duplicate_fd` to use these new fatal functions, since they produce standard error messages and stack traces that replace those previously implemented directly in
`@go.open_file_or_duplicate_fd`.