### PR TITLE
`@go.restore_stubbed_core_modules`, `lib/kcov-ubuntu`, and test tweaks

### DIFF
--- a/lib/kcov-ubuntu
+++ b/lib/kcov-ubuntu
@@ -3,7 +3,6 @@
 # Builds kcov from scratch on Ubuntu to support Bash test coverage
 #
 # Exports:
-#
 #   run_kcov
 #     Downloads and compiles kcov if necessary, then runs tests under kcov
 #
@@ -20,6 +19,7 @@ readonly __KCOV_DEV_PACKAGES=(
   'zlib1g-dev'
 )
 readonly __KCOV_URL='https://github.com/SimonKagstrom/kcov'
+readonly __KCOV_VERSION='master'
 
 # Downloads and compiles kcov if necessary, then runs tests under kcov
 #
@@ -103,8 +103,7 @@ __clone_and_build_kcov() {
   if [[ ! -d "$kcov_dir" ]]; then
     @go.printf 'Cloning kcov repository from %s...\n' "$__KCOV_URL"
 
-    if ! git clone "$__KCOV_URL" "$kcov_dir"; then
-      @go.printf "Failed to clone $__KCOV_URL into $kcov_dir." >&2
+    if ! @go get git-repo "$__KCOV_URL" "$__KCOV_VERSION" "$kcov_dir"; then
       return 1
     fi
   fi

--- a/lib/testing/stubbing
+++ b/lib/testing/stubbing
@@ -33,8 +33,11 @@
 # YOU MUST CALL THIS FROM TEARDOWN IF YOU USE `@go.create_core_module_stub`!
 @go.restore_stubbed_core_modules() {
   local module
+  local stubbed_modules=("$_GO_CORE_DIR/lib"/*.stubbed)
 
-  for module in "$_GO_CORE_DIR/lib"/*.stubbed; do
-    mv "$module" "${module%.stubbed}"
-  done
+  if [[ "${stubbed_modules#$_GO_CORE_DIR/lib/}" != '*.stubbed' ]]; then
+    for module in "${stubbed_modules[@]}"; do
+      mv "$module" "${module%.stubbed}"
+    done
+  fi
 }

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -99,7 +99,7 @@ load environment
   # Setting _GO_CMD will trick the script into thinking the shell function is
   # running it.
   
-  run env _GO_CMD='test-go' ./go aliases --help cd
+  _GO_CMD='test-go' run ./go aliases --help cd
   [ "$status" -eq '0' ]
 
   local expected=("test-go cd - Shell alias that will execute in $_GO_ROOTDIR")
@@ -109,7 +109,7 @@ load environment
   [ "${lines[1]}" == "${expected[1]}" ]
   [ -z "${lines[2]}" ]
 
-  run env _GO_CMD='test-go' ./go aliases --help pushd
+  _GO_CMD='test-go' run ./go aliases --help pushd
   [ "$status" -eq '0' ]
 
   expected[0]="${expected[0]/test-go cd/test-go pushd}"

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -21,7 +21,7 @@ load environment
 }
 
 @test "$SUITE: invoke editor on edit command" {
-  run env EDITOR=echo ./go edit 'editor invoked'
+  EDITOR=echo run ./go edit 'editor invoked'
   assert_success 'editor invoked'
 }
 

--- a/tests/core/columns.bats
+++ b/tests/core/columns.bats
@@ -28,18 +28,18 @@ teardown() {
 }
 
 @test "$SUITE: set COLUMNS if unset" {
-  run env COLUMNS= "$TEST_GO_SCRIPT"
+  COLUMNS= run "$TEST_GO_SCRIPT"
   assert_success
   [ -n "$output" ]
 }
 
 @test "$SUITE: honor COLUMNS if already set" {
-  run env COLUMNS="19700918" "$TEST_GO_SCRIPT"
+  COLUMNS="19700918" run "$TEST_GO_SCRIPT"
   assert_success '19700918'
 }
 
 @test "$SUITE: default COLUMNS to 80 if actual columns can't be determined" {
-  run env COLUMNS= PATH= "$BASH" "$TEST_GO_SCRIPT"
+  COLUMNS= PATH= run "$BASH" "$TEST_GO_SCRIPT"
   assert_success '80'
 }
 
@@ -60,7 +60,7 @@ teardown() {
   local expected_cols="$(env COLUMNS= tput cols)"
   exec 1>&27 27>&- 2>&1
 
-  run env COLUMNS= "$TEST_GO_SCRIPT"
+  COLUMNS= run "$TEST_GO_SCRIPT"
   assert_success "$expected_cols"
 }
 
@@ -73,6 +73,6 @@ teardown() {
 
   # One way to cause tput to fail is to set `$TERM` to null. On Travis it's set
   # to 'dumb', but tput fails anyway. The code now defaults to 80 on all errors.
-  run env COLUMNS= TERM= "$TEST_GO_SCRIPT"
+  COLUMNS= TERM= run "$TEST_GO_SCRIPT"
   assert_success "$expected_cols"
 }

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -3,11 +3,11 @@
 load environment
 
 @test "$SUITE: open file with EDITOR" {
-  run env EDITOR='echo' ./go edit foo/bar/baz
+  EDITOR='echo' run ./go edit foo/bar/baz
   assert_success 'foo/bar/baz'
 }
 
 @test "$SUITE: error if EDITOR not defined" {
-  run env EDITOR= ./go edit foo/bar/baz
+  EDITOR= run ./go edit foo/bar/baz
   assert_failure 'Cannot edit foo/bar/baz: $EDITOR not defined.'
 }

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -26,7 +26,7 @@ teardown() {
 
 @test "$SUITE: error if no implementation available for SHELL" {
   local shell='nonexistent-sh'
-  run env SHELL="$shell" "$TEST_GO_SCRIPT" env
+  SHELL="$shell" run "$TEST_GO_SCRIPT" env
 
   assert_failure
   assert_line_equals 0 "The $shell shell currently isn't supported."
@@ -37,7 +37,7 @@ teardown() {
   local go_script="$TEST_GO_ROOTDIR/go script"
   mv "$TEST_GO_SCRIPT" "$go_script"
 
-  run env SHELL='bash' "$go_script" env
+  SHELL='bash' run "$go_script" env
   assert_failure
 
   local expected="ERROR: the \"${go_script#$TEST_GO_ROOTDIR/}\" script "
@@ -49,7 +49,7 @@ teardown() {
   local go_script="$TEST_GO_ROOTDIR/my-go"
   mv "$TEST_GO_SCRIPT" "$go_script"
 
-  run env SHELL='bash' "$go_script" env
+  SHELL='bash' run "$go_script" env
   assert_success
   assert_line_matches 0 "Define the \"${go_script#$TEST_GO_ROOTDIR/}\" function"
   assert_line_equals 2 "eval \"\$($go_script env -)\""
@@ -58,7 +58,7 @@ teardown() {
 @test "$SUITE: error if shell impl doesn't contain eval line" {
   echo '' > "$_GO_ROOTDIR/lib/internal/env/badsh"
 
-  run env SHELL='badsh' "$TEST_GO_SCRIPT" env
+  SHELL='badsh' run "$TEST_GO_SCRIPT" env
   rm "$_GO_ROOTDIR/lib/internal/env/badsh"
 
   assert_failure
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "$SUITE: error if function name contains spaces" {
-  run env SHELL='bash' "$TEST_GO_SCRIPT" env 'foo bar'
+  SHELL='bash' run "$TEST_GO_SCRIPT" env 'foo bar'
   assert_failure
   assert_output_matches 'ERROR: "foo bar" must not contain spaces'
 }
@@ -78,7 +78,7 @@ teardown() {
   local go_script="$TEST_GO_ROOTDIR/$script_name"
   mv "$TEST_GO_SCRIPT" "$go_script"
 
-  run env SHELL='bash' "$go_script" env -
+  SHELL='bash' run "$go_script" env -
   assert_success
 
   ! command -v "_$script_name"
@@ -110,7 +110,7 @@ teardown() {
 
 @test "$SUITE: generate functions using specified name" {
   local func_name='never-collide-with-test-environment-go'
-  run env SHELL='bash' "$TEST_GO_SCRIPT" env "$func_name"
+  SHELL='bash' run "$TEST_GO_SCRIPT" env "$func_name"
   assert_success
 
   ! command -v "_$func_name"

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -88,16 +88,14 @@ write_kcov_dummy() {
 
   TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
-  local expected_output=(
-    "Cloning kcov repository from $__KCOV_URL..."
-    "Successfully cloned \"$__KCOV_URL\" reference \"$__KCOV_VERSION\" into "
-    'Installing dev packages to build kcov...'
-    'Building kcov...')
   assert_success
-  assert_lines_match "${expected_output[@]}"
+  assert_lines_match "Cloning kcov repository from $__KCOV_URL..." \
+    "Successfully cloned \"$__KCOV_URL\" reference \"$__KCOV_VERSION\" into " \
+    'Installing dev packages to build kcov...' \
+    'Building kcov...'
 
   assert_file_matches "$BATS_TEST_BINDIR/git.out" \
-    "clone .* -b master $__KCOV_URL tests/kcov"
+    "clone .* -b $__KCOV_VERSION $__KCOV_URL tests/kcov"
 
   IFS=' '
   assert_file_equals "$BATS_TEST_BINDIR/sudo.out" \

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -86,7 +86,7 @@ write_kcov_dummy() {
   # Use `mkdir` to create the target directory of `git clone`.
   echo 'mkdir -p "${@:$(($# - 1))}"' >> "$BATS_TEST_BINDIR/git"
 
-  run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
   local expected_output=(
     "Cloning kcov repository from $__KCOV_URL..."
@@ -110,7 +110,7 @@ write_kcov_dummy() {
   write_kcov_go_script '__clone_and_build_kcov tests/kcov'
   echo 'exit 1' >> "$BATS_TEST_BINDIR/git"
 
-  run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
   assert_failure
   assert_lines_match "Cloning kcov repository from $__KCOV_URL\.\.\." \
@@ -123,7 +123,7 @@ write_kcov_dummy() {
   echo 'exit 1' >> "$BATS_TEST_BINDIR/sudo"
   mkdir -p "$TEST_GO_ROOTDIR/tests/kcov"
 
-  run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
   local expected_output=(
     'Installing dev packages to build kcov...'
@@ -137,7 +137,7 @@ write_kcov_dummy() {
   mkdir -p "$TEST_GO_ROOTDIR/tests/kcov"
   echo 'exit 1' >> "$BATS_TEST_BINDIR/cmake"
 
-  run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
   local expected_output=(
     'Building kcov...'
@@ -151,7 +151,7 @@ write_kcov_dummy() {
   mkdir -p "$TEST_GO_ROOTDIR/tests/kcov"
   echo 'exit 1' >> "$BATS_TEST_BINDIR/make"
 
-  run env TRAVIS_OS_NAME= "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME= run "$TEST_GO_SCRIPT"
   . 'lib/kcov-ubuntu'
   local expected_output=(
     'Building kcov...'
@@ -165,7 +165,7 @@ write_kcov_dummy() {
     '__clone_and_build_kcov tests/kcov'
 
   mkdir -p "$TEST_GO_ROOTDIR/tests/kcov"
-  run env TRAVIS_OS_NAME='linux' "$TEST_GO_SCRIPT"
+  TRAVIS_OS_NAME='linux' run "$TEST_GO_SCRIPT"
   assert_success 'Building kcov...'
 }
 
@@ -208,7 +208,7 @@ write_kcov_dummy() {
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
 
-  run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  TRAVIS_JOB_ID= run "$TEST_GO_SCRIPT"
   local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
@@ -230,7 +230,7 @@ write_kcov_dummy() {
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
 
-  run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  TRAVIS_JOB_ID= run "$TEST_GO_SCRIPT"
   local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
@@ -247,7 +247,7 @@ write_kcov_dummy() {
     "  ${kcov_argv[*]}"
     'kcov exited with errors.')
 
-  run env TRAVIS_JOB_ID= "$TEST_GO_SCRIPT"
+  TRAVIS_JOB_ID= run "$TEST_GO_SCRIPT"
   local IFS=$'\n'
   assert_failure "${expected_output[*]}"
 }
@@ -266,7 +266,7 @@ write_kcov_dummy() {
     'Coverage results sent to:'
     "  $KCOV_COVERALLS_URL")
 
-  run env TRAVIS_JOB_ID=666 "$TEST_GO_SCRIPT"
+  TRAVIS_JOB_ID=666 run "$TEST_GO_SCRIPT"
   local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }
@@ -290,7 +290,7 @@ write_kcov_dummy() {
     'Coverage results located in:'
     "  $TEST_GO_ROOTDIR/$KCOV_COVERAGE_DIR")
 
-  run env TRAVIS_JOB_ID=666 "$TEST_GO_SCRIPT"
+  TRAVIS_JOB_ID=666 run "$TEST_GO_SCRIPT"
   local IFS=$'\n'
   assert_success "${expected_output[*]}"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -70,7 +70,7 @@ _trim_expected() {
 }
 
 @test "$SUITE: open EDITOR on --edit" {
-  run env EDITOR='echo' ./go test --edit test aliases 'builtins*'
+  EDITOR='echo' run ./go test --edit test aliases 'builtins*'
   local expected=(
     'tests/test.bats' 'tests/aliases.bats' 'tests/builtins.bats'
     tests/builtins/*)

--- a/tests/testing/stubbing.bats
+++ b/tests/testing/stubbing.bats
@@ -27,6 +27,11 @@ teardown() {
   assert_success 'Hello, World!'
 }
 
+@test "$SUITE: restore_stubbed_core_modules does nothing if no stubs exist" {
+  run @go.restore_stubbed_core_modules
+  assert_success ''
+}
+
 @test "$SUITE: create_core_module_stub aborts if module unknown" {
   [ ! -e "$_GO_CORE_DIR/lib/foobar" ]
   run @go.create_core_module_stub 'foobar' 'echo Hello, World!'


### PR DESCRIPTION
This is a collection of three small changes I want to merge before a more substantial change to extract `lib/bats-main` in the next PR:

- Previously, if no modules had been stubbed, `@go.restore_stubbed_core_modules` would
try to remove the glob pattern itself, resulting in an error message. Now it's a no-op if nothing's been stubbed.
- Updated `lib/kcov-ubuntu` to use the new `@go get git-repo` from #114.
- Replaced `run env VAR=foo` with `VAR=foo run` everywhere. Don't notice much of a performance impact on macOS, but it's more consistent with my more recent style and should save a process, which might make more of an impact on Windows.