### PR TITLE
Test existing test helpers, add new ones

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -135,6 +135,7 @@ fail_if() {
   local assertion="assert_${1}"
   shift
   local label
+  local value
   local operation='equal'
   local constraints=()
   local constraint
@@ -149,15 +150,18 @@ fail_if() {
   assert_equal|assert_matches)
     label="$3"
     constraints=("$1")
+    value="$2"
     ;;
   assert_output*|assert_status)
     label="${assertion#assert_}"
     label="${label%_*}"
     constraints=("$1")
+    value="$output"
     ;;
   assert_line_*)
     label="line $1"
     constraints=("$2")
+    value="${lines[$1]}"
     ;;
   assert_lines_*)
     __bats_fail_suppress_output=
@@ -183,7 +187,14 @@ fail_if() {
   for ((i=0; i != ${#constraints[@]}; ++i)); do
     constraint+=$'\n'"  '${constraints[$i]}'"
   done
-  fail "Expected $label not to $operation:$constraint"
+
+  if [[ "$operation" == 'match' && -n "$value" ]]; then
+    value=$'\nValue:\n'"  '$value'"
+  else
+    value=
+  fi
+
+  fail "Expected $label not to $operation:$constraint$value"
   return_from_bats_assertion "$?"
 }
 

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -166,3 +166,40 @@ skip_if_cannot_trigger_file_permission_failure() {
     skip "Can't trigger condition when run by superuser"
   fi
 }
+
+# Prints its arguments to standard error whenever `TEST_DEBUG` is set
+#
+# When debugging a piece of code, you may wish to source this file and
+# temporarily include `test_printf` to trace values in your program.
+#
+# Arguments:
+#    ...:  Arguments to `printf`
+test_printf() {
+  if [[ -n "$TEST_DEBUG" ]]; then
+    printf "$@" >&2
+  fi
+}
+
+# Skips a test if `TEST_FILTER` is set but doesn't match `BATS_TEST_DESCRIPTION`
+#
+# Call this from the `setup` function of your test suite if you'd like to
+# quickly execute a subset of test cases within the suite.
+test_filter() {
+  if [[ -n "$TEST_FILTER" && ! "$BATS_TEST_DESCRIPTION" =~ $TEST_FILTER ]]; then
+    skip
+  fi
+}
+
+# Replaces `lines` with the split content of `output`, including blank lines
+#
+# Blank lines are eliminated from `lines` by default. This makes it easier to
+# compare the exact lines of `output` using `assert_lines_equal` and other
+# `lines`-based assertions.
+split_bats_output_into_lines() {
+  local line
+  lines=()
+
+  while IFS= read -r line; do
+    lines+=("${line%$'\r'}")
+  done <<<"$output"
+}

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -590,7 +590,9 @@ export -f test_file_printf
   expect_failure "echo 'Hello, world!'" \
     'fail_if matches "Hello" "$output" "echo result"' \
     'Expected echo result not to match:' \
-    "  'Hello'"
+    "  'Hello'" \
+    'Value:' \
+    "  'Hello, world!'"
 }
 
 @test "$SUITE: fail_if succeeds when assert_output fails" {
@@ -614,7 +616,9 @@ export -f test_file_printf
   expect_failure "echo 'Hello, world!'" \
     "fail_if output_matches 'Hello'" \
     'Expected output not to match:' \
-    "  'Hello'"
+    "  'Hello'" \
+    'Value:' \
+    "  'Hello, world!'"
 }
 
 @test "$SUITE: fail_if succeeds when assert_status fails" {
@@ -650,7 +654,9 @@ export -f test_file_printf
   expect_failure "echo 'Hello, world!'" \
     "fail_if line_matches '0' 'Hello'" \
     'Expected line 0 not to match:' \
-    "  'Hello'"
+    "  'Hello'" \
+    'Value:' \
+    "  'Hello, world!'"
 }
 
 @test "$SUITE: fail_if succeeds when assert_lines_match fails" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -1,0 +1,122 @@
+#! /usr/bin/env bats
+
+load environment
+
+teardown() {
+  remove_bats_test_dirs
+}
+
+@test "$SUITE: suite name" {
+  assert_equal 'bats-helpers: suite name' "$BATS_TEST_DESCRIPTION" 'SUITE'
+}
+
+@test "$SUITE: BATS_TEST_ROOTDIR contains space" {
+  assert_matches ' ' "$BATS_TEST_ROOTDIR" "BATS_TEST_ROOTDIR"
+}
+
+@test "$SUITE: {create,remove}_bats_test_dirs" {
+  local test_dirs=('foo'
+    'bar/baz'
+    'quux/xyzzy'
+    'quux/plugh'
+  )
+  local test_dir
+
+  if [[ -d "$BATS_TEST_ROOTDIR" ]]; then
+    fail "'$BATS_TEST_ROOTDIR' already exists"
+  fi
+
+  for test_dir in "${test_dirs[@]}"; do
+    if [[ -d "$BATS_TEST_ROOTDIR/$test_dir" ]]; then
+      fail "'$test_dir' already present in '$BATS_TEST_ROOTDIR'"
+    fi
+  done
+
+  run create_bats_test_dirs "${test_dirs[@]}"
+  assert_success
+
+  for test_dir in "${test_dirs[@]}"; do
+    if [[ ! -d "$BATS_TEST_ROOTDIR/$test_dir" ]]; then
+      fail "Failed to create '$test_dir' in '$BATS_TEST_ROOTDIR'"
+    fi
+  done
+
+  run remove_bats_test_dirs
+  assert_success
+
+  if [[ -d "$BATS_TEST_ROOTDIR" ]]; then
+    fail "Failed to remove '$BATS_TEST_ROOTDIR'"
+  fi
+}
+
+@test "$SUITE: create_bats_test_script errors if no args" {
+  run create_bats_test_script
+  assert_failure 'No test script specified'
+}
+
+@test "$SUITE: create_bats_test_script creates Bash script" {
+  if [[ -d "$BATS_TEST_ROOTDIR" ]]; then
+    fail "'$BATS_TEST_ROOTDIR' already exists"
+  fi
+
+  run create_bats_test_script test-script \
+    'echo Hello, World!'
+  assert_success
+  assert_file_equals "$BATS_TEST_ROOTDIR/test-script" \
+    '#! /usr/bin/env bash' \
+    'echo Hello, World!'
+
+  if [[ ! -x "$BATS_TEST_ROOTDIR/test-script" ]]; then
+    fail "Failed to make the test script executable"
+  fi
+}
+
+@test "$SUITE: create_bats_test_script creates Perl script" {
+  run create_bats_test_script test-script \
+    '#! /usr/bin/env perl' \
+    'printf "Hello, World!\n";'
+  assert_success
+  assert_file_equals "$BATS_TEST_ROOTDIR/test-script" \
+    '#! /usr/bin/env perl' \
+    'printf "Hello, World!\n";'
+}
+
+@test "$SUITE: create_bats_test_script automatically creates parent dirs" {
+  if [[ -d "$BATS_TEST_ROOTDIR/foo/bar" ]]; then
+    fail "'$BATS_TEST_ROOTDIR/foo/bar' already exists"
+  fi
+
+  run create_bats_test_script foo/bar/test-script \
+    'echo Hello, World!'
+  assert_success
+  assert_file_equals "$BATS_TEST_ROOTDIR/foo/bar/test-script" \
+    '#! /usr/bin/env bash' \
+    'echo Hello, World!'
+}
+
+@test "$SUITE: fs_missing_permission_support" {
+  local expected_result='false'
+
+  # On some Windows file systems, any file starting with '#!' will be marked
+  # executable. This is how we can tell Unix-style permissions aren't supported,
+  # and thus some test conditions can't be created.
+  run create_bats_test_script test-script 'echo Hello, World!'
+  chmod 600 "$BATS_TEST_ROOTDIR/test-script"
+  run fs_missing_permission_support
+
+  if [[ -x "$BATS_TEST_ROOTDIR/test-script" ]]; then
+    assert_success
+  else
+    assert_failure
+  fi
+}
+
+@test "$SUITE: skip_if_cannot_trigger_file_permission_failure" {
+  if fs_missing_file_permission_support; then
+    skip_if_cannot_trigger_file_permission_failure
+    fail "Should have skipped this test due to missing file permission support"
+  elif [[ "$EUID" -eq '0' ]]; then
+    skip_if_cannot_trigger_file_permission_failure
+    fail "Should have skipped this test due to running as the superuser"
+  fi
+}


### PR DESCRIPTION
Closes #82, closes #90, and closes #92. Also updates `fail_if` output for `matches`, `output_matches`, and `line_matches` failures.