### PR TITLE
Add `strings` module, apply `@go.join` and `@go.split` functions

### DIFF
--- a/lib/file
+++ b/lib/file
@@ -30,7 +30,7 @@ if [[ ! "$_GO_MAX_FILE_DESCRIPTORS" =~ $__GO_FILE_DESCRIPTOR_PATTERN ||
   exit 1
 fi
 
-. "$_GO_USE_MODULES" 'validation'
+. "$_GO_USE_MODULES" 'strings' 'validation'
 
 # Opens a file or duplicates an existing descriptor, and returns the new fd.
 #
@@ -119,7 +119,7 @@ fi
   local output_fds=()
   local result=0
 
-  IFS=',' read -ra output_fds <<<"$1"
+  @go.split ',' "$1" 'output_fds'
   shift
 
   for output_fd in "${output_fds[@]}"; do

--- a/lib/log
+++ b/lib/log
@@ -359,11 +359,11 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
       "logging already initialized"
   fi
 
-  . "$_GO_USE_MODULES" 'file'
+  . "$_GO_USE_MODULES" 'file' 'strings'
   @go.open_file_or_duplicate_fd "$output_file" 'a' 'output_fd'
 
   if [[ -n "$log_level" ]]; then
-    IFS=',' read -ra levels <<<"$log_level"
+    @go.split ',' "$log_level" 'levels'
   else
     levels=("${_GO_LOG_LEVELS[@]}")
   fi

--- a/lib/strings
+++ b/lib/strings
@@ -1,0 +1,56 @@
+#! /usr/bin/env bash
+#
+# String maniuplation functions
+#
+# Exports:
+#   @go.split
+#     Splits fields from a delimited string into an array defined by the caller
+#
+#   @go.join
+#     Joins multiple items into a string variable defined by the caller
+#
+# These functions help avoid `IFS`-related pitfalls as described by:
+#
+#   http://mywiki.wooledge.org/Arguments
+
+. "$_GO_USE_MODULES" 'validation'
+
+# Splits fields from a delimited string into an array defined by the caller
+#
+# While `IFS= read -ra array_name <<<"$value"` is idiomatic, this function
+# guards against a bug in Bash 4.2.25 (the version in the Ubuntu Precise image
+# used by Travis CI) and not fixed until 4.2.41 whereby the temporary
+# environment of `IFS= read` isn't honored when running in a process
+# substitution. For details, see the message for commit
+# 99ab7805e6ef0a14568d8a100eec03bb2cb03631.
+#
+# Strangely `while IFS= read` does work as expected. See the message for commit
+# 2297b48e3851323c9bfcb567ad794ec58a846d1b.
+#
+# Note that there is no way to escape the delimiter value to make it appear as a
+# valid character in a field.
+#
+# Arguments:
+#   delimiter:   The character separating individual fields
+#   value:       The string to split into individual fields
+#   array_name:  Name of caller's array variable into which to store fields
+@go.split() {
+  @go.validate_identifier_or_die 'Result array name' "$3"
+  local IFS="$1"
+  read -ra "$3" <<<"$2"
+}
+
+# Joins multiple items into a string variable defined by the caller
+#
+# Encapsulates the use of `IFS` to avoid polluting other portions of the script,
+# and to avoid the need for saving and restoring the original `IFS` value.
+#
+# Arguments:
+#   delimiter:  The character separating individual fields
+#   var_name:   Name of caller's variable to which to assign the joined string
+#   ...:        Elements to join into a string assigned to `var_name`
+@go.join() {
+  @go.validate_identifier_or_die 'Result variable name' "$2"
+  local IFS="$1"
+  eval "$2=\"\${*:3}\""
+}

--- a/libexec/commands
+++ b/libexec/commands
@@ -42,7 +42,8 @@ _@go.summarize_commands() {
 }
 
 _@go.commands_parse_search_paths() {
-  IFS=':' read -ra __go_commands_search_paths <<<"$1"
+  . "$_GO_USE_MODULES" 'strings'
+  @go.split ':' "$1" '__go_commands_search_paths'
 
   local search_path
   for search_path in "${__go_commands_search_paths[@]}"; do

--- a/libexec/fullpath
+++ b/libexec/fullpath
@@ -41,7 +41,7 @@ _@go.fullpath() {
 
   local arg
   local expanded
-  local IFS=$'\n'
+  local IFS=
 
   for arg in "$@"; do
     if [[ "${arg:0:1}" != '/' ]]; then

--- a/libexec/glob
+++ b/libexec/glob
@@ -58,7 +58,7 @@ _@go.glob_impl() {
   fi
 
   # Setting IFS ensures that matching paths with spaces are handled properly.
-  local IFS=$'\n'
+  local IFS=
   local __go_glob_impl_matches=()
   _@go.glob_impl_helper "$pattern"
 

--- a/libexec/help
+++ b/libexec/help
@@ -56,13 +56,11 @@
 
 _@go.usage() {
   local cmd_paths=("${_GO_PLUGINS_PATHS[@]}" "$_GO_SCRIPTS_DIR")
-  local origIFS="$IFS"
-  local IFS=':'
   local summaries
   local summaries_status=0
 
-  cmd_paths="${cmd_paths[*]}"
-  IFS="$origIFS"
+  . "$_GO_USE_MODULES" 'strings'
+  @go.join ':' 'cmd_paths' "${cmd_paths[@]}"
   summaries="$(_@go.source_builtin 'commands' --summaries "$cmd_paths")"
 
   if [[ "$?" -ne '0' ]]; then

--- a/tests/strings/helpers.bash
+++ b/tests/strings/helpers.bash
@@ -1,0 +1,7 @@
+#! /bin/bash
+#
+# Helper functions for `lib/strings` tests
+
+create_strings_test_script() {
+  create_test_go_script '. "$_GO_USE_MODULES" strings' "$@"
+}

--- a/tests/strings/join.bats
+++ b/tests/strings/join.bats
@@ -1,0 +1,52 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: error if result variable name not a valid identifier" {
+  create_strings_test_script '@go.join "," "invalid;" "foo" "bar" "baz"'
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='^Result variable name "invalid;" for @go.join '
+  err_msg+='contains invalid identifier characters at:$'
+
+  assert_lines_match "$err_msg" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: empty string" {
+  create_strings_test_script 'declare result=()' \
+    '@go.join "," "result" ""' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: single item" {
+  create_strings_test_script 'declare result=()' \
+    '@go.join "," "result" "foo"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo'
+}
+
+@test "$SUITE: multiple items" {
+  create_strings_test_script 'declare result=()' \
+    '@go.join "," "result" "foo" "bar" "baz"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo,bar,baz'
+}
+
+@test "$SUITE: join items into same variable" {
+  create_strings_test_script 'declare items=("foo" "bar" "baz")' \
+    '@go.join "," "items" "${items[@]}"' \
+    'echo "$items"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo,bar,baz'
+}

--- a/tests/strings/split.bats
+++ b/tests/strings/split.bats
@@ -1,0 +1,51 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+teardown() {
+  remove_test_go_rootdir
+}
+
+@test "$SUITE: error if result array name not a valid identifier" {
+  create_strings_test_script '@go.split "," "foo,bar,baz" "invalid;"'
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='^Result array name "invalid;" for @go.split '
+  err_msg+='contains invalid identifier characters at:$'
+  assert_lines_match "$err_msg" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: empty string" {
+  create_strings_test_script 'declare result=()' \
+    '@go.split "," "" "result"' \
+    'echo "${result[@]}"'
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: single item" {
+  create_strings_test_script 'declare result=()' \
+    '@go.split "," "foo" "result"' \
+    'echo "${result[@]}"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo'
+}
+
+@test "$SUITE: multiple items" {
+  create_strings_test_script 'declare result=()' \
+    '@go.split "," "foo,bar,baz" "result"' \
+    'echo "${result[@]}"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar baz'
+}
+
+@test "$SUITE: split items into same variable" {
+  create_strings_test_script 'declare items="foo,bar,baz"' \
+    '@go.split "," "$items" "items"' \
+    'echo "${items[@]}"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar baz'
+}


### PR DESCRIPTION
Closes #62. The urgent need for `@go.split` in particular was made apparent during the course of implementing #81, whereby Travis's Linux build running Bash 4.2.25(1)-release caused the `log/log-command` test to expose a bug whereby the temporary environment for `IFS=, read` in `_@go.log_level_file_descriptors` wasn't honored inside of process substitutions. Also see the message for commit 99ab7805e6ef0a14568d8a100eec03bb2cb03631.

Since `@go.log_command` uses a process substitution to capture command output, and thus potentially any `./go` script command could be so captured, the need for `@go.split` to encapsulate (and document) the workaround for this bug became a priority.

Strangely, `while IFS= read` invocations (such as the one in `@go.log_command`) aren't affected by the bug, so those don't require any special treatment. See the message for commit 2297b48e3851323c9bfcb567ad794ec58a846d1b, also from this PR.