### PR TITLE
Add `skip_if_system_missing` Bats helper, new `get` builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,12 +452,15 @@ run it as `bash ./go` every time.
 
 #### Recommended utilities
 
-The framework as-is does not require any other external tools. However, in order
-for the automatic command help and output formatting to work, you'll need the
-following utilities installed:
+Most of the framework as-is does not require any other external tools. However,
+in order for the automatic command help and output formatting to work, you'll
+need the following utilities installed:
 
-- `fold` (coreutils)
-- `tput` (ncurses) on Linux, OS X, UNIX; `mode.com` should be present on Windows
+- `tput` (ncurses) on Linux, OS X, UNIX
+- `mode.com` should be present on Windows
+
+To use the `get` builtin, the `curl`, `wget`, and `git` programs must be
+installed on your system.
 
 ### Open Source License
 

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -178,6 +178,26 @@ skip_if_cannot_trigger_file_permission_failure() {
   fi
 }
 
+# Skips the current test if any of the listed system programs are not installed
+#
+# Arguments:
+#   ...:  System programs that must be present for the test case to proceed
+skip_if_system_missing() {
+  local missing=()
+  local program
+
+  for program in "$@"; do
+    if ! command -v "$program" >/dev/null; then
+      missing+=("$program")
+    fi
+  done
+
+  if [[ "${#missing[@]}" -ne '0' ]]; then
+    printf -v missing '%s, ' "${missing[@]}"
+    skip "${missing%, } not installed on the system"
+  fi
+}
+
 # Joins lines using a delimiter into a user-defined variable
 #
 # Just like `@go.join` from `lib/strings`, except that it doesn't depend on any

