### PR TITLE
Export arrays from `go-core.bash` with Unit Separator, not NUL

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -105,13 +105,13 @@ declare -r -x _GO_CMD="${_GO_CMD:=$0}"
 # _GO_CMD.
 #
 # When exported to scripts not written in bash, the array is converted to a
-# string with the components delimited by the ASCII NUL character ($'\0').
+# string with the components delimited by the ASCII Unit Separator ($'\x1f').
 declare -x _GO_CMD_NAME=
 
 # The array of command line arguments for the ./go command after _GO_CMD_NAME.
 #
 # When exported to scripts not written in bash, the array is converted to a
-# string with the arguments delimited by the ASCII NUL character ($'\0').
+# string with the arguments delimited by the ASCII Unit Separator ($'\x1f').
 declare -x _GO_CMD_ARGV=
 
 # The directory in which plugins are installed.
@@ -290,7 +290,7 @@ _@go.run_command_script() {
   else
     if [[ -z "$_GO_CMD_NAME" ]]; then
       local origIFS="$IFS"
-      local IFS=$'\0'
+      local IFS=$'\x1f'
       _GO_CMD_NAME="${__go_cmd_name[*]}"
       _GO_CMD_ARGV="$*"
       IFS="$origIFS"

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -115,8 +115,8 @@ quotify_expected() {
   run "$TEST_GO_SCRIPT" test-command test-subcommand foo bar 'baz quux' xyzzy
   assert_success
   assert_lines_equal "_GO_CMD: $TEST_GO_SCRIPT" \
-    "_GO_CMD_ARGV: foo"$'\0'"bar"$'\0'"baz quux"$'\0'"xyzzy" \
-    "_GO_CMD_NAME: test-command"$'\0'"test-subcommand" \
+    $'_GO_CMD_ARGV: foo\x1fbar\x1fbaz quux\x1fxyzzy' \
+    $'_GO_CMD_NAME: test-command\x1ftest-subcommand' \
     "_GO_CORE_DIR: $_GO_CORE_DIR" \
     "_GO_CORE_URL: $_GO_CORE_URL" \
     "_GO_CORE_VERSION: $_GO_CORE_VERSION" \


### PR DESCRIPTION
After #107, in which I decided to use the ASCII Unit Separator (`$'\x1f'`) to delimit array elements for `@go.array_printf` because doing so with NUL (`$'\0'`) wasn't working, it seemed a good idea to switch the `_GO_CMD_NAME` and `_GO_CMD_ARGV` export mechanism to use the Unit Separator as well.