### PR TITLE
Add `stub_program_in_path` Bats helper, apply `assert_file_*` everywhere

### DIFF
--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -357,6 +357,8 @@ assert_line_matches() {
 # `output` should contain blank lines, call `split_bats_output_into_lines` from
 # `lib/bats/helpers` before this.
 #
+# If you expect zero lines, then don't supply any arguments.
+#
 # Arguments:
 #   $@: Values to compare to each element of `${lines[@]}` for equality
 assert_lines_equal() {
@@ -380,6 +382,10 @@ assert_lines_match() {
 }
 
 # Validates that a file contains exactly the specified output
+#
+# NOTE: If the file doesn't end with a newline, the last line will not be
+# present. To check that a file is completely empty, supply only the `file_path`
+# argument.
 #
 # Arguments:
 #   file_path:  Path to file to evaluate
@@ -476,6 +482,9 @@ return_from_bats_assertion() {
 # this function; but if you wish to examine specific output lines without the
 # regard to the rest (such as the first or last lines), or search for several
 # regular expressions in no particular order, this function may help.
+#
+# NOTE: If the file doesn't end with a newline, the last line will not be
+# present. If the file is completely empty, `lines` will contain zero elements.
 #
 # Arguments:
 #   file_path:  Path to file from which `output` and `lines` will be filled

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -47,6 +47,9 @@
 # variables are quoted properly in most places.
 BATS_TEST_ROOTDIR="$BATS_TMPDIR/test rootdir"
 
+# Created by `stub_program_in_path` and exported to `PATH`
+BATS_TEST_BINDIR="$BATS_TEST_ROOTDIR/bin"
+
 # Sets the global SUITE variable based on the path of the test file.
 #
 # To make Bats output easier to follow, call this function from your shared
@@ -230,4 +233,21 @@ split_bats_output_into_lines() {
   while IFS= read -r line; do
     lines+=("${line%$'\r'}")
   done <<<"$output"
+}
+
+# Creates a stub program in PATH for testing purposes
+#
+# The script is written as `$BATS_TEST_BINDIR/$cmd_name`. `$BATS_TEST_BINDIR` is
+# added to `PATH` and exported if it isn't already present.
+#
+# Arguments:
+#   cmd_name:  Name of the command from PATH to stub
+#   ...:       Lines comprising the stub script
+stub_program_in_path() {
+  local bindir_pattern="^${BATS_TEST_BINDIR}:"
+
+  if [[ ! "$PATH" =~ $bindir_pattern ]]; then
+    export PATH="$BATS_TEST_BINDIR:$PATH"
+  fi
+  create_bats_test_script "${BATS_TEST_BINDIR#$BATS_TEST_ROOTDIR/}/$1" "${@:2}"
 }

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -267,6 +267,11 @@ teardown() {
     "assert_lines_equal 'foo' 'bar' 'baz'"
 }
 
+@test "$SUITE: assert_lines_equal zero lines" {
+  expect_assertion_success "printf ''" \
+    "assert_lines_equal"
+}
+
 @test "$SUITE: assert_lines_equal failure" {
   expect_assertion_failure "printf 'foo\nbar\nbaz\n'" \
     "assert_lines_equal 'foo' 'quux' 'baz'" \
@@ -387,6 +392,21 @@ teardown() {
   assert_lines_equal '' 'foo' '' 'bar' '' 'baz' ''
 }
 
+@test "$SUITE: set_bats_output_and_lines_from_file from empty file" {
+  printf_to_test_output_file '\n'
+  set_bats_output_and_lines_from_file "$TEST_OUTPUT_FILE"
+  assert_lines_equal ''
+}
+
+@test "$SUITE: set_bats_output_and_lines_from_file from completely empty file" {
+  printf_to_test_output_file ''
+  set_bats_output_and_lines_from_file "$TEST_OUTPUT_FILE"
+
+  # Note that because there wasn't even a newline, we don't even expect the
+  # empty string to be present in `lines`.
+  assert_lines_equal
+}
+
 @test "$SUITE: set_bats_output_and_lines_from_file fails if file is missing" {
   run set_bats_output_and_lines_from_file "$TEST_OUTPUT_FILE"
   assert_failure "'$TEST_OUTPUT_FILE' doesn't exist or isn't a regular file."
@@ -410,6 +430,20 @@ teardown() {
   expect_assertion_success \
     "printf_to_test_output_file '\nfoo\n\nbar\n\nbaz\n\n'" \
     "assert_file_equals '$TEST_OUTPUT_FILE' '' 'foo' '' 'bar' '' 'baz' ''"
+}
+
+@test "$SUITE: assert_file_equals expect file containing empty string only" {
+  expect_assertion_success \
+    "printf_to_test_output_file '\n'" \
+    "assert_file_equals '$TEST_OUTPUT_FILE' ''"
+}
+
+@test "$SUITE: assert_file_equals expect file completely empty file" {
+  # Note that because there wasn't even a newline, we don't even supply the
+  # empty string to `assert_file_equals`.
+  expect_assertion_success \
+    "printf_to_test_output_file ''" \
+    "assert_file_equals '$TEST_OUTPUT_FILE'"
 }
 
 @test "$SUITE: assert_file_equals failure" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -191,3 +191,14 @@ teardown() {
   split_bats_output_into_lines
   assert_lines_equal '' '' 'foo' '' 'bar' '' 'baz'
 }
+
+@test "$SUITE: stub_program_in_path" {
+  local bats_bindir_pattern="^${BATS_TEST_BINDIR}:"
+  fail_if matches "$bats_bindir_pattern" "$PATH"
+
+  stub_program_in_path 'git' 'echo "$@"'
+  assert_matches "$bats_bindir_pattern" "$PATH"
+
+  run git Hello, World!
+  assert_success 'Hello, World!'
+}

--- a/tests/changes.bats
+++ b/tests/changes.bats
@@ -10,32 +10,21 @@ teardown() {
   remove_test_go_rootdir
 }
 
-create_fake_git() {
-  local fake_git_path="$TEST_GO_ROOTDIR/bin/git"
-  local fake_git_impl=('#! /usr/bin/env bash' "$@")
-  local IFS=$'\n'
-
-  echo "${fake_git_impl[*]}" >"$fake_git_path"
-  chmod 700 "$fake_git_path"
-}
-
 @test "$SUITE: tab completions" {
   local versions=('v1.0.0' 'v1.1.0')
-  local IFS=$'\n'
-  local fake_git_impl=(
-    "if [[ \"\$1\" == 'tag' ]]; then"
-    "  echo '${versions[*]}'"
-    '  exit 0'
-    'fi'
-    'exit 1'
-  )
 
-  create_fake_git "${fake_git_impl[@]}"
-  run "$TEST_GO_ROOTDIR/bin/git" 'tag'
+  stub_program_in_path 'git' \
+    "if [[ \"\$1\" == 'tag' ]]; then" \
+    "  echo '${versions[*]}'" \
+    '  exit 0' \
+    'fi' \
+    'exit 1'
+
+  run git tag
   assert_success "${versions[*]}"
 
-  local PATH="$TEST_GO_ROOTDIR/bin:$PATH"
   run ./go complete 1 changes ''
+  local IFS=$'\n'
   assert_success "${versions[*]}"
 
   run ./go complete 1 changes 'v1.0'
@@ -59,19 +48,15 @@ create_fake_git() {
 }
 
 @test "$SUITE: git log call is well-formed" {
-  local IFS=$'\n'
-  local fake_git_impl=(
-    "if [[ \"\$1\" == 'log' ]]; then"
-    '  shift'
-    "  IFS=\$'\\n'"
-    '  echo "$*"'
-    '  exit 0'
-    'fi'
+  stub_program_in_path 'git' \
+    "if [[ \"\$1\" == 'log' ]]; then" \
+    '  shift' \
+    "  IFS=\$'\\n'" \
+    '  echo "$*"' \
+    '  exit 0' \
+    'fi' \
     'exit 1'
-  )
 
-  create_fake_git "${fake_git_impl[@]}"
-  local PATH="$TEST_GO_ROOTDIR/bin:$PATH"
   run ./go changes v1.0.0 v1.1.0
   assert_success
   assert_line_matches 0 '^--pretty=format:'

--- a/tests/file/fds-printf.bats
+++ b/tests/file/fds-printf.bats
@@ -33,7 +33,7 @@ create_fds_printf_test_script() {
     'output_fds="$output_fd"'
   run "$TEST_GO_SCRIPT"
   assert_success
-  assert_equal "$MESSAGE" "$(< "$file_path")"
+  assert_file_equals "$file_path" "$MESSAGE"
 }
 
 @test "$SUITE: print to standard output and to a file" {
@@ -46,7 +46,7 @@ create_fds_printf_test_script() {
     'output_fds="1,$output_fd"'
   run "$TEST_GO_SCRIPT"
   assert_success "$MESSAGE"
-  assert_equal "$MESSAGE" "$(< "$file_path")"
+  assert_file_equals "$file_path" "$MESSAGE"
 }
 
 @test "$SUITE: error if non-file descriptor argument given" {
@@ -79,5 +79,8 @@ create_fds_printf_test_script() {
   assert_line_equals  0    "$MESSAGE"
   assert_line_matches '-2' "Failed to print to fd [1-9][0-9]* at:"
   assert_line_matches '-1' "  $TEST_GO_SCRIPT:10 main"
-  assert_equal '' "$(< "$file_path")"
+
+  # Note that no "expected" argument means we expect the file to be completely
+  # empty, with not even a newline.
+  assert_file_equals "$file_path"
 }

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -52,7 +52,7 @@ create_file_open_test_go_script() {
     'echo "Goodbye, World!" >&"$write_fd"'
   run "$TEST_GO_SCRIPT"
   assert_success
-  assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
+  assert_file_equals "$FILE_PATH" "Goodbye, World!"
 }
 
 @test "$SUITE: duplicate descriptor for writing" {
@@ -64,7 +64,7 @@ create_file_open_test_go_script() {
     'echo "Goodbye, World!" >&"$dup_write_fd"'
   run "$TEST_GO_SCRIPT"
   assert_success
-  assert_equal "Goodbye, World!" "$(< "$FILE_PATH")"
+  assert_file_equals "$FILE_PATH" "Goodbye, World!"
 }
 
 @test "$SUITE: open file for appending" {
@@ -77,9 +77,7 @@ create_file_open_test_go_script() {
     'echo "Goodbye, World!" >&"$append_fd"'
   run "$TEST_GO_SCRIPT"
   assert_success
-
-  local IFS=$'\n'
-  assert_equal "${expected[*]}" "$(< "$FILE_PATH")"
+  assert_file_equals "$FILE_PATH" "${expected[@]}"
 }
 
 @test "$SUITE: open file for read and write" {
@@ -104,15 +102,11 @@ create_file_open_test_go_script() {
     'echo " hello!" >&"$read_write_fd"' \
 
   run "$TEST_GO_SCRIPT"
-
-  local IFS=$'\n'
-  local orig_content=("$first_line"
-    "$second_line")
-  assert_success "${orig_content[*]}"
+  assert_success "$first_line" "$second_line"
 
   local updated_content=('You say goodbye,'
     'and I say hello!')
-  assert_equal "${updated_content[*]}" "$(< "$FILE_PATH")"
+  assert_file_equals "$FILE_PATH" "${updated_content[@]}"
 }
 
 @test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS is not an integer" {

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -61,8 +61,8 @@ write_kcov_dummy() {
   assert_success ''
 
   . 'lib/kcov-ubuntu'
-  assert_equal "-W -f=\${Package} \${Status}\\n ${__KCOV_DEV_PACKAGES[*]}" \
-    "$(<"$BATS_TEST_BINDIR/dpkg-query.out")"
+  assert_file_equals "$BATS_TEST_BINDIR/dpkg-query.out" \
+    "-W -f=\${Package} \${Status}\\n ${__KCOV_DEV_PACKAGES[*]}"
 }
 
 @test "$SUITE: check dev packages fails on dpkg-query error" {
@@ -93,14 +93,13 @@ write_kcov_dummy() {
   local IFS=$'\n'
   assert_success "${expected_output[*]}"
 
-  assert_equal "clone $__KCOV_URL tests/kcov" "$(<"$BATS_TEST_BINDIR/git.out")"
+  assert_file_equals "$BATS_TEST_BINDIR/git.out" "clone $__KCOV_URL tests/kcov"
 
   IFS=' '
-  assert_equal "apt-get install -y ${__KCOV_DEV_PACKAGES[*]}" \
-    "$(<"$BATS_TEST_BINDIR/sudo.out")"
-
-  assert_equal '.' "$(<"$BATS_TEST_BINDIR/cmake.out")"
-  assert_equal '' "$(<"$BATS_TEST_BINDIR/make.out")"
+  assert_file_equals "$BATS_TEST_BINDIR/sudo.out" \
+    "apt-get install -y ${__KCOV_DEV_PACKAGES[*]}"
+  assert_file_equals "$BATS_TEST_BINDIR/cmake.out" '.'
+  assert_file_equals "$BATS_TEST_BINDIR/make.out" ''
 }
 
 @test "$SUITE: clone and build fails if clone fails" {

--- a/tests/log/add-update.bats
+++ b/tests/log/add-update.bats
@@ -54,9 +54,8 @@ teardown() {
     "@go.add_or_update_log_level FOOBAR '$INFO_FORMAT' 27" \
     '@go.log FOOBAR Hello, World!'
   assert_success ''
-
-  local expected="$(printf "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m\n")"
-  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+  assert_file_equals "$TEST_GO_ROOTDIR/logfile" \
+    "$(printf "${INFO_FORMAT}FOOBAR\e[0m Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: add new log level defaulting to standard output" {
@@ -79,9 +78,8 @@ teardown() {
     '@go.add_or_update_log_level INFO keep 27' \
     '@go.log INFO Hello, World!'
   assert_success ''
-  
-  local expected="$(printf "${INFO_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
-  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+  assert_file_equals "$TEST_GO_ROOTDIR/logfile" \
+    "$(printf "${INFO_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
 }
 
 @test "$SUITE: update format and file descriptor of existing log level" {
@@ -90,7 +88,6 @@ teardown() {
     "@go.add_or_update_log_level INFO '$START_FORMAT' 27" \
     '@go.log INFO Hello, World!'
   assert_success ''
-
-  local expected="$(printf "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
-  assert_equal "$expected" "$(< "$TEST_GO_ROOTDIR/logfile")" 'log file output'
+  assert_file_equals "$TEST_GO_ROOTDIR/logfile" \
+    "$(printf "${START_FORMAT}INFO\e[0m   Hello, World!\e[0m\n")"
 }

--- a/tests/log/timestamp.bats
+++ b/tests/log/timestamp.bats
@@ -5,7 +5,6 @@ load ../environment
 HAS_TIMESTAMP_BUILTIN=
 DATE_CMD=
 DATE_CMD_FILE=
-TEST_PATH=
 
 setup() {
   if printf '%(%Y)T' &>/dev/null; then
@@ -14,9 +13,8 @@ setup() {
 
   DATE_CMD="$(command -v date)"
   DATE_CMD_FILE="$TEST_GO_ROOTDIR/date-cmd-called"
-  TEST_PATH="$TEST_GO_ROOTDIR/bin:$PATH"
 
-  create_bats_test_script "${TEST_GO_ROOTDIR#$BATS_TEST_ROOTDIR}/bin/date" \
+  stub_program_in_path date \
     "declare -r DATE_CMD='$DATE_CMD'" \
     "touch '$DATE_CMD_FILE'" \
     "if [[ -n '$DATE_CMD' ]]; then" \
@@ -39,7 +37,7 @@ teardown() {
 }
 
 @test "$SUITE: return error if _GO_LOG_TIMESTAMP_FORMAT not set" {
-  _GO_LOG_TIMESTAMP_FORMAT= PATH="$TEST_PATH" run "$BASH" "$TEST_GO_SCRIPT"
+  _GO_LOG_TIMESTAMP_FORMAT= run "$BASH" "$TEST_GO_SCRIPT"
   assert_failure
 
   if [[ -f "$DATE_CMD_FILE" ]]; then
@@ -52,8 +50,7 @@ teardown() {
     skip "Builtin format not available in bash version $BASH_VERSION"
   fi
 
-  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH="$TEST_PATH" \
-    run "$BASH" "$TEST_GO_SCRIPT"
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' run "$BASH" "$TEST_GO_SCRIPT"
   assert_success
   assert_output_matches '^[0-5][0-9]:[0-5][0-9]$'
 
@@ -69,8 +66,7 @@ teardown() {
     skip "`date` command not found in \$PATH: $PATH"
   fi
 
-  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' PATH="$TEST_PATH" \
-    run "$BASH" "$TEST_GO_SCRIPT"
+  _GO_LOG_TIMESTAMP_FORMAT='%M:%S' run "$BASH" "$TEST_GO_SCRIPT"
   assert_success
   assert_output_matches '^[0-5][0-9]:[0-5][0-9]$'
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -83,14 +83,9 @@ _trim_expected() {
 }
 
 @test "$SUITE: update bats submodule if not present" {
-  mkdir -p "$TEST_GO_SCRIPTS_DIR/bin"
-
-  local git_dummy="$TEST_GO_SCRIPTS_DIR/bin/git"
-  printf '#! /usr/bin/env bash\necho "GIT ARGV: $*"\n' >"$git_dummy"
-  chmod 700 "$git_dummy"
-
+  create_test_go_script '@go "$@"'
   cp "$_GO_ROOTDIR/scripts/test" "$TEST_GO_SCRIPTS_DIR"
-  create_test_go_script "PATH=\"$TEST_GO_SCRIPTS_DIR/bin:\$PATH\"; @go \"\$@\""
+  stub_program_in_path 'git' 'echo "GIT ARGV: $*"'
 
   # This will fail because we didn't create the tests/ directory, but git should
   # have been called correctly.


### PR DESCRIPTION
More work pertaining to #40.

Introduces the new `stub_program_in_path` function in `lib/bats/helpers`, which makes it super easy to stub out system programs by injecting testing stub implementations into the `PATH` of tests that call the function.

Also updates a number of tests to use the `assert_file_*` functions, and includes new comments and test cases indicating how to check for completely empty output or files.