--- a/libexec/get
+++ b/libexec/get
@@ -1,0 +1,20 @@
+#! /bin/bash
+#
+# Utilities for downloading remote items
+#
+# For common downloading tasks, this command provides safety, convenience, and
+# portability. It isn't intended for complicated tasks such as recursive
+# fetching or directory syncing.
+#
+# Unlike most other builtin commands, `{{go}} {{cmd}}` subcommands depend on
+# external programs that must be installed on the system already.
+#
+# A NOTE ON TESTING: To test programs that use `{{go}} {{cmd}}`, you can try one
+# of two strategies:
+#
+#   - use local `file://` URLs with the real system `curl`, `git`, etc.
+#   - use `stub_program_in_path` from `lib/bats/helpers` to stub these programs
+
+. "$_GO_USE_MODULES" 'subcommands'
+
+@go.show_subcommands

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -1,0 +1,165 @@
+#! /bin/bash
+#
+# Downloads a single file using `curl` or `wget`
+#
+# Usage:
+#   {{go}} {{cmd}} [-f <filename>] <url>
+#
+# Flags:
+#   -f <filename>  (Optional) Name of the output file, `-` for stdout
+#
+# Where:
+#   url:  URL of the file to download
+#
+# This is a basic wrapper over the system `curl` or `wget` for downloading a
+# single file. If `-f <filename>` isn't specified, it will download the target
+# of `url` to the current working directory, using the same file name as that in
+# the URL.
+#
+# If `-f <filename>` is specified:
+#
+#   - `-` will stream the content to standard output;
+#   - otherwise it will be relative to `$PWD` if not absolute, and
+#   - if it specifies an existing directory, the file will be downloaded into it
+#
+# If the target file already exists locally, it will not be overwritten.
+# Instead, this command will print an error message and return nonzero.
+
+# Performs automatic completion of command line arguments
+#
+# Arguments:
+#   word_index:  Index of the item to complete from the command line arg array
+#   ...:         Command line argument array
+_@go.fetch_file_tab_completions() {
+  local word_index="$1"
+  shift
+
+  case "$word_index" in
+  0)
+    printf -- '-f\n'
+    ;;
+  1)
+    if [[ "$1" == '-f' ]]; then
+      compgen -f -- "$2"
+    fi
+    ;;
+  esac
+}
+
+# Implements the script behavior per the top-level description
+#
+# If `filename` is empty, the content will be directed to standard output and
+# `download_dir` will be ignored.
+#
+# Arguments:
+#   download_dir:  Directory into which to download the file, if not stdout
+#   filename:      Name of the file to save to `download_dir`, if not stdout
+#   url:           URL of the file ot download
+_@go.fetch_file_impl() {
+  local download_dir="$1"
+  local filename="$2"
+  local url="$3"
+  local result='0'
+  local dl_cmd=()
+  local errfile="${url##*/}.fetch-error"
+  local errmsg
+
+  if command -v curl >/dev/null; then
+    dl_cmd=('curl' '-L')
+    if [[ -n "$filename" ]]; then
+      dl_cmd+=('-o' "$filename")
+    fi
+  elif command -v wget >/dev/null; then
+    dl_cmd=('wget' '-O' "${filename:--}")
+  else
+    @go.printf 'Please install curl or wget before running "%s".' \
+      "${_GO_CMD_NAME[*]}" >&2
+    return 1
+  fi
+
+  if [[ -n "$filename" ]]; then
+    if [[ -f "$filename" ]]; then
+      @go.printf 'File already exists; not overwriting: %s\n' "$filename" >&2
+      return 1
+    elif [[ ! -d "$download_dir" ]] && ! mkdir -p "$download_dir"; then
+      @go.printf "Download dir doesn't exist and can't be created: %s\n" \
+        "$download_dir" >&2
+      return 1
+    elif [[ ! -w "$download_dir" ]]; then
+      @go.printf "You don't have permission to write to download dir: %s\n" \
+        "$download_dir" >&2
+      return 1
+    fi
+    errfile="${filename}.fetch-error"
+  fi
+
+  if ! "${dl_cmd[@]}" "$url" 2>"$errfile"; then
+    errmsg="$(< "$errfile")"
+    printf '%s\n' "$errmsg" >&2
+    @go.printf 'Failed to download: %s' "$url" >&2
+
+    if [[ "${dl_cmd[0]}" == 'wget' && "$errmsg" =~ Unsupported\ scheme ]]; then
+      @go.printf 'Consider installing `curl` and trying again.\n' >&2
+    fi
+
+    if [[ -f "$filename" ]]; then
+      rm "$filename"
+    fi
+    result='1'
+
+  elif [[ -n "$filename" ]]; then
+    @go.printf 'Downloaded "%s" as: %s\n' "$url" "$filename"
+  fi
+
+  rm -f "$errfile"
+  return "$result"
+}
+
+# Parses the command line flags before invoking _@go.fetch_file_impl
+#
+# The arguments are the same as in the script description.
+_@go.fetch_file() {
+  local url
+  local download_dir
+  local filename
+  local dl_cmd=()
+
+  case "$1" in
+  --complete)
+    # Tab completions
+    _@go.fetch_file_tab_completions "${@:2}"
+    return
+    ;;
+  -f)
+    filename="$2"
+    shift 2
+  esac
+
+  if [[ "$#" -ne '1' ]]; then
+    @go help "${_GO_CMD_NAME[@]}" >&2
+    return 1
+  fi
+
+  url="$1"
+  if [[ "$filename" == '-' ]]; then
+    filename=''
+  elif [[ -z "$filename" ]]; then
+    filename="${url##*/}"
+  elif [[ -d "$filename" ]]; then
+    download_dir="${filename%/}"
+    filename="$download_dir/${url##*/}"
+  else
+    download_dir="${filename%/*}"
+  fi
+  download_dir="${download_dir:-$PWD}"
+
+  if [[ -e "$url" ]]; then
+    if [[ "${url:0:1}" != '/' ]]; then
+      url="${PWD}/${url}"
+    fi
+    url="file://${url}"
+  fi
+  _@go.fetch_file_impl "$download_dir" "$filename" "$url"
+}
+
+_@go.fetch_file "$@"

