### PR TITLE
Prevent stale `BATS_TEST_ROOTDIR` test failures

### DIFF
--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -8,6 +8,7 @@
 #
 #   . "path/to/bats/helpers"
 #   set_bats_suite_name "${BASH_SOURCE[0]%/*}"
+#   remove_bats_test_dirs
 #
 # Then have each Bats test file load the environment file and start each of
 # its test cases with "$SUITE":
@@ -37,6 +38,8 @@
 #     remove_bats_test_dirs
 #   }
 #
+# This is good practice even if you call `remove_bats_test_dirs` in your
+# `environment.bash` file.
 
 # A subdirectory of BATS_TMPDIR that contains a space.
 #
@@ -113,10 +116,14 @@ create_bats_test_script() {
   chmod 700 "$script"
 }
 
-# Recursively removes BATS_TEST_ROOTDIR and its subdirectories
+# Recursively removes `BATS_TEST_ROOTDIR` and its subdirectories
 #
-# Call this from teardown(), as Bats will not remove $BATS_TMPDIR and everything
-# in it automatically.
+# Call this from `teardown`, as Bats will not remove `BATS_TMPDIR` and
+# everything in it automatically.
+#
+# Calling this from `environment.bash` helps prevent spurious failures if
+# previous `bats` invocations failed to clean up `BATS_TEST_ROOTDIR`. It's still
+# recommended to call it from `teardown` where applicable regardless.
 remove_bats_test_dirs() {
   if [[ -d "$BATS_TEST_ROOTDIR" ]]; then
     chmod -R u+rwx "$BATS_TEST_ROOTDIR"

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -6,6 +6,7 @@
 . "$_GO_ROOTDIR/lib/bats/helpers"
 
 set_bats_test_suite_name "${BASH_SOURCE[0]%/*}"
+remove_bats_test_dirs
 
 # Avoid having to fold our test strings. Tests that verify folding behavior will
 # override this.


### PR DESCRIPTION
While fixing the breakages from #98, I determined the cause of spurious failures that I'd noticed at least under Bash 3.2.57(1)-release: `BATS_TEST_ROOTDIR` wasn't always getting cleaned up. The final tip-off was the occurrence of a test failure that showed a string that only appeared in another branch.

Since Bats registers a trap to run `teardown` on `ERR`, I performed the now-common drill to search https://tiswww.case.edu/php/chet/bash/CHANGES and found this:

```
  This document details the changes between this version,
  bash-4.4-alpha, and the previous version, bash-4.3-release.

  rrr. Fixed a bug that caused some of the shell's internal traps (e.g.,
       ERR) to be interrupted (and leave incorrect state) by pending
       SIGINTs.
```

Even though this mentions the shell's internal traps, it seems fair to assume that it may have an impact on user-defined `ERR` traps as well.

At any rate, unconditionally removing `BATS_TEST_ROOTDIR` upon loading `tests/environment.bash` seems like a reasonable move.