### PR TITLE
tests: Replace `[[ ]]` with `[ ]` because Bash 3.2

### DIFF
--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -100,21 +100,21 @@ load environment
   # running it.
   
   run env _GO_CMD='test-go' ./go aliases --help cd
-  [[ "$status" -eq '0' ]]
+  [ "$status" -eq '0' ]
 
   local expected=("test-go cd - Shell alias that will execute in $_GO_ROOTDIR")
   expected+=('Filename completion is available via the "test-go env" command.')
 
-  [[ "${lines[0]}" == "${expected[0]}" ]]
-  [[ "${lines[1]}" == "${expected[1]}" ]]
-  [[ -z "${lines[2]}" ]]
+  [ "${lines[0]}" == "${expected[0]}" ]
+  [ "${lines[1]}" == "${expected[1]}" ]
+  [ -z "${lines[2]}" ]
 
   run env _GO_CMD='test-go' ./go aliases --help pushd
-  [[ "$status" -eq '0' ]]
+  [ "$status" -eq '0' ]
 
   expected[0]="${expected[0]/test-go cd/test-go pushd}"
 
-  [[ "${lines[0]}" == "${expected[0]}" ]]
-  [[ "${lines[1]}" == "${expected[1]}" ]]
-  [[ -z "${lines[2]}" ]]
+  [ "${lines[0]}" == "${expected[0]}" ]
+  [ "${lines[1]}" == "${expected[1]}" ]
+  [ -z "${lines[2]}" ]
 }

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -30,7 +30,7 @@ teardown() {
 @test "$SUITE: set COLUMNS if unset" {
   run env COLUMNS= "$TEST_GO_SCRIPT"
   assert_success
-  [[ -n "$output" ]]
+  [ -n "$output" ]
 }
 
 @test "$SUITE: honor COLUMNS if already set" {

--- a/tests/fullpath.bats
+++ b/tests/fullpath.bats
@@ -18,7 +18,7 @@ teardown() {
   assert_success '--existing'
 
   expected=($(compgen -f -- 'li'))
-  [[ "${#expected[@]}" -ne '0' ]]
+  [ "${#expected[@]}" -ne '0' ]
   run ./go complete 1 fullpath 'li'
   assert_success "${expected[*]}"
 }

--- a/tests/glob/arg-completion.bats
+++ b/tests/glob/arg-completion.bats
@@ -35,7 +35,7 @@ teardown() {
   assert_success '--ignore'
 
   expected=($(compgen -f -- 'li'))
-  [[ "${#expected[@]}" -ne '0' ]]
+  [ "${#expected[@]}" -ne '0' ]
   run ./go complete 1 glob 'li'
   assert_success "${expected[*]}"
 }
@@ -61,7 +61,7 @@ teardown() {
   assert_success "${expected[*]}"
 
   expected=($(compgen -f -- 'li'))
-  [[ "${#expected[@]}" -ne '0' ]]
+  [ "${#expected[@]}" -ne '0' ]
   run ./go complete 4 glob '--ignore' 'foo*:bar*' '--trim' 'li'
   assert_success "${expected[*]}"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -20,7 +20,7 @@ teardown() {
   local expected=('--coverage' '--edit' '--list')
   expected+=($('./go' 'glob' '--complete' '5' \
     '--trim' '--ignore' 'bats' 'tests' '.bats'))
-  [[ "${#expected[@]}" -ne 1 ]]
+  [ "${#expected[@]}" -ne 1 ]
 
   run ./go complete 1 test ''
   local IFS=$'\n'
@@ -51,7 +51,7 @@ _trim_expected() {
 @test "$SUITE: no arguments after --list lists all tests" {
   local expected=(
     $('./go' 'glob' '--trim' '--ignore' 'bats' 'tests' '.bats'))
-  [[ "${#expected[@]}" -ne 0 ]]
+  [ "${#expected[@]}" -ne 0 ]
 
   run ./go test --list
   local IFS=$'\n'


### PR DESCRIPTION
While writing test cases for `lib/bats/assertion-test-helpers` per #49, I noticed that some failing `[[ ]]` conditions were causing the stack trace to point to the previous line—if it was the last line of the test case. I eventually noticed that `[[ ]]` conditions earlier in a test case would always pass regardless of what was getting checked, even when `echo "$?" >&2` on the following line would report the expected status.

That was when running the test with Bash 3.2.57(1)-release on macOS. When I switched to Bash 4.4.5, the `[[ ]]` conditions behaved as expected. I reasoned that somehow `[[ ]]` wasn't triggering the ERR trap like `[` was, perhaps because `/bin/[` is an external command. Then I found this in https://tiswww.case.edu/php/chet/bash/CHANGES:

```
  This document details the changes between this version,
  bash-4.1-alpha, and the previous version, bash-4.0-release.

  j.  The [[ and (( commands are now subject to the setting of `set -e'
      and the ERR trap.
```

Yeah. So I was right. On the bright side, under Bash 3.2.57(1)-release, `command -V '['` reports "[ is a shell builtin", so there shouln't be a performance penalty. But it's still frustrating that we can't use the safer `[[ ]]` construct in portable Bats test cases.