--- a/libexec/get.d/git-repo
+++ b/libexec/get.d/git-repo
@@ -1,0 +1,74 @@
+#! /bin/bash
+#
+# Creates a shallow clone of a git repository at a specified version
+#
+# Usage:
+#   {{go}} {{cmd}} <repo_url> <git_ref> <clone_dir>
+#
+# Where:
+#   repo_url:   URL of the repository to clone
+#   git_ref:    Tag, branch, or commit to clone
+#   clone_dir:  Directory into which to clone the repo
+#
+# Useful for fetching a specific version of a project repository without its
+# entire history. A project may use this to install dependencies instead of a
+# git submodule.
+#
+# Will not clone the repository and will return an error if `clone_dir` exists.
+#
+# If you want to create a clone with the full history, either use `git clone`
+# directly or add the repository to your own repository as a submodule.
+
+# Implements the script behavior per the top-level description
+#
+# The arguments are the same as in the script description.
+_@go.git_repo_impl() {
+  local repo_url="$1"
+  local git_ref="$2"
+  local clone_dir="$3"
+  local git_clone=(git clone -q -c advice.detachedHead=false --depth 1)
+  local repo_msg="\"$repo_url\" reference \"$git_ref\" into \"$clone_dir\""
+
+  if ! command -v git >/dev/null; then
+    @go.printf 'Please install git before running "%s".\n' \
+      "${_GO_CMD_NAME[*]}" >&2
+    return 1
+  elif [[ -e "$clone_dir" ]]; then
+    @go.printf '"%s" already exists; not updating.\n' "$clone_dir"
+    return 1
+  elif ! "${git_clone[@]}" -b "$git_ref" "$repo_url" "$clone_dir"; then
+    @go.printf 'Failed to clone %s.\n' "$repo_msg" >&2
+    return 1
+  fi
+  @go.printf 'Successfully cloned %s.\n' "$repo_msg"
+}
+
+# Parses the command line flags before invoking _@go.git_repo_impl
+#
+# The arguments are the same as in the script description.
+_@go.git_repo() {
+  local repo_url="$1"
+  local git_ref="$2"
+  local clone_dir="$3"
+
+  if [[ "$1" == '--complete' ]]; then
+    # Tab completions
+    if [[ "$2" -eq '2' ]]; then
+      compgen -f -- "$3"
+    fi
+    return
+  fi
+
+  if [[ "$#" -ne '3' ]]; then
+    @go help "${_GO_CMD_NAME[@]}" >&2
+    return 1
+  fi
+
+  if [[ -e "$repo_url" ]]; then
+    repo_url="file://$repo_url"
+  fi
+
+  _@go.git_repo_impl "$repo_url" "$git_ref" "$clone_dir"
+}
+
+_@go.git_repo "$@"

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -125,6 +125,28 @@ teardown() {
   fi
 }
 
