### PR TITLE
Fix `@go.array_printf` comment, add tests for missing coverage

### DIFF
--- a/lib/format
+++ b/lib/format
@@ -23,7 +23,7 @@
 # provides a portable means of printing to an array variable while avoiding the
 # use of `eval`.
 #
-# NOTE: By default, this function relies on the ASCII Record Separator character
+# NOTE: By default, this function relies on the ASCII Unit Separator character
 # ($'\x1f') to delimit generated strings before splitting them into the result
 # array. If you have strings containing this character, you can set a new
 # delimiter via `_GO_ARRAY_PRINTF_DELIMITER`.

--- a/tests/core/set-scripts-dir.bats
+++ b/tests/core/set-scripts-dir.bats
@@ -35,6 +35,13 @@ teardown() {
   assert_failure "$expected"
 }
 
+@test "$SUITE: produce an error if the script dir isn't a directory" {
+  rm -rf "$TEST_GO_SCRIPTS_DIR"
+  printf '' >"$TEST_GO_SCRIPTS_DIR"
+  run "$TEST_GO_SCRIPT"
+  assert_failure "ERROR: $TEST_GO_SCRIPTS_DIR is not a directory"
+}
+
 @test "$SUITE: produce an error if the script dir can't be read or accessed" {
   skip_if_cannot_trigger_file_permission_failure
 

--- a/tests/testing/stubbing.bats
+++ b/tests/testing/stubbing.bats
@@ -26,3 +26,10 @@ teardown() {
   [ -e "$_GO_CORE_DIR/lib/log" ]
   assert_success 'Hello, World!'
 }
+
+
+@test "$SUITE: create_core_module_stub aborts if module unknown" {
+  [ ! -e "$_GO_CORE_DIR/lib/foobar" ]
+  run create_core_module_stub 'foobar' 'echo Hello, World!'
+  assert_failure "No such core module: $_GO_CORE_DIR/lib/foobar"
+}


### PR DESCRIPTION
Fixes an incorrect comment for `@go.array_printf` from #107 and adds a couple of new test cases for previously uncovered code.