### PR TITLE
Add `test_join` Bats helper and multiline `assert_output` assertion

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -139,12 +139,11 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
   if [[ "$#" -eq 0 ]]; then
     format="${format//\%/%%}"
   fi
-  # If `format` ends with a newline, chomp it, since the loop will add one.
-  printf -v result "${format%\\n}" "$@"
+  printf -v result -- "$format" "$@"
+  result="${result//$'\r\n'/$'\n'}"
 
+  # If `result` ends with a newline, chomp it, since the loop will add one.
   while read -r line; do
-    line="${line%$'\r'}"
-
     while [[ "${#line}" -gt "$COLUMNS" ]]; do
       prefix="${line:0:$COLUMNS}"
       prefix="${prefix% *}"
@@ -158,9 +157,8 @@ declare _GO_SEARCH_PATHS=("$_GO_CORE_DIR/libexec")
       fi
       printf '%s\n' "$prefix"
     done
-
     printf '%s\n' "$line"
-  done <<<"$result"
+  done <<<"${result%$'\n'}"
 }
 
 # Prints the stack trace at the point of the call.

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -155,7 +155,7 @@ fail_if() {
   assert_output*|assert_status)
     label="${assertion#assert_}"
     label="${label%_*}"
-    constraints=("$1")
+    constraints=("$@")
     value="$output"
     ;;
   assert_line_*)
@@ -240,13 +240,24 @@ assert_matches() {
   fi
 }
 
-# Validates that the Bats $output value is equal to the expected value
+# Validates that the Bats `output` value is equal to the expected value
+#
+# Will join multiple arguments using a newline character to check a multiline
+# value for equality. This is suggested only for short `output` values, however.
+# For longer values, use `assert_lines_equal` or `assert_lines_match`, possibly
+# in combination with `split_bats_output_into_lines` from `lib/bats/helpers`.
 #
 # Arguments:
-#   $1: The expected value for $output
+#   ...:  Lines comprising the expected value for `output`
 assert_output() {
   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
-  __assert_output 'assert_equal' "$@"
+  local expected
+  local origIFS="$IFS"
+  local IFS=$'\n'
+
+  printf -v 'expected' "$*"
+  origIFS="$IFS"
+  assert_equal "$expected" "$output" 'output'
   return_from_bats_assertion "$?"
 }
 