+@test "$SUITE: skip if system missing" {
+  create_bats_test_script 'test.bats' \
+    '#! /usr/bin/env bats' \
+    "load '$_GO_CORE_DIR/lib/bats/helpers'" \
+    '@test "skip if missing" { skip_if_system_missing foo bar baz; }'
+
+  stub_program_in_path 'foo'
+  stub_program_in_path 'bar'
+  stub_program_in_path 'baz'
+
+  run bats "$BATS_TEST_ROOTDIR/test.bats"
+  assert_success
+  assert_lines_equal '1..1' \
+    'ok 1 skip if missing'
+
+  rm "$BATS_TEST_BINDIR"/*
+  run bats "$BATS_TEST_ROOTDIR/test.bats"
+  assert_success
+  assert_lines_equal '1..1' \
+    'ok 1 # skip (foo, bar, baz not installed on the system) skip if missing'
+}
+
 @test "$SUITE: test_join fails if result variable name is invalid" {
   create_bats_test_script test-script \
     ". '$_GO_CORE_DIR/lib/bats/helpers'" \

--- a/tests/get.bats
+++ b/tests/get.bats
@@ -1,0 +1,15 @@
+#! /usr/bin/env bats
+
+load environment
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: show available subcommands" {
+  @go.create_test_go_script '@go "$@"'
+  run "$TEST_GO_SCRIPT" get
+  assert_success
+  assert_line_equals 0 'Available subcommands of "get" are:'
+}
+

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -1,0 +1,209 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '@go "$@"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: show help if too few or too many args" {
+  run test-go get file
+  assert_failure
+  assert_output_matches "^test-go get file - Downloads a single file"
+
+  run test-go get file -f foobar.txt bazquux.txt xyzzy
+  assert_failure
+  assert_output_matches "^test-go get file - Downloads a single file"
+}
+
+@test "$SUITE: tab completion" {
+  run "$TEST_GO_SCRIPT" get file --complete 0
+  assert_success '-f'
+
+  local expected=("$TEST_GO_ROOTDIR"/*)
+  test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
+
+  run "$TEST_GO_SCRIPT" get file --complete 1 -f
+  assert_success "$expected"
+}
+
+@test "$SUITE: fail if neither curl nor wget installed" {
+  PATH= run "$BASH" "$TEST_GO_SCRIPT" get file foobar.txt
+  assert_failure 'Please install curl or wget before running "get file".'
+}
+
+@test "$SUITE: curl called with correct args with URL only" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    http://localhost/foobar.txt
+  assert_success '-L -o foobar.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: foobar.txt'
+}
+
+@test "$SUITE: curl called with correct args with output file" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f barbaz.txt http://localhost/foobar.txt
+  assert_success '-L -o barbaz.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: barbaz.txt'
+}
+
+@test "$SUITE: curl called with correct args for standard output" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f - http://localhost/foobar.txt
+  assert_success '-L http://localhost/foobar.txt'
+}
+
+@test "$SUITE: curl called with correct args for local relative path" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf '' >"$TEST_GO_ROOTDIR/foobar.txt"
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file -f - foobar.txt
+  assert_success "-L file://$TEST_GO_ROOTDIR/foobar.txt"
+}
+
+@test "$SUITE: curl called with correct args for local absolute path" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf '' >"$TEST_GO_ROOTDIR/foobar.txt"
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file -f - \
+    "$TEST_GO_ROOTDIR/foobar.txt"
+  assert_success "-L file://$TEST_GO_ROOTDIR/foobar.txt"
+}
+
+@test "$SUITE: wget called with correct args with URL only" {
+  stub_program_in_path 'wget' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    http://localhost/foobar.txt
+  assert_success '-O foobar.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: foobar.txt'
+}
+
+@test "$SUITE: wget called with correct args with output file" {
+  stub_program_in_path 'wget' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f barbaz.txt http://localhost/foobar.txt
+  assert_success '-O barbaz.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: barbaz.txt'
+}
+
+@test "$SUITE: wget called with correct args for standard output" {
+  stub_program_in_path 'wget' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f - http://localhost/foobar.txt
+  assert_success '-O - http://localhost/foobar.txt'
+}
+
+@test "$SUITE: curl called with existing output directory" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  mkdir -p "$TEST_GO_ROOTDIR/bazquux"
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f bazquux http://localhost/foobar.txt
+  assert_success '-L -o bazquux/foobar.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: bazquux/foobar.txt'
+}
+
+@test "$SUITE: curl called with new output directory" {
+  stub_program_in_path 'curl' 'printf "%s\n" "$*"'
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f bazquux/xyzzyplugh.txt http://localhost/foobar.txt
+  assert_success '-L -o bazquux/xyzzyplugh.txt http://localhost/foobar.txt' \
+    'Downloaded "http://localhost/foobar.txt" as: bazquux/xyzzyplugh.txt'
+}
+
+@test "$SUITE: fail if file already exists" {
+  stub_program_in_path 'curl' 'echo Should not see this'
+  printf '' >"$TEST_GO_ROOTDIR/foobar.txt"
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    http://localhost/foobar.txt
+  assert_failure 'File already exists; not overwriting: foobar.txt'
+}
+
+@test "$SUITE: fail if download directory can't be created" {
+  skip_if_cannot_trigger_file_permission_failure
+
+  stub_program_in_path 'curl' 'echo Should not see this'
+  chmod ugo-w "$TEST_GO_ROOTDIR"
+
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f bad-parent/innocent-child.txt http://localhost/foobar.txt
+  assert_failure
+  assert_output_matches \
+    $'\nDownload dir doesn\'t exist and can\'t be created: bad-parent$'
+}
+
+@test "$SUITE: fail if download directory can't be written to" {
+  skip_if_cannot_trigger_file_permission_failure
+
+  stub_program_in_path 'curl' 'echo Should not see this'
+  mkdir -p "$TEST_GO_ROOTDIR/barbaz"
+  chmod ugo-w "$TEST_GO_ROOTDIR/barbaz"
+
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" get file \
+    -f barbaz http://localhost/foobar.txt
+  assert_failure "You don't have permission to write to download dir: barbaz"
+}
+
+@test "$SUITE: show failure message if curl fails" {
+  stub_program_in_path 'curl' 'printf "Oh noes!\n" >&2' 'exit 1'
+  run "$TEST_GO_SCRIPT" get file http://localhost/foobar.txt
+  assert_failure 'Oh noes!' 'Failed to download: http://localhost/foobar.txt'
+}
+
+@test "$SUITE: use real curl to copy a local file" {
+  skip_if_system_missing 'curl'
+
+  local source_path="$TEST_GO_ROOTDIR/hello.txt"
+  local download_path="$TEST_GO_ROOTDIR/download.txt"
+
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf 'Hello, World!\n' >"$source_path"
+  run "$TEST_GO_SCRIPT" get file -f "$download_path" "$source_path"
+
+  assert_success "Downloaded \"file://$source_path\" as: $download_path"
+  assert_file_equals "$download_path" 'Hello, World!'
+}
+
+@test "$SUITE: use real curl to print a local file to standard output" {
+  skip_if_system_missing 'curl'
+
+  local source_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf 'Hello, World!\n' >"$source_path"
+  run "$TEST_GO_SCRIPT" get file -f - "$source_path"
+
+  assert_success 'Hello, World!'
+}
+
+@test "$SUITE: show failure message if real wget fails" {
+  skip_if_system_missing 'wget'
+
+  # We have to use a stub and manipulate `PATH` since `./go get` will try to use
+  # `curl` first. The setup below is predicated on the notion that `wget` will
+  # be installed somewhere other than `/bin`.
+  if [[ -x '/bin/wget' ]]; then
+    skip "can't stub out system wget"
+  fi
+  stub_program_in_path 'wget' "$(command -v 'wget') \"\$@\""
+
+  # It turns out that `wget` isn't equipped to handle `file://` URLs, so we
+  # produce a real failure by trying to fetch a local file.
+  local source_path="$TEST_GO_ROOTDIR/hello.txt"
+
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf 'Hello, World!\n' >"$source_path"
+  PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" \
+    get file -f - "$source_path"
+
+  # Note that `wget` is using "smart" quotes around `file`.
+  assert_failure "file://$source_path: Unsupported scheme ‘file’." \
+    "Failed to download: file://$source_path" \
+    'Consider installing `curl` and trying again.'
+}

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -202,8 +202,10 @@ teardown() {
   PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" \
     get file -f - "$source_path"
 
-  # Note that `wget` is using "smart" quotes around `file`.
-  assert_failure "file://$source_path: Unsupported scheme ‘file’." \
-    "Failed to download: file://$source_path" \
-    'Consider installing `curl` and trying again.'
+  # Note that `wget` uses "smart" quotes around `file` on some platforms, so we
+  # have to use a regex.
+  assert_failure
+  assert_lines_match "^file://$source_path: Unsupported scheme .file.\.$" \
+    "^Failed to download: file://$source_path$" \
+    '^Consider installing `curl` and trying again\.$'
 }

--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -68,6 +68,8 @@ teardown() {
   mkdir -p "$TEST_GO_ROOTDIR/test-repo"
   cd "$TEST_GO_ROOTDIR/test-repo"
   git init
+  git config user.email 'mbland@example.com'
+  git config user.name 'Mike Bland'
   printf '# This is a test\n' >README.md
   git add README.md
   git commit -m 'Initial commit'

--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -1,0 +1,82 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '@go "$@"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: show help if not exactly three args" {
+  run test-go get git-repo
+  assert_failure
+  assert_output_matches "^test-go get git-repo - Creates a shallow clone"
+}
+
+@test "$SUITE: tab completion" {
+  run "$TEST_GO_SCRIPT" get git-repo --complete 0
+  assert_success ''
+
+  run "$TEST_GO_SCRIPT" get git-repo --complete 1
+  assert_success ''
+
+  local expected=("$TEST_GO_ROOTDIR"/*)
+  test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
+
+  run "$TEST_GO_SCRIPT" get git-repo --complete 2
+  assert_success "$expected"
+}
+
+@test "$SUITE: fail if git not installed" {
+  PATH= run "$BASH" "$TEST_GO_SCRIPT" get git-repo foobar.git v1.0.0 foo/bar
+  assert_failure 'Please install git before running "get git-repo".'
+}
+
+@test "$SUITE: fail if target directory already exists" {
+  stub_program_in_path 'git' 'echo Should not see this!' 'exit 1'
+  mkdir -p "$TEST_GO_ROOTDIR/foo/bar"
+  run "$TEST_GO_SCRIPT" get git-repo foobar.git v1.0.0 foo/bar
+  assert_failure '"foo/bar" already exists; not updating.'
+}
+
+@test "$SUITE: git called with the correct arguments" {
+  stub_program_in_path 'git' 'printf "%s\n" "$*"'
+  run "$TEST_GO_SCRIPT" get git-repo foobar.git v1.0.0 foo/bar
+
+  local expected=('clone -q -c advice.detachedHead=false --depth 1'
+    '-b v1.0.0 foobar.git foo/bar')
+  assert_success "${expected[*]}" \
+    'Successfully cloned "foobar.git" reference "v1.0.0" into "foo/bar".'
+}
+
+@test "$SUITE: git fails to clone the repo" {
+  stub_program_in_path 'git' 'exit 1'
+  run "$TEST_GO_SCRIPT" get git-repo foobar.git v1.0.0 foo/bar
+
+  local expected=('Failed to clone "foobar.git" reference "v1.0.0"'
+    'into "foo/bar".')
+  assert_failure "${expected[*]}"
+}
+
+@test "$SUITE: use the real git to clone the framework repo" {
+  if ! command -v git >/dev/null; then
+    skip "git not installed on the system"
+  fi
+
+  run "$TEST_GO_SCRIPT" get git-repo "$_GO_CORE_DIR" v1.3.0 go-core
+
+  # Note that we add a `file://` prefix to local repositories.
+  local expected=("Successfully cloned \"file://$_GO_CORE_DIR\""
+    'reference "v1.3.0" into "go-core".')
+  assert_success "${expected[*]}"
+
+  [ -d "$TEST_GO_ROOTDIR/go-core/.git" ]
+  cd "$TEST_GO_ROOTDIR/go-core"
+
+  run git log --oneline
+  assert_success 'daa9f5d go-script-bash v1.3.0'
+}


### PR DESCRIPTION
While beginning to write my first plugin for the framework, I found myself writing utilities to fetch remote files and repositories that I thought would be useful to add to the core builtins. They depend on external programs, but that's par for the course.