### PR TITLE
Extract `lib/bats-main` and replace Bats submodule with a shallow clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.swp
 .DS_Store
+tests/bats/
 tests/coverage/
 tests/kcov/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "test/bats"]
-	path = tests/bats
-	url = https://github.com/sstephenson/bats
-	shallow = true

--- a/lib/bats-main
+++ b/lib/bats-main
@@ -1,0 +1,224 @@
+#! /bin/bash
+#
+# Run automated tests written using Bats
+#
+# Exports:
+#   @go.bats_main
+#     Parses command-line flags and arguments and executes Bats and Kcov
+#
+#   @go.bats_clone
+#     Creates a shallow clone of the Bats repository at `_GO_BATS_DIR`
+#
+#   @go.bats_tab_completion
+#     Provides command line argument completion
+#
+#   @go.bats_coverage
+#     Reinvokes the test command script using kcov to collect test coverage data
+#
+# If a project keeps all of its bats tests in `$_GO_ROOTDIR/tests`, test
+# commands need contain at a minimum:
+#
+#   . "$_GO_USE_MODULES" 'bats-main'
+#   @go.bats_main "$@"
+#
+# As a more realistic example, to enable tab completion and automatic coverage
+# collection on Travis CI that gets sent to Coveralls:
+#
+#   declare _GO_COVERAGE_INCLUDE
+#   _GO_COVERAGE_INCLUDE=('go' 'bin/' 'lib/' 'scripts/')
+#   declare _GO_COVERALLS_URL='https://coveralls.io/github/USER/PROJECT'
+#
+#   . "$_GO_USE_MODULES" 'bats-main'
+#   # Tab completions
+#   @go.bats_main "$@"
+#
+# There are many other variables that are available for fine-tuning, but
+# sticking to the above should cover most cases.
+#
+# Note that `@go.bats_main` will call `@go.bats_clone` to clone the Bats
+# repository if `_GO_BATS_DIR` doesn't yet exist. This means there's no need to
+# make the Bats repository a submodule if so desired. The Bats version so cloned
+# may be set by overriding `_GO_BATS_VERSION`.
+
+# Directory containing Bats tests, relative to `_GO_ROOTDIR`
+export _GO_TEST_DIR="${_GO_TEST_DIR:-tests}"
+
+# Directory in which kcov will be built
+export _GO_KCOV_DIR="${_GO_KCOV_DIR:-$_GO_TEST_DIR/kcov}"
+
+# Directory in which coverage results are written
+export _GO_BATS_COVERAGE_DIR="${_GO_BATS_COVERAGE_DIR:-$_GO_TEST_DIR/coverage}"
+
+# Directory containing the Bats testing framework sources
+export _GO_BATS_DIR="${_GO_BATS_DIR:-$_GO_TEST_DIR/bats}"
+
+# Path to the main Bats executable
+export _GO_BATS_PATH="$_GO_BATS_DIR/libexec/bats"
+
+# Version of Bats to fetch if `_GO_BATS_DIR` is missing
+export _GO_BATS_VERSION="${_GO_BATS_VERSION:-master}"
+
+# URL of the Bats git repository to clone to `_GO_BATS_DIR`
+export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/sstephenson/bats.git}"
+
+# Set this to nonempty if you wish to collect coverage using kcov by default
+export _GO_COLLECT_BATS_COVERAGE="$_GO_COLLECT_BATS_COVERAGE"
+
+# Array of patterns identifying sources to include in the coverage report
+export _GO_BATS_COVERAGE_INCLUDE
+_GO_BATS_COVERAGE_INCLUDE=("${_GO_BATS_COVERAGE_INCLUDE[@]}")
+
+# Array of patterns identifying sources to exclude from the coverage report
+export _GO_BATS_COVERAGE_EXCLUDE
+_GO_BATS_COVERAGE_EXCLUDE=('/tmp/' "${_GO_BATS_COVERAGE_EXCLUDE[@]}")
+
+# URL of the project's coverage statistics on Coveralls.io
+export _GO_COVERALLS_URL="${_GO_COVERALLS_URL}"
+
+# Collect coverage on Travis. Doesn't seem to slow anything down substantially.
+if [[ -n "$_GO_COVERALLS_URL" && "$TRAVIS_OS_NAME" == 'linux' ]]; then
+  declare _GO_COLLECT_BATS_COVERAGE='true'
+fi
+
+# Array of `./go glob` arguments to select Bats test files in `_GO_TEST_DIR`
+export _GO_BATS_GLOB_ARGS
+_GO_BATS_GLOB_ARGS=("${_GO_BATS_GLOB_ARGS[@]}")
+
+# Set _GO_BATS_GLOB_ARGS if the caller hasn't already done so. There should be
+# little need for the caller ever to do so, so long as the conventions encoded
+# in the above variables are followed.
+if [[ "${#_GO_BATS_GLOB_ARGS[@]}" -eq '0' ]]; then
+  _GO_BATS_GLOB_ARGS+=("$_GO_TEST_DIR" '.bats')
+
+  declare __go_bats_d="${_GO_BATS_DIR#$_GO_TEST_DIR/}"
+  if [[ "$__go_bats_d" != "$_GO_BATS_DIR" ]]; then
+    _GO_BATS_GLOB_ARGS=('--ignore' "${__go_bats_d}" "${_GO_BATS_GLOB_ARGS[@]}")
+    _GO_BATS_COVERAGE_EXCLUDE+=("${_GO_BATS_DIR}/")
+  fi
+  unset '__go_bats_d'
+fi
+
+# Parses command-line flags and arguments and executes Bats and Kcov
+#
+# The first argument can be one of the following flags:
+#
+#   --complete  Perform tab completion; see `{{go}} help complete` for details
+#   --coverage  Collect test coverage data using kcov (Linux only)
+#   --edit      Open matching test files using `{{go}} edit`
+#   --list      List test suite names without executing them
+#
+# If the argument list following is empty, or if it is only one of the flags
+# above (aside from `--complete`), all Bats test files are matched.
+#
+# Globals:
+#   _GO_BATS_GLOB_ARGS:  Array of arguments to '@go glob' to select Bats tests
+#   _GO_BATS_PATH:       The path to your project's Bats installation
+#   _GO_COLLECT_BATS_COVERAGE:  If set, collect coverage using kcov if available
+#   Also see `@go.bats_clone` and `@go.bats_coverage`
+#
+# Arguments:
+#   $1:   One of the flags defined above, or the first test glob pattern
+#   ...:  Remaining test glob patterns
+@go.bats_main() {
+  if [[ "$1" == '--complete' ]]; then
+    shift
+    @go.bats_tab_completion "$@"
+    return
+  fi
+  @go.bats_clone
+
+  if [[ "$1" == '--coverage' && -z "$__GO_COVERAGE_RUN" ]]; then
+    shift
+    export __GO_COVERAGE_RUN='true'
+    @go.bats_coverage "$@"
+  elif [[ "$1" == '--edit' ]]; then
+    shift
+    local tests=($(@go 'glob' "${_GO_BATS_GLOB_ARGS[@]}" "$@"))
+    @go 'edit' "${tests[@]}"
+  elif [[ "$1" == '--list' ]]; then
+    shift
+    @go 'glob' '--trim' "${_GO_BATS_GLOB_ARGS[@]}" "$@"
+  elif [[ -z "$__GO_COVERAGE_RUN" && -n "$_GO_COLLECT_BATS_COVERAGE" ]]; then
+    @go.bats_main '--coverage' "$@"
+  else
+    local tests=($(@go 'glob' "${_GO_BATS_GLOB_ARGS[@]}" "$@"))
+    time "$BASH" "$_GO_BATS_PATH" "${tests[@]}"
+  fi
+}
+
+# Creates a shallow clone of the Bats repository at `_GO_BATS_DIR`
+#
+# Does nothing if `_GO_BATS_DIR` is already present.
+#
+# Globals:
+#   _GO_BATS_DIR:      Location of the Bats sources
+#   _GO_BATS_URL:      URL of the Bats git repository to clone
+#   _GO_BATS_VERSION:  Tag or branch to clone from _GO_BATS_URL
+@go.bats_clone() {
+  if [[ ! -d "$_GO_BATS_DIR" ]]; then
+    @go get git-repo "$_GO_BATS_URL" "$_GO_BATS_VERSION" "$_GO_BATS_DIR"
+  fi
+}
+
+# Provides command line argument completion
+#
+# Emits the standard --coverage, --edit, and --list flags and uses '@go glob' to
+# produce a list of test name completions based on test file names.
+#
+# See './go help complete' for information on the argument completion protocol.
+#
+# Globals:
+#   _GO_BATS_GLOB_ARGS:  Array of arguments to '@go glob' to select Bats tests
+#
+# Arguments:
+#   word_index:  Zero-based index of the command line argument to be completed
+#   ...:         Array of remaining command line arguments
+@go.bats_tab_completion() {
+  local word_index="$1"
+  shift
+
+  # Skip over completing the initial `@go glob` args themselves.
+  local test_word_index="$((word_index + ${#_GO_BATS_GLOB_ARGS[@]}))"
+
+  if [[ "$word_index" -eq '0' ]]; then
+    echo '--coverage' '--edit' '--list'
+    if [[ "${1:0:1}" == '-' ]]; then
+      return
+    fi
+  fi
+  @go 'glob' '--complete' "$test_word_index" "${_GO_BATS_GLOB_ARGS[@]}" "$@"
+}
+
+# Reinvokes the test command script using kcov to collect test coverage data
+#
+# Currently only supported on Ubuntu Linux, via the core lib/kcov-ubuntu module.
+#
+# If the test suite passes and results are sent to Coveralls,
+# `_GO_COVERALLS_URL` is output to the console.
+#
+# Globals:
+#   _GO_KCOV_DIR:           Directory in which kcov will be built
+#   _GO_BATS_COVERAGE_DIR:  Directory in which coverage results are written
+#   _GO_COVERAGE_INCLUDE:   Patterns of files to include in the coverage report
+#   _GO_COVERAGE_EXCLUDE:   Patterns of files to include in the coverage report
+#   _GO_COVERALLS_URL:      The project's Coveralls URL
+#   _GO_SCRIPT:             Path to the `./go` script
+#   _GO_CMD_NAME:           Array comprising the `./go` command name
+#
+# Arguments:
+#   ...: Command line arguments for the command script run under kcov
+@go.bats_coverage() {
+  local include_paths
+  local exclude_paths
+
+  . "$_GO_USE_MODULES" 'kcov-ubuntu'
+  printf -v include_paths '%s,' "${_GO_BATS_COVERAGE_INCLUDE[@]}"
+  printf -v exclude_paths '%s,' "${_GO_BATS_COVERAGE_EXCLUDE[@]}"
+
+  time run_kcov "$_GO_KCOV_DIR" \
+    "$_GO_BATS_COVERAGE_DIR" \
+    "${include_paths%,}" \
+    "${exclude_paths%,}" \
+    "$_GO_COVERALLS_URL" \
+    "$_GO_SCRIPT" "${_GO_CMD_NAME[@]}" "$@"
+}

--- a/scripts/test
+++ b/scripts/test
@@ -23,18 +23,13 @@
 # This command script can serve as a template for your own project's test
 # script. Copy it into your project's script directory and customize as needed.
 
-declare _GO_BATS_COVERAGE_INCLUDE
-_GO_BATS_COVERAGE_INCLUDE=('go' 'go-core.bash' 'lib/' 'libexec/' 'scripts/')
-declare _GO_COVERALLS_URL='https://coveralls.io/github/mbland/go-script-bash'
-
 # Passes all arguments through to `@go.bats_main` from `lib/bats-main`.
 _test_main() {
+  local _GO_BATS_COVERAGE_INCLUDE
+  _GO_BATS_COVERAGE_INCLUDE=('go' 'go-core.bash' 'lib/' 'libexec/' 'scripts/')
+  local _GO_COVERALLS_URL='https://coveralls.io/github/mbland/go-script-bash'
+
   . "$_GO_USE_MODULES" 'bats-main'
-
-  if [[ ! -d "$_GO_BATS_DIR" ]]; then
-    git submodule update --init "$_GO_BATS_DIR"
-  fi
-
   # Tab completions
   @go.bats_main "$@"
 }

--- a/scripts/test
+++ b/scripts/test
@@ -23,111 +23,20 @@
 # This command script can serve as a template for your own project's test
 # script. Copy it into your project's script directory and customize as needed.
 
-# These variables are documented in the comments of the functions that use them
-# below.
-declare -r _GO_TEST_DIR='tests'
-declare -r _GO_TEST_GLOB_ARGS=('--ignore' 'bats' "$_GO_TEST_DIR" '.bats')
-declare -r _GO_BATS_DIR="$_GO_TEST_DIR/bats"
-declare -r _GO_BATS_PATH="$_GO_BATS_DIR/libexec/bats"
-declare -r _GO_COVERALLS_URL='https://coveralls.io/github/mbland/go-script-bash'
+declare _GO_BATS_COVERAGE_INCLUDE
+_GO_BATS_COVERAGE_INCLUDE=('go' 'go-core.bash' 'lib/' 'libexec/' 'scripts/')
+declare _GO_COVERALLS_URL='https://coveralls.io/github/mbland/go-script-bash'
 
-# Provides command line argument completion
-#
-# Emits the standard --coverage, --edit, and --list flags and uses '@go glob' to
-# produce a list of test name completions based on test file names.
-#
-# See './go help complete' for information on the argument completion protocol.
-#
-# Globals:
-#   _GO_TEST_GLOB_ARGS  An array of arguments to '@go glob' to select Bats tests
-#
-# Arguments:
-#   $1:   Zero-based index of the word to be completed from the remaining args
-#   ...:  Array of remaining command line arguments
-_test_tab_completion() {
-  local word_index="$1"
-  shift
-  if [[ "$word_index" -eq '0' ]]; then
-    echo '--coverage' '--edit' '--list'
-    if [[ "${1:0:1}" == '-' ]]; then
-      return
-    fi
-  fi
-  @go 'glob' '--complete' "$((word_index + ${#_GO_TEST_GLOB_ARGS[@]}))" \
-    "${_GO_TEST_GLOB_ARGS[@]}" "$@"
-}
-
-# Reinvokes the test command script using kcov to collect test coverage data
-#
-# Currently only supported on Ubuntu Linux, via the core kcov-ubuntu module.
-#
-# Globals:
-#   _GO_COVERALLS_URL  The project's Coveralls URL; appears in Travis output
-#
-# Arguments:
-#   $@: Command line arguments for the command script run under kcov
-_test_coverage() {
-  . "$_GO_USE_MODULES" 'kcov-ubuntu'
-  run_kcov "$_GO_TEST_DIR/kcov" \
-    "$_GO_TEST_DIR/coverage" \
-    'go,go-core.bash,lib/,libexec/,scripts/' \
-    "/tmp,$_GO_TEST_DIR/bats/" \
-    "$_GO_COVERALLS_URL" \
-    "$_GO_SCRIPT" "${_GO_CMD_NAME[@]}" "$@"
-}
-
-# Parses command-line flags and arguments and executes Bats and Kcov
-#
-# The first argument can be one of the following flags:
-#
-#   --complete  Perform tab completion; see `{{go}} help complete` for details
-#   --coverage  Collect test coverage data using kcov (Linux only)
-#   --list      List test suite names without executing them
-#   --edit      Open matching test files using `{{go}} edit`
-#
-# If the argument list following is empty, or if it is only one of the flags
-# above (aside from `--complete`), all Bats test files are matched.
-#
-# Globals:
-#   _GO_TEST_DIR        Test directory, relative to _GO_ROOTDIR
-#   _GO_TEST_GLOB_ARGS  An array of arguments to '@go glob' to select Bats tests
-#   _GO_BATS_DIR        Bats submodule path, relative to _GO_ROOTDIR
-#   _GO_BATS_PATH       The path to your project's Bats installation
-#
-# Arguments:
-#   $1:   One of the flags defined above, or the first test glob pattern
-#   ...:  Remaining test glob patterns
+# Passes all arguments through to `@go.bats_main` from `lib/bats-main`.
 _test_main() {
-  if [[ "$1" == '--complete' ]]; then
-    # Tab completions
-    shift
-    _test_tab_completion "$@"
-    return
-  fi
+  . "$_GO_USE_MODULES" 'bats-main'
 
-  if [[ ! -f "$_GO_BATS_PATH" ]]; then
+  if [[ ! -d "$_GO_BATS_DIR" ]]; then
     git submodule update --init "$_GO_BATS_DIR"
   fi
 
-  if [[ "$1" == '--coverage' && "$__COVERAGE_RUN" != 'true' ]]; then
-    shift
-    local -x __COVERAGE_RUN='true'
-    _test_coverage "$@"
-  elif [[ "$1" == '--list' ]]; then
-    shift
-    @go 'glob' '--trim' "${_GO_TEST_GLOB_ARGS[@]}" "$@"
-  elif [[ "$1" == '--edit' ]]; then
-    shift
-    local tests=($(@go 'glob' "${_GO_TEST_GLOB_ARGS[@]}" "$@"))
-    @go 'edit' "${tests[@]}"
-  elif [[ "$__COVERAGE_RUN" != 'true' && "$TRAVIS_OS_NAME" == 'linux' ]]; then
-    # Collect coverage by default on Travis. Doesn't seem to slow anything down
-    # substantially.
-    _test_main '--coverage' "$@"
-  else
-    local tests=($(@go 'glob' "${_GO_TEST_GLOB_ARGS[@]}" "$@"))
-    time "$BASH" "$_GO_BATS_PATH" "${tests[@]}"
-  fi
+  # Tab completions
+  @go.bats_main "$@"
 }
 
 _test_main "$@"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -88,14 +88,12 @@ _trim_expected() {
 
   stub_program_in_path 'git' 'echo "GIT ARGV: $*"'
 
-  # This will fail because we didn't create the tests/ directory, but git should
-  # have been called correctly.
+  # Note that rather than running our own `./go` script, we're running
+  # `TEST_GO_SCRIPT` instead. This will fail because we didn't create the tests/
+  # directory, but `git` should have been called correctly.
   run "$TEST_GO_SCRIPT" test --list test
-
-  # Since `test` will try to clone the submodule, but the `git` stub doesn't
-  # actually do anything, `@go.bats_main` will then call `@go.bats_clone`.
   assert_failure
-  assert_lines_match '^GIT ARGV: submodule update --init tests/bats$' \
+  assert_lines_match \
     "^GIT ARGV: clone .* -b $_GO_BATS_VERSION $_GO_BATS_URL $_GO_BATS_DIR\$" \
     "^Successfully cloned \"$_GO_BATS_URL\" .* \"$_GO_BATS_DIR\"" \
     '^Root directory argument tests is not a directory\.$'

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -30,19 +30,28 @@ quotify_expected() {
   local search_paths=("[0]=\"$_GO_CORE_DIR/libexec\""
     "[1]=\"$TEST_GO_SCRIPTS_DIR\"")
 
-  local expected=("declare -rx _GO_CMD=\"$TEST_GO_SCRIPT\""
+  local expected=("declare -x _GO_BATS_COVERAGE_DIR=\"$_GO_BATS_COVERAGE_DIR\""
+    "declare -x _GO_BATS_DIR=\"$_GO_BATS_DIR\""
+    "declare -x _GO_BATS_PATH=\"$_GO_BATS_PATH\""
+    "declare -x _GO_BATS_URL=\"$_GO_BATS_URL\""
+    "declare -x _GO_BATS_VERSION=\"$_GO_BATS_VERSION\""
+    "declare -rx _GO_CMD=\"$TEST_GO_SCRIPT\""
     'declare -ax _GO_CMD_ARGV=()'
     'declare -ax _GO_CMD_NAME=([0]="vars")'
+    "declare -x _GO_COLLECT_BATS_COVERAGE=\"$_GO_COLLECT_BATS_COVERAGE\""
     "declare -rx _GO_CORE_DIR=\"$_GO_CORE_DIR\""
     "declare -rx _GO_CORE_URL=\"$_GO_CORE_URL\""
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
+    "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
     'declare -a _GO_IMPORTED_MODULES=()'
+    "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
     'declare -- _GO_PLUGINS_DIR=""'
     'declare -a _GO_PLUGINS_PATHS=()'
     "declare -rx _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
+    "declare -x _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
@@ -78,19 +87,28 @@ quotify_expected() {
     '[1]="format"'
     '[2]="strings"'
     '[3]="validation"')
-  local expected=("declare -rx _GO_CMD=\"$TEST_GO_SCRIPT\""
+  local expected=("declare -x _GO_BATS_COVERAGE_DIR=\"$_GO_BATS_COVERAGE_DIR\""
+    "declare -x _GO_BATS_DIR=\"$_GO_BATS_DIR\""
+    "declare -x _GO_BATS_PATH=\"$_GO_BATS_PATH\""
+    "declare -x _GO_BATS_URL=\"$_GO_BATS_URL\""
+    "declare -x _GO_BATS_VERSION=\"$_GO_BATS_VERSION\""
+    "declare -rx _GO_CMD=\"$TEST_GO_SCRIPT\""
     "declare -ax _GO_CMD_ARGV=(${cmd_argv[*]})"
     'declare -ax _GO_CMD_NAME=([0]="test-command" [1]="test-subcommand")'
+    "declare -x _GO_COLLECT_BATS_COVERAGE=\"$_GO_COLLECT_BATS_COVERAGE\""
     "declare -rx _GO_CORE_DIR=\"$_GO_CORE_DIR\""
     "declare -rx _GO_CORE_URL=\"$_GO_CORE_URL\""
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
+    "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
     "declare -a _GO_IMPORTED_MODULES=(${expected_modules[*]})"
+    "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
     "declare -- _GO_PLUGINS_DIR=\"$TEST_GO_PLUGINS_DIR\""
     "declare -a _GO_PLUGINS_PATHS=(${plugins_paths[*]})"
     "declare -rx _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
+    "declare -x _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
@@ -114,13 +132,22 @@ quotify_expected() {
     '}'
   run "$TEST_GO_SCRIPT" test-command test-subcommand foo bar 'baz quux' xyzzy
   assert_success
-  assert_lines_equal "_GO_CMD: $TEST_GO_SCRIPT" \
+  assert_lines_equal "_GO_BATS_COVERAGE_DIR: $_GO_BATS_COVERAGE_DIR" \
+    "_GO_BATS_DIR: $_GO_BATS_DIR" \
+    "_GO_BATS_PATH: $_GO_BATS_PATH" \
+    "_GO_BATS_URL: $_GO_BATS_URL" \
+    "_GO_BATS_VERSION: $_GO_BATS_VERSION" \
+    "_GO_CMD: $TEST_GO_SCRIPT" \
     $'_GO_CMD_ARGV: foo\x1fbar\x1fbaz quux\x1fxyzzy' \
     $'_GO_CMD_NAME: test-command\x1ftest-subcommand' \
+    "_GO_COLLECT_BATS_COVERAGE: $_GO_COLLECT_BATS_COVERAGE" \
     "_GO_CORE_DIR: $_GO_CORE_DIR" \
     "_GO_CORE_URL: $_GO_CORE_URL" \
     "_GO_CORE_VERSION: $_GO_CORE_VERSION" \
+    "_GO_COVERALLS_URL: $_GO_COVERALLS_URL" \
+    "_GO_KCOV_DIR: $_GO_KCOV_DIR" \
     "_GO_ROOTDIR: $TEST_GO_ROOTDIR" \
     "_GO_SCRIPT: $TEST_GO_SCRIPT" \
+    "_GO_TEST_DIR: $_GO_TEST_DIR" \
     "_GO_USE_MODULES: $_GO_USE_MODULES"
 }


### PR DESCRIPTION
Been thinking about extracting `lib/bats-main` for a while. Now that I'm beginning to write plugins that I want to test using the same command line interface to Bats, but without copying and pasting a ton of code, I finally became motivated to extract most of the logic from `scripts/test` into `lib/bats-main`, with some improvements.

`tests/test.bats` required very few changes to stay up-to-date with the new architecture. `tests/vars.bats` was another story, since all the new `_GO_*` vars in `lib/bats-main` now show up in the output.

There probably are a few more test cases that could be added to validate different configuration variable scenarios; I'll consider adding them in a future commit/PR.

With regards to replacing the Bats submodule with a shallow clone, the theory is that this will work better when trying to compose projects using the framework and its plugins, since it won't be a web of submodules all the way down. By creating shallow clones on demand when the `./go` script for the framework, a plugin, or an application is executed, we may avoid creating circular dependencies and generally reduce the amount of bandwidth and disk space consumed by each build.