### PR TITLE
Add `@go.strip_formatting_codes` for `@go.log`

### DIFF
--- a/lib/format
+++ b/lib/format
@@ -9,6 +9,9 @@
 #
 #   @go.zip_items
 #     Concatenates parallel elements from each input array
+#
+#   @go.strip_formatting_codes
+#     Strips ANSI escape codes of the form `\e[...(;...)m` from a string
 
 # Pads each string in an array to match the length of the longest element
 #
@@ -55,5 +58,22 @@
   for item in "${!lhs_array_reference}"; do
     rhs_item_ref="${rhs_reference}[$((++i))]"
     __go_zipped_result+=("${item}${delimiter}${!rhs_item_ref}")
+  done
+}
+
+# Strips ANSI escape codes of the form `\e[...(;...)m` from a string
+#
+# Used primarily by `@go.log`.
+#
+# Arguments:
+#   $1: The string to strip
+# Outputs:
+#   __go_stripped_value:  The caller-declared variable for the stripped result
+@go.strip_formatting_codes() {
+  __go_stripped_value="$1"
+  local format_pattern='\\e\[[0-9]{1,3}(;[0-9]{1,3})*m'
+
+  while [[ "$__go_stripped_value" =~ $format_pattern ]]; do
+    __go_stripped_value="${__go_stripped_value/"${BASH_REMATCH[0]}"}"
   done
 }

--- a/lib/log
+++ b/lib/log
@@ -196,7 +196,7 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
   local log_level="${args[0]^^}"
   local exit_status=0
   local log_msg
-  local unformatted_log_msg
+  local __go_stripped_value
   local level_fd
 
   unset 'args[0]'
@@ -237,12 +237,10 @@ readonly __GO_LOG_COMMAND_EXIT_PATTERN='^@go.log_command (exit|fatal):([0-9]+)$'
       _@go.log_command_should_skip_file_descriptor "$level_fd"; then
       continue
     elif [[ ! -t "$level_fd" && -z "$_GO_LOG_FORMATTING" ]]; then
-      if [[ -z "$unformatted_log_msg" ]]; then
-        unformatted_log_msg="${log_msg//\\e\[[0-9]m}"
-        unformatted_log_msg="${unformatted_log_msg//\\e\[[0-9][0-9]m}"
-        unformatted_log_msg="${unformatted_log_msg//\\e\[[0-9][0-9][0-9]m}"
+      if [[ -z "$__go_stripped_value" ]]; then
+        @go.strip_formatting_codes "$log_msg"
       fi
-      printf '%s\n' "$unformatted_log_msg" >&"$level_fd"
+      printf '%s\n' "$__go_stripped_value" >&"$level_fd"
     else
       printf '%b\n' "$log_msg" >&"$level_fd"
     fi
@@ -556,6 +554,7 @@ _@go.log_init() {
   fi
 
   readonly __GO_LOG_INIT='done'
+  . "$_GO_USE_MODULES" 'format'
   ((__GO_LOG_FATAL_STACK_TRACE_SKIP_CALLERS+=2))
   _@go.log_format_level_labels
 

--- a/tests/format.bats
+++ b/tests/format.bats
@@ -43,3 +43,27 @@ setup() {
   assert_equal $'\n'"${expected[*]/#/$indent}" \
     $'\n'"${__go_zipped_result[*]/#/$indent}"
 }
+
+@test "$SUITE: strip formatting codes from empty string" {
+  local __go_stripped_value
+  @go.strip_formatting_codes ''
+  assert_equal '' "$__go_stripped_value"
+}
+
+@test "$SUITE: strip formatting codes from string with no codes" {
+  local __go_stripped_value
+  @go.strip_formatting_codes 'foobar'
+  assert_equal 'foobar' "$__go_stripped_value"
+}
+
+@test "$SUITE: strip formatting codes from string with one code" {
+  local __go_stripped_value
+  @go.strip_formatting_codes 'foobar\e[0m'
+  assert_equal 'foobar' "$__go_stripped_value"
+}
+
+@test "$SUITE: strip formatting codes from string with multiple codes" {
+  local __go_stripped_value
+  @go.strip_formatting_codes '\e[1mf\e[30;47mo\e[0;111mo\e[32mbar\e[0m'
+  assert_equal 'foobar' "$__go_stripped_value"
+}


### PR DESCRIPTION
Closes #87.