@@ -256,8 +267,15 @@ assert_output() {
 #   $1: The regular expression to match against $output
 assert_output_matches() {
   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
-  __assert_output 'assert_matches' "$@"
-  return_from_bats_assertion "$?"
+  local pattern="$1"
+
+  if [[ "$#" -ne 1 ]]; then
+    echo "ERROR: ${FUNCNAME[0]} takes exactly one argument" >&2
+    return_from_bats_assertion '1'
+  else
+    assert_matches "$pattern" "$output" 'output'
+    return_from_bats_assertion "$?"
+  fi
 }
 
 # Validates that the Bats $status value is equal to the expected value
@@ -270,10 +288,10 @@ assert_status() {
   return_from_bats_assertion "$?"
 }
 
-# Validates that 'run' returned success and $output equals the expected value
+# Validates that `run` returned success and `output` equals the expected value
 #
 # Arguments:
-#   $1: The regular expression to match against $output
+#   ...:  (Optional) Lines comprising the expected value for `output`
 assert_success() {
   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
 
@@ -286,10 +304,10 @@ assert_success() {
   return_from_bats_assertion "$?"
 }
 
-# Validates that 'run' returned an error and $output equals the expected value
+# Validates that `run` returned an error and `output` equals the expected value
 #
 # Arguments:
-#   $1: The regular expression to match against $output
+#   ...:  (Optional) Lines comprising the expected value for `output`
 assert_failure() {
   set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
 
@@ -326,7 +344,9 @@ assert_line_matches() {
 
 # Validates that each output line equals each corresponding argument
 #
-# Also ensures there are no more and no fewer lines of output than expected.
+# Also ensures there are no more and no fewer lines of output than expected. If
+# `output` should contain blank lines, call `split_bats_output_into_lines` from
+# `lib/bats/helpers` before this.
 #
 # Arguments:
 #   $@: Values to compare to each element of `${lines[@]}` for equality
@@ -338,7 +358,9 @@ assert_lines_equal() {
 
 # Validates that each output line matches each corresponding argument
 #
-# Also ensures there are no more and no fewer lines of output than expected.
+# Also ensures there are no more and no fewer lines of output than expected. If
+# `output` should contain blank lines, call `split_bats_output_into_lines` from
+# `lib/bats/helpers` before this.
 #
 # Arguments:
 #   $@: Values to compare to each element of `${lines[@]}` for equality
@@ -479,22 +501,6 @@ set_bats_output_and_lines_from_file() {
 #
 # None of the functions below this line are part of the public interface.
 # --------------------------------
-
-# Common implementation for assertions that evaluate the Bats `$output` variable
-#
-# Arguments:
-#   assertion:   The assertion to execute
-#   constraint:  The assertion constraint used to evaluate $output
-__assert_output() {
-  local assertion="$1"
-  local constraint="$2"
-
-  if [[ "$#" -ne 2 ]]; then
-    echo "ERROR: ${FUNCNAME[1]} takes exactly one argument" >&2
-    return '1'
-  fi
-  "$assertion" "$constraint" "$output" 'output'
-}
 
 # Common implementation for assertions that evaluate a single `$lines` element
 #

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -255,7 +255,7 @@ assert_output() {
   local origIFS="$IFS"
   local IFS=$'\n'
 
-  printf -v 'expected' -- "$*"
+  printf -v 'expected' -- '%s' "$*"
   origIFS="$IFS"
   assert_equal "$expected" "$output" 'output'
   return_from_bats_assertion "$?"

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -255,7 +255,7 @@ assert_output() {
   local origIFS="$IFS"
   local IFS=$'\n'
 
-  printf -v 'expected' "$*"
+  printf -v 'expected' -- "$*"
   origIFS="$IFS"
   assert_equal "$expected" "$output" 'output'
   return_from_bats_assertion "$?"

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -182,7 +182,7 @@ test_join() {
   fi
 
   local IFS="$1"
-  printf -v "$2" "${*:3}"
+  printf -v "$2" -- "${*:3}"
 }
 
 # Prints its arguments to standard error whenever `TEST_DEBUG` is set

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -182,7 +182,7 @@ test_join() {
   fi
 
   local IFS="$1"
-  printf -v "$2" -- "${*:3}"
+  printf -v "$2" -- '%s' "${*:3}"
 }
 
 # Prints its arguments to standard error whenever `TEST_DEBUG` is set

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -109,9 +109,7 @@ create_bats_test_script() {
   if [[ "${1:0:2}" != '#!' ]]; then
     echo "#! /usr/bin/env bash" >"$script"
   fi
-
-  local IFS=$'\n'
-  echo "$*" >> "$script"
+  printf '%s\n' "$@" >>"$script"
   chmod 700 "$script"
 }
 
@@ -165,6 +163,26 @@ skip_if_cannot_trigger_file_permission_failure() {
   elif [[ "$EUID" -eq '0' ]]; then
     skip "Can't trigger condition when run by superuser"
   fi
+}
+
+# Joins lines using a delimiter into a user-defined variable
+#
+# Just like `@go.join` from `lib/strings`, except that it doesn't depend on any
+# core framework features. Returns the result in a variable to avoid a subshell,
+# as subshells can add substantially to a test suite's running time.
+#
+# Arguments:
+#   delimiter:  The character separating individual fields
+#   var_name:   Name of caller's variable to which to assign the joined string
+#   ...:        Elements to join into a string assigned to `var_name`
+test_join() {
+  if [[ ! "$2" =~ ^[[:alpha:]_][[:alnum:]_]*$ ]]; then
+    printf '"%s" is not a valid variable identifier.\n' "$2" >&2
+    return 1
+  fi
+
+  local IFS="$1"
+  printf -v "$2" "${*:3}"
 }
 
 # Prints its arguments to standard error whenever `TEST_DEBUG` is set

--- a/lib/file
+++ b/lib/file
@@ -91,7 +91,7 @@ fi
         @go.print_stack_trace '1' >&2
         exit 1
       fi
-      eval "$fd_var_reference=$i"
+      printf -v "$fd_var_reference" "$i"
       return
     fi
   done

--- a/lib/file
+++ b/lib/file
@@ -91,7 +91,7 @@ fi
         @go.print_stack_trace '1' >&2
         exit 1
       fi
-      printf -v "$fd_var_reference" "$i"
+      printf -v "$fd_var_reference" -- '%s' "$i"
       return
     fi
   done

--- a/lib/strings
+++ b/lib/strings
@@ -52,5 +52,5 @@
 @go.join() {
   @go.validate_identifier_or_die 'Result variable name' "$2"
   local IFS="$1"
-  eval "$2=\"\${*:3}\""
+  printf -v "$2" -- "${*:3}"
 }

--- a/lib/strings
+++ b/lib/strings
@@ -52,5 +52,5 @@
 @go.join() {
   @go.validate_identifier_or_die 'Result variable name' "$2"
   local IFS="$1"
-  printf -v "$2" -- "${*:3}"
+  printf -v "$2" -- '%s' "${*:3}"
 }

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -206,6 +206,11 @@ export -f test_file_printf
     "assert_output 'Hello,' 'world!'"
 }
 
+@test "$SUITE: assert_output handles output starting with dashes" {
+  expect_success "echo '--flag-from-tab-completion'" \
+    "assert_output '--flag-from-tab-completion'"
+}
+
 @test "$SUITE: assert_output fail output check" {
   expect_failure "echo 'Hello, world!'" \
     "assert_output 'Goodbye, world!'" \

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -8,6 +8,7 @@ export TEST_OUTPUT_FILE="$BATS_TEST_ROOTDIR/test-output.txt"
 
 setup() {
   mkdir "$BATS_TEST_ROOTDIR"
+  test_filter
 }
 
 teardown() {
@@ -117,7 +118,7 @@ run_test_script() {
 
 write_failing_test_script() {
   create_bats_test_script "${FAILING_TEST_SCRIPT#$BATS_TEST_ROOTDIR}" \
-    'echo "$@"; exit 1'
+    'printf "%s\n" "$@"; exit 1'
 }
 
 check_expected_output() {
@@ -200,6 +201,11 @@ export -f test_file_printf
     "assert_output 'Hello, world!'"
 }
 
+@test "$SUITE: assert_output success with joining multiple lines" {
+  expect_success "printf '%s\n' 'Hello,' 'world!'" \
+    "assert_output 'Hello,' 'world!'"
+}
+
 @test "$SUITE: assert_output fail output check" {
   expect_failure "echo 'Hello, world!'" \
     "assert_output 'Goodbye, world!'" \
@@ -221,12 +227,6 @@ export -f test_file_printf
     "  actual:   'Not empty'"
 }
 
-@test "$SUITE: assert_output fails if more than one argument" {
-  expect_failure "echo 'Hello, world!'" \
-    "assert_output 'Hello,' 'world!'" \
-    'ERROR: assert_output takes exactly one argument'
-}
-
 @test "$SUITE: assert_output_matches success" {
   expect_success "echo 'Hello, world!'" \
     "assert_output_matches 'o, w'"
@@ -238,6 +238,12 @@ export -f test_file_printf
     'output does not match expected pattern:' \
     "  pattern: 'e, w'" \
     "  value:   'Hello, world!'"
+}
+
+@test "$SUITE: assert_output_matches fails if more than one argument" {
+  expect_failure "echo 'Hello, world!'" \
+    "assert_output_matches 'o, w' 'ell'" \
+    'ERROR: assert_output_matches takes exactly one argument'
 }
 
 @test "$SUITE: assert_status" {
@@ -269,8 +275,8 @@ export -f test_file_printf
 }
 
 @test "$SUITE: assert_success with output check" {
-  expect_success "echo 'Hello, world!'" \
-    "assert_success 'Hello, world!'"
+  expect_success "printf '%s\n' 'Hello,' 'world!'" \
+    "assert_success 'Hello,' 'world!'"
 }
 
 @test "$SUITE: assert_success output check failure" {
@@ -298,17 +304,19 @@ export -f test_file_printf
 
 @test "$SUITE: assert_failure with output check" {
   write_failing_test_script
-  expect_success "'$FAILING_TEST_SCRIPT' 'Hello, world!'" \
-    "assert_failure 'Hello, world!'"
+  expect_success "'$FAILING_TEST_SCRIPT' 'Hello,' 'world!'" \
+    "assert_failure 'Hello,' 'world!'"
 }
 
 @test "$SUITE: assert_failure output check failure" {
   write_failing_test_script
-  expect_failure "'$FAILING_TEST_SCRIPT' 'Hello, world!'" \
-    "assert_failure 'Goodbye, world!'" \
+  expect_failure "'$FAILING_TEST_SCRIPT' 'Hello,' 'world!'" \
+    "assert_failure 'Goodbye,' 'world!'" \
     'output not equal to expected value:' \
-    "  expected: 'Goodbye, world!'" \
-    "  actual:   'Hello, world!'"
+    "  expected: 'Goodbye," \
+    "world!'" \
+    "  actual:   'Hello," \
+    "world!'"
 }
 
 @test "$SUITE: assert_line_equals" {
@@ -596,15 +604,16 @@ export -f test_file_printf
 }
 
 @test "$SUITE: fail_if succeeds when assert_output fails" {
-  expect_success "echo 'Hello, world!'" \
-    "fail_if output 'Goodbye, world!'"
+  expect_success "printf '%s\n' 'Hello,' 'world!'" \
+    "fail_if output 'Goodbye,' 'world!'"
 }
 
 @test "$SUITE: fail_if fails when assert_output succeeds" {
-  expect_failure "echo 'Hello, world!'" \
-    "fail_if output 'Hello, world!'" \
+  expect_failure "printf '%s\n' 'Hello,' 'world!'" \
+    "fail_if output 'Hello,' 'world!'" \
     'Expected output not to equal:' \
-    "  'Hello, world!'"
+    "  'Hello,'" \
+    "  'world!'"
 }
 
 @test "$SUITE: fail_if succeeds when assert_output_matches fails" {

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -140,7 +140,6 @@ check_expected_output() {
 # This function and `TEST_OUTPUT_FILE` are exported to make them available to
 # generated test scripts.
 test_file_printf() {
-  echo "printf \"$*\" \>\"$TEST_OUTPUT_FILE\""
   printf "$@" >"$TEST_OUTPUT_FILE"
 }
 export -f test_file_printf
@@ -204,6 +203,11 @@ export -f test_file_printf
 @test "$SUITE: assert_output success with joining multiple lines" {
   expect_success "printf '%s\n' 'Hello,' 'world!'" \
     "assert_output 'Hello,' 'world!'"
+}
+
+@test "$SUITE: assert_output success with argument containing '%'" {
+  expect_success "printf 'This \"%%/\" reproduces failures from #98.\n'" \
+    "assert_output 'This \"%/\" reproduces failures from #98.'"
 }
 
 @test "$SUITE: assert_output handles output starting with dashes" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -125,20 +125,22 @@ teardown() {
   fi
 }
 
-@test "$SUITE: test_join" {
+@test "$SUITE: test_join fails if result variable name is invalid" {
   create_bats_test_script test-script \
     ". '$_GO_CORE_DIR/lib/bats/helpers'" \
     "test_join ',' '3foobar'"
   run "$BATS_TEST_ROOTDIR/test-script"
   assert_failure '"3foobar" is not a valid variable identifier.'
+}
 
+@test "$SUITE: test_join succeeds" {
   create_bats_test_script test-script \
     ". '$_GO_CORE_DIR/lib/bats/helpers'" \
     "declare result" \
-    "test_join ',' 'result' 'foo' 'bar' 'baz'" \
+    "test_join ',' 'result' '--foo' 'bar' 'baz'" \
     "printf '%s\n' \"\$result\""
   run "$BATS_TEST_ROOTDIR/test-script"
-  assert_success 'foo,bar,baz'
+  assert_success '--foo,bar,baz'
 }
 
 @test "$SUITE: test_printf" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -137,10 +137,10 @@ teardown() {
   create_bats_test_script test-script \
     ". '$_GO_CORE_DIR/lib/bats/helpers'" \
     "declare result" \
-    "test_join ',' 'result' '--foo' 'bar' 'baz'" \
+    "test_join ',' 'result' '--foo' 'bar' 'baz' 'This \"%/\" is from #98.'" \
     "printf '%s\n' \"\$result\""
   run "$BATS_TEST_ROOTDIR/test-script"
-  assert_success '--foo,bar,baz'
+  assert_success '--foo,bar,baz,This "%/" is from #98.'
 }
 
 @test "$SUITE: test_printf" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -125,6 +125,22 @@ teardown() {
   fi
 }
 
+@test "$SUITE: test_join" {
+  create_bats_test_script test-script \
+    ". '$_GO_CORE_DIR/lib/bats/helpers'" \
+    "test_join ',' '3foobar'"
+  run "$BATS_TEST_ROOTDIR/test-script"
+  assert_failure '"3foobar" is not a valid variable identifier.'
+
+  create_bats_test_script test-script \
+    ". '$_GO_CORE_DIR/lib/bats/helpers'" \
+    "declare result" \
+    "test_join ',' 'result' 'foo' 'bar' 'baz'" \
+    "printf '%s\n' \"\$result\""
+  run "$BATS_TEST_ROOTDIR/test-script"
+  assert_success 'foo,bar,baz'
+}
+
 @test "$SUITE: test_printf" {
   create_bats_test_script test-script \
     ". '$_GO_CORE_DIR/lib/bats/helpers'" \

--- a/tests/core/printf.bats
+++ b/tests/core/printf.bats
@@ -2,6 +2,10 @@
 
 load ../environment
 
+setup() {
+  test_filter
+}
+
 teardown() {
   remove_test_go_rootdir
 }
@@ -17,6 +21,12 @@ teardown() {
   create_test_go_script '@go.printf "$@"'
   run "$TEST_GO_SCRIPT" "$test_text"
   assert_success "$test_text"
+}
+
+@test "$SUITE: Handle leading hyphen and newlines in format" {
+  create_test_go_script "@go.printf '- %s\n' 'foo' 'bar' 'baz'"
+  run "$TEST_GO_SCRIPT"
+  assert_success '- foo' '- bar' '- baz'
 }
 
 @test "$SUITE: preserve blank lines" {

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -22,6 +22,8 @@ KCOV_ARGV_START=(
 )
 
 setup() {
+  test_filter
+
   local fake_binaries=(
     'apt-get'
     'cmake'

--- a/tests/strings/join.bats
+++ b/tests/strings/join.bats
@@ -3,6 +3,10 @@
 load ../environment
 load helpers
 
+setup() {
+  test_filter
+}
+
 teardown() {
   remove_test_go_rootdir
 }
@@ -41,6 +45,14 @@ teardown() {
     'echo "$result"'
   run "$TEST_GO_SCRIPT"
   assert_success '--foo,bar,baz'
+}
+
+@test "$SUITE: multiple items containing '%'" {
+  create_strings_test_script 'declare result=()' \
+    '@go.join "," "result" "This \"%/\" is from #98" "--foo" "bar" "baz"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'This "%/" is from #98,--foo,bar,baz'
 }
 
 @test "$SUITE: join items into same variable" {

--- a/tests/strings/join.bats
+++ b/tests/strings/join.bats
@@ -29,24 +29,24 @@ teardown() {
 
 @test "$SUITE: single item" {
   create_strings_test_script 'declare result=()' \
-    '@go.join "," "result" "foo"' \
+    '@go.join "," "result" "--foo"' \
     'echo "$result"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo'
+  assert_success '--foo'
 }
 
 @test "$SUITE: multiple items" {
   create_strings_test_script 'declare result=()' \
-    '@go.join "," "result" "foo" "bar" "baz"' \
+    '@go.join "," "result" "--foo" "bar" "baz"' \
     'echo "$result"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo,bar,baz'
+  assert_success '--foo,bar,baz'
 }
 
 @test "$SUITE: join items into same variable" {
-  create_strings_test_script 'declare items=("foo" "bar" "baz")' \
+  create_strings_test_script 'declare items=("--foo" "bar" "baz")' \
     '@go.join "," "items" "${items[@]}"' \
     'echo "$items"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo,bar,baz'
+  assert_success '--foo,bar,baz'
 }


### PR DESCRIPTION
Closes #97. Also updates `create_bats_test_script` to use `printf '%s\n%` instead of `IFS` + `echo`.