### PR TITLE
Fix failing `./go get` tests across platforms

### DIFF
--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -201,9 +201,12 @@ _@go.get_file() {
   fi
   download_dir="${download_dir:-$PWD}"
 
-  if [[ -e "$url" ]]; then
+  if [[ -f "$url" ]]; then
     if [[ "${url:0:1}" != '/' ]]; then
       url="${PWD}/${url}"
+    fi
+    if [[ "$url" =~ ^/[^/]+ && -d "$BASH_REMATCH/Windows" ]]; then
+      url="${BASH_REMATCH}:/${url#$BASH_REMATCH/}"
     fi
     url="file://${url}"
   fi

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Downloads a single file using `curl` or `wget`
+# Downloads a single file using `curl`, `fetch`, or `wget`
 #
 # Usage:
 #   {{go}} {{cmd}} [-f <filename>] <url>
@@ -11,10 +11,13 @@
 # Where:
 #   url:  URL of the file to download
 #
-# This is a basic wrapper over the system `curl` or `wget` for downloading a
-# single file. If `-f <filename>` isn't specified, it will download the target
-# of `url` to the current working directory, using the same file name as that in
-# the URL.
+# Globals:
+#   _GO_GET_FILE_DOWNLOAD_COMMAND:  Overrides download program detection
+#
+# This is a basic wrapper over the system `curl`, `fetch` (on FreeBSD), or
+# `wget` for downloading a single file. If `-f <filename>` isn't specified, it
+# will download the target of `url` to the current working directory, using
+# the same file name as that in the URL.
 #
 # If `-f <filename>` is specified:
 #
@@ -61,7 +64,7 @@ _@go.get_file_tab_completions() {
 _@go.get_file_download_command() {
   local filename="$1"
   local dl_cmd="$_GO_GET_FILE_DOWNLOAD_COMMAND"
-  local supported=('curl' 'wget')
+  local supported=('curl' 'fetch' 'wget')
 
   if [[ -z "$dl_cmd" ]]; then
     for dl_cmd in "${supported[@]}"; do
@@ -81,6 +84,9 @@ _@go.get_file_download_command() {
     if [[ -n "$filename" ]]; then
       __go_get_file_download_cmd+=('-o' "$filename")
     fi
+    ;;
+  fetch)
+    __go_get_file_download_cmd=("$dl_cmd" '-o' "${filename:--}")
     ;;
   wget)
     __go_get_file_download_cmd=("$dl_cmd" '-O' "${filename:--}")

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -30,7 +30,7 @@
 # Arguments:
 #   word_index:  Index of the item to complete from the command line arg array
 #   ...:         Command line argument array
-_@go.fetch_file_tab_completions() {
+_@go.get_file_tab_completions() {
   local word_index="$1"
   shift
 
@@ -46,6 +46,56 @@ _@go.fetch_file_tab_completions() {
   esac
 }
 
+# Determines the download program to use and builds the command line
+#
+# Globals:
+#   _GO_GET_FILE_DOWNLOAD_COMMAND:  Overrides automatic program detection
+#   __go_get_file_download_cmd:     Caller-declared result array
+#
+# Arguments:
+#   filename:  Name of the file to download
+#
+# Returns:
+#   Zero if a suitable program was detected and `__go_get_file_download_cmd`
+#     was successfully built, nonzero otherwise
+_@go.get_file_download_command() {
+  local filename="$1"
+  local dl_cmd="$_GO_GET_FILE_DOWNLOAD_COMMAND"
+  local supported=('curl' 'wget')
+
+  if [[ -z "$dl_cmd" ]]; then
+    for dl_cmd in "${supported[@]}"; do
+      if command -v "$dl_cmd" >/dev/null; then
+        break
+      fi
+      dl_cmd=''
+    done
+  elif ! command -v "$dl_cmd" >/dev/null; then
+    @go.printf 'Download program not found on this system: %s\n' "$dl_cmd" >&2
+    dl_cmd=''
+  fi
+
+  case "${dl_cmd##*/}" in
+  curl)
+    __go_get_file_download_cmd=("$dl_cmd" '-L')
+    if [[ -n "$filename" ]]; then
+      __go_get_file_download_cmd+=('-o' "$filename")
+    fi
+    ;;
+  wget)
+    __go_get_file_download_cmd=("$dl_cmd" '-O' "${filename:--}")
+    ;;
+  *)
+    if [[ -n "$dl_cmd" ]]; then
+      @go.printf 'Download program not supported: %s\n' "$dl_cmd" >&2
+    fi
+    @go.printf 'Please install curl or wget before running "%s".' \
+      "${_GO_CMD_NAME[*]}" >&2
+    return 1
+    ;;
+  esac
+}
+
 # Implements the script behavior per the top-level description
 #
 # If `filename` is empty, the content will be directed to standard output and
@@ -55,25 +105,16 @@ _@go.fetch_file_tab_completions() {
 #   download_dir:  Directory into which to download the file, if not stdout
 #   filename:      Name of the file to save to `download_dir`, if not stdout
 #   url:           URL of the file ot download
-_@go.fetch_file_impl() {
+_@go.get_file_impl() {
   local download_dir="$1"
   local filename="$2"
   local url="$3"
   local result='0'
-  local dl_cmd=()
-  local errfile="${url##*/}.fetch-error"
+  local errfile="${url##*/}.get-error"
   local errmsg
 
-  if command -v curl >/dev/null; then
-    dl_cmd=('curl' '-L')
-    if [[ -n "$filename" ]]; then
-      dl_cmd+=('-o' "$filename")
-    fi
-  elif command -v wget >/dev/null; then
-    dl_cmd=('wget' '-O' "${filename:--}")
-  else
-    @go.printf 'Please install curl or wget before running "%s".' \
-      "${_GO_CMD_NAME[*]}" >&2
+  local __go_get_file_download_cmd=()
+  if ! _@go.get_file_download_command "$filename"; then
     return 1
   fi
 
@@ -90,15 +131,16 @@ _@go.fetch_file_impl() {
         "$download_dir" >&2
       return 1
     fi
-    errfile="${filename}.fetch-error"
+    errfile="${filename}.get-error"
   fi
 
-  if ! "${dl_cmd[@]}" "$url" 2>"$errfile"; then
+  if ! "${__go_get_file_download_cmd[@]}" "$url" 2>"$errfile"; then
     errmsg="$(< "$errfile")"
     printf '%s\n' "$errmsg" >&2
-    @go.printf 'Failed to download using %s: %s' "${dl_cmd[0]}" "$url" >&2
+    @go.printf 'Failed to download using %s: %s' \
+      "${__go_get_file_download_cmd[0]}" "$url" >&2
 
-    if [[ "${dl_cmd[0]}" != 'curl' ]]; then
+    if [[ "${__go_get_file_download_cmd[0]}" != 'curl' ]]; then
       @go.printf 'Consider installing `curl` and trying again.\n' >&2
     fi
 
@@ -115,10 +157,10 @@ _@go.fetch_file_impl() {
   return "$result"
 }
 
-# Parses the command line flags before invoking _@go.fetch_file_impl
+# Parses the command line flags before invoking _@go.get_file_impl
 #
 # The arguments are the same as in the script description.
-_@go.fetch_file() {
+_@go.get_file() {
   local url
   local download_dir
   local filename
@@ -127,7 +169,7 @@ _@go.fetch_file() {
   case "$1" in
   --complete)
     # Tab completions
-    _@go.fetch_file_tab_completions "${@:2}"
+    _@go.get_file_tab_completions "${@:2}"
     return
     ;;
   -f)
@@ -159,7 +201,7 @@ _@go.fetch_file() {
     fi
     url="file://${url}"
   fi
-  _@go.fetch_file_impl "$download_dir" "$filename" "$url"
+  _@go.get_file_impl "$download_dir" "$filename" "$url"
 }
 
-_@go.fetch_file "$@"
+_@go.get_file "$@"

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -96,9 +96,9 @@ _@go.fetch_file_impl() {
   if ! "${dl_cmd[@]}" "$url" 2>"$errfile"; then
     errmsg="$(< "$errfile")"
     printf '%s\n' "$errmsg" >&2
-    @go.printf 'Failed to download: %s' "$url" >&2
+    @go.printf 'Failed to download using %s: %s' "${dl_cmd[0]}" "$url" >&2
 
-    if [[ "${dl_cmd[0]}" == 'wget' && "$errmsg" =~ Unsupported\ scheme ]]; then
+    if [[ "${dl_cmd[0]}" != 'curl' ]]; then
       @go.printf 'Consider installing `curl` and trying again.\n' >&2
     fi
 

--- a/libexec/get.d/git-repo
+++ b/libexec/get.d/git-repo
@@ -22,7 +22,7 @@
 # Implements the script behavior per the top-level description
 #
 # The arguments are the same as in the script description.
-_@go.git_repo_impl() {
+_@go.get_git_repo_impl() {
   local repo_url="$1"
   local git_ref="$2"
   local clone_dir="$3"
@@ -43,10 +43,10 @@ _@go.git_repo_impl() {
   @go.printf 'Successfully cloned %s.\n' "$repo_msg"
 }
 
-# Parses the command line flags before invoking _@go.git_repo_impl
+# Parses the command line flags before invoking _@go.get_git_repo_impl
 #
 # The arguments are the same as in the script description.
-_@go.git_repo() {
+_@go.get_git_repo() {
   local repo_url="$1"
   local git_ref="$2"
   local clone_dir="$3"
@@ -68,7 +68,7 @@ _@go.git_repo() {
     repo_url="file://$repo_url"
   fi
 
-  _@go.git_repo_impl "$repo_url" "$git_ref" "$clone_dir"
+  _@go.get_git_repo_impl "$repo_url" "$git_ref" "$clone_dir"
 }
 
-_@go.git_repo "$@"
+_@go.get_git_repo "$@"

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -25,7 +25,7 @@ teardown() {
   run "$TEST_GO_SCRIPT" get file --complete 0
   assert_success '-f'
 
-  local expected
+  local expected=()
   local item
   while IFS= read -r item; do
     expected+=("$item")

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -25,7 +25,11 @@ teardown() {
   run "$TEST_GO_SCRIPT" get file --complete 0
   assert_success '-f'
 
-  local expected=("$TEST_GO_ROOTDIR"/*)
+  local expected
+  local item
+  while IFS= read -r item; do
+    expected+=("$item")
+  done <<<"$(compgen -f -- "$TEST_GO_ROOTDIR/")"
   test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
 
   run "$TEST_GO_SCRIPT" get file --complete 1 -f

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -153,7 +153,8 @@ teardown() {
 @test "$SUITE: show failure message if curl fails" {
   stub_program_in_path 'curl' 'printf "Oh noes!\n" >&2' 'exit 1'
   run "$TEST_GO_SCRIPT" get file http://localhost/foobar.txt
-  assert_failure 'Oh noes!' 'Failed to download: http://localhost/foobar.txt'
+  assert_failure 'Oh noes!' \
+    'Failed to download using curl: http://localhost/foobar.txt'
 }
 
 @test "$SUITE: use real curl to copy a local file" {
@@ -202,10 +203,11 @@ teardown() {
   PATH="${PATH%%:*}:/bin" run "$BASH" "$TEST_GO_SCRIPT" \
     get file -f - "$source_path"
 
-  # Note that `wget` uses "smart" quotes around `file` on some platforms, so we
-  # have to use a regex.
+  # Note that `wget` uses "smart" quotes around `file` on some platforms, and
+  # has a completely different error message on others (e.g. Busybox/Arch
+  # Linux), so we have to use a regex.
   assert_failure
-  assert_lines_match "^file://$source_path: Unsupported scheme .file.\.$" \
-    "^Failed to download: file://$source_path$" \
+  assert_lines_match "file://$source_path" \
+    "^Failed to download using wget: file://$source_path$" \
     '^Consider installing `curl` and trying again\.$'
 }

--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -24,7 +24,11 @@ teardown() {
   run "$TEST_GO_SCRIPT" get git-repo --complete 1
   assert_success ''
 
-  local expected=("$TEST_GO_ROOTDIR"/*)
+  local expected=()
+  local item
+  while IFS= read -r item; do
+    expected+=("$item")
+  done <<<"$(compgen -f -- "$TEST_GO_ROOTDIR/")"
   test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
 
   run "$TEST_GO_SCRIPT" get git-repo --complete 2


### PR DESCRIPTION
This resolves several small issues affecting Alpine Linux, Arch Linux, FreeBSD, and MSYS2 (Windows). Also adds support to `./go get file` for the FreeBSD `fetch` command.