### PR TITLE
complete: Don't change to `_GO_ROOTDIR`

### DIFF
--- a/lib/complete
+++ b/lib/complete
@@ -3,9 +3,52 @@
 # Automatic command and argument completion utilities
 #
 # Exports:
+#   @go.compgen
+#     Wrapper around the `compgen` to ensure compatibility with `./go complete`
 #
 #   @go.complete_remove_completions_already_present
 #     Removes completion values already present in an argument array
+
+# Wrapper around the `compgen` to ensure compatibility with `./go complete`
+#
+# Use this instead of using `compgen` directly, especially if you are using the
+# `-f` or `-d` options to generate file or directory paths.
+#
+# Arguments:
+#   ...:  Arguments passed directly ot the builtin `compgen`
+@go.compgen() {
+  local add_slashes
+  local compreply=()
+  local reply_item
+  local compgen_exit_index
+
+  while IFS= read -r reply_item; do
+    compreply+=("$reply_item")
+  done < <(trap 'echo "$?"' EXIT; compgen "$@"; exit "$?")
+
+  compgen_exit_index="$((${#compreply[@]} - 1))"
+
+  if [[ "${compreply[$compgen_exit_index]}" -ne '0' ]]; then
+    return "${compreply[$compgen_exit_index]}"
+  fi
+  unset "compreply[$compgen_exit_index]"
+
+  if [[ "$1" =~ ^-[df]$ ]]; then
+    add_slashes='true'
+  fi
+
+  for reply_item in "${compreply[@]}"; do
+    # Since we're not using -o filenames, we must add slashes to dir names.
+    # Since we're using -o nospace, we must add a space to a single match.
+    if [[ -n "$add_slashes" && -d "$reply_item" ]]; then
+      printf -- '%s/\n' "$reply_item"
+    elif [[ "${#compreply[@]}" -eq '1' && ! $reply_item =~ [\ /]$ ]]; then
+      printf -- '%s \n' "$reply_item"
+    else
+      printf -- '%s\n' "$reply_item"
+    fi
+  done
+}
 
 # Removes completion values already present in an argument array
 #

--- a/lib/internal/env/bash
+++ b/lib/internal/env/bash
@@ -4,8 +4,10 @@
 
 __go_func() {
   unset 'COMP_WORDS[0]'
-  COMPREPLY=($("$_GO_SCRIPT" 'complete' "$((COMP_CWORD-1))" "${COMP_WORDS[@]}"))
-  cd "$_GO_ROOTDIR"
+  local item
+  while IFS= read -r item; do
+    COMPREPLY+=("$item")
+  done < <("$_GO_SCRIPT" 'complete' "$((COMP_CWORD-1))" "${COMP_WORDS[@]}")
 }
 
 _go_func() {
@@ -25,4 +27,4 @@ _go_func() {
   esac
 }
 
-complete -o filenames -F __go_func _go_func
+complete -o nospace -F __go_func _go_func

--- a/libexec/complete
+++ b/libexec/complete
@@ -25,6 +25,12 @@
 #
 # * Notes on implementing argument completion:
 #
+# - Considering calling `. "$_GO_USE_MODULES" 'complete'` to make use of common
+# helper functions.
+#
+# - If you need to call `compgen -f` or `compgen -d`, you must use `@go.compgen`
+# from `lib/complete` or otherwise ensure that directory names end with `/`.
+#
 # - If you wish to implement custom argument completion in your own command
 # scripts, your script must contain a `# Tab completions` comment and respond to
 # the `--complete` command line interface described above.
@@ -37,6 +43,8 @@
 # - Subcommand scripts stored in `<parent>.d` directories are automatically
 # added to the argument completions for `{{go}} <parent>` and do not need to be
 # explicitly implemented.
+
+. "$_GO_USE_MODULES" 'complete'
 
 _@go.complete_command() {
   local __go_complete_word_index
@@ -66,16 +74,16 @@ _@go.complete_args() {
   if [[ "$word_index" -eq '0' ]]; then
     case "$cmd_name" in
     -h)
-      echo '-h'
+      printf -- '-h \n'
       ;;
     -he*)
-      echo '-help'
+      printf -- '-help \n'
       ;;
     -|--*)
-      echo '--help'
+      printf -- '--help \n'
       ;;
     *)
-      compgen -W "$(_@go.complete_top_level_commands)" -- "$cmd_name"
+      @go.compgen -W "$(_@go.complete_top_level_commands)" -- "$cmd_name"
       ;;
     esac
     return
@@ -83,11 +91,11 @@ _@go.complete_args() {
 
   case "$cmd_name" in
   cd|pushd)
-    compgen -d -- "$word"
+    @go.compgen -d -- "$word"
     return
     ;;
   edit|run)
-    compgen -f -- "$word"
+    @go.compgen -f -- "$word"
     return
     ;;
   -h|-help|--help)
@@ -99,12 +107,12 @@ _@go.complete_args() {
   esac
 
   if _@go.source_builtin 'aliases' --exists "$cmd_name"; then
-    compgen -f -- "$word"
+    @go.compgen -f -- "$word"
     return
   fi
 
   unset 'args[0]'
-  compgen -W \
+  @go.compgen -W \
     "$(_@go.complete_command "$word_index" "$cmd_name" "${args[@]}")" -- "$word"
 }
 

--- a/libexec/fullpath
+++ b/libexec/fullpath
@@ -17,7 +17,8 @@ _@go.fullpath_tab_completion() {
   if [[ "$word_index" -eq '0' ]]; then
     echo '--existing'
   fi
-  compgen -f -- "$word"
+  . "$_GO_USE_MODULES" 'complete'
+  @go.compgen -f -- "$word"
 }
 
 _@go.fullpath() {

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -43,7 +43,8 @@ _@go.get_file_tab_completions() {
     ;;
   1)
     if [[ "$1" == '-f' ]]; then
-      compgen -f -- "$2"
+      . "$_GO_USE_MODULES" 'complete'
+      @go.compgen -f -- "$2"
     fi
     ;;
   esac

--- a/libexec/get.d/git-repo
+++ b/libexec/get.d/git-repo
@@ -54,7 +54,8 @@ _@go.get_git_repo() {
   if [[ "$1" == '--complete' ]]; then
     # Tab completions
     if [[ "$2" -eq '2' ]]; then
-      compgen -f -- "$3"
+      . "$_GO_USE_MODULES" 'complete'
+      @go.compgen -f -- "$3"
     fi
     return
   fi

--- a/libexec/glob
+++ b/libexec/glob
@@ -193,7 +193,8 @@ _@go.glob_tab_completion() {
     return
   elif [[ -z "$__go_glob_rootdir" ]]; then
     echo "${__go_glob_flags[@]}"
-    compgen -d -- "$__go_glob_complete_word"
+    . "$_GO_USE_MODULES" 'complete'
+    @go.compgen -d -- "$__go_glob_complete_word"
     return
   fi
 

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -11,10 +11,10 @@ load environment
 
 @test "$SUITE: tab completions" {
   run ./go complete 1 aliases ''
-  assert_success '--exists'
+  assert_success '--exists '
 
   run ./go complete 1 aliases -
-  assert_success '--exists'
+  assert_success '--exists '
 
   run ./go complete 2 aliases --exists
   assert_failure ''

--- a/tests/changes.bats
+++ b/tests/changes.bats
@@ -28,10 +28,10 @@ teardown() {
   assert_success "${versions[*]}"
 
   run ./go complete 1 changes 'v1.0'
-  assert_success 'v1.0.0'
+  assert_success 'v1.0.0 '
 
   run ./go complete 2 changes 'v1.0.0' 'v1.1'
-  assert_success 'v1.1.0'
+  assert_success 'v1.1.0 '
 
   run ./go complete 3 changes 'v1.0.0' 'v1.1.0' ''
   assert_failure ''

--- a/tests/commands/main.bats
+++ b/tests/commands/main.bats
@@ -4,6 +4,7 @@ load ../environment
 load helpers
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
   find_builtins
 
@@ -22,25 +23,24 @@ teardown() {
   run "$TEST_GO_SCRIPT" complete 1 commands ''
   local flags=('--paths' '--summaries')
   local expected=("${flags[@]}" "${BUILTIN_CMDS[@]}")
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 1 commands --
   local flags=('--paths' '--summaries')
-  assert_success "${flags[*]}"
+  assert_success "${flags[@]}"
 
   run "$TEST_GO_SCRIPT" complete 1 commands --p
   local flags=('--paths')
-  assert_success '--paths'
+  assert_success '--paths '
 
   run "$TEST_GO_SCRIPT" complete 1 commands --foo
   assert_failure
 
   run "$TEST_GO_SCRIPT" complete 2 commands --paths
-  assert_success "${BUILTIN_CMDS[*]}"
+  assert_success "${BUILTIN_CMDS[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 commands --summaries
-  assert_success "${BUILTIN_CMDS[*]}"
+  assert_success "${BUILTIN_CMDS[@]}"
 }
 
 @test "$SUITE: no tab completions for or after search paths" {
@@ -63,12 +63,11 @@ teardown() {
   done
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo b
   expected=('bar' 'baz')
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo g
   assert_failure
@@ -90,8 +89,7 @@ teardown() {
 
   run "$TEST_GO_SCRIPT" complete 1 commands '' foo
   expected=('--paths' '--summaries')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo '' bar
   assert_failure
@@ -148,8 +146,7 @@ teardown() {
   @go.create_test_command_script 'plugins/xyzzy.d/child5'
 
   run "$TEST_GO_SCRIPT" commands
-  local IFS=$'\n'
-  assert_success "${__all_scripts[*]##*/}"
+  assert_success "${__all_scripts[@]##*/}"
 }
 
 @test "$SUITE: specify plugins and user search paths, omit builtins" {
@@ -159,12 +156,10 @@ teardown() {
 
   add_scripts "$TEST_GO_SCRIPTS_DIR" "${user_commands[@]}"
   add_scripts "$TEST_GO_SCRIPTS_DIR/plugins" "${plugin_commands[@]}"
-  local IFS=':'
-  local search_paths=("$TEST_GO_SCRIPTS_DIR/plugins" "$TEST_GO_SCRIPTS_DIR")
+  local search_paths="$TEST_GO_SCRIPTS_DIR/plugins:$TEST_GO_SCRIPTS_DIR"
 
   run "$TEST_GO_SCRIPT" commands "${search_paths[*]}"
-  IFS=$'\n'
-  assert_success "${__all_scripts[*]##*/}"
+  assert_success "${__all_scripts[@]##*/}"
 }
 
 generate_expected_paths() {
@@ -197,8 +192,7 @@ generate_expected_paths() {
   generate_expected_paths
 
   run "$TEST_GO_SCRIPT" commands --paths
-  local IFS=$'\n'
-  assert_success "${__expected_paths[*]}"
+  assert_success "${__expected_paths[@]}"
 }
 
 create_script_with_description() {
@@ -218,12 +212,11 @@ create_script_with_description() {
   done
 
   run "$TEST_GO_SCRIPT" commands --summaries "$TEST_GO_SCRIPTS_DIR"
-  local IFS=$'\n'
   local expected=(
     '  bar  Does bar stuff'
     '  baz  Does baz stuff'
     '  foo  Does foo stuff')
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: subcommand list, paths, and summaries" {
@@ -244,8 +237,7 @@ create_script_with_description() {
   done
 
   run "$TEST_GO_SCRIPT" commands 'foo'
-  local IFS=$'\n'
-  assert_success "${subcommands[*]}"
+  assert_success "${subcommands[@]}"
 
   local expected_paths=(
     'plugh  scripts/foo.d/plugh'
@@ -253,12 +245,12 @@ create_script_with_description() {
     'xyzzy  scripts/foo.d/xyzzy')
 
   run "$TEST_GO_SCRIPT" commands --paths 'foo'
-  assert_success "${expected_paths[*]}"
+  assert_success "${expected_paths[@]}"
 
   local expected_summaries=(
     '  plugh  Does plugh stuff'
     '  quux   Does quux stuff'
     '  xyzzy  Does xyzzy stuff')
   run "$TEST_GO_SCRIPT" commands --summaries 'foo'
-  assert_success "${expected_summaries[*]}"
+  assert_success "${expected_summaries[@]}"
 }

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -6,6 +6,7 @@ load commands/helpers
 setup() {
   @go.create_test_go_script '@go "$@"'
   find_builtins
+  . "$_GO_USE_MODULES" 'complete'
 }
 
 teardown() {
@@ -14,16 +15,16 @@ teardown() {
 
 @test "$SUITE: complete help flag variations" {
   run "$TEST_GO_SCRIPT" complete 0 -h
-  assert_success '-h'
+  assert_success '-h '
 
   run "$TEST_GO_SCRIPT" complete 0 -he
-  assert_success '-help'
+  assert_success '-help '
 
   run "$TEST_GO_SCRIPT" complete 0 -
-  assert_success '--help'
+  assert_success '--help '
 
   run "$TEST_GO_SCRIPT" complete 0 --
-  assert_success '--help'
+  assert_success '--help '
 }
 
 @test "$SUITE: all top-level commands for zeroth or first argument" {
@@ -31,11 +32,10 @@ teardown() {
   local __all_commands=("$(./go 'aliases')" "${BUILTIN_CMDS[@]}")
 
   run "$TEST_GO_SCRIPT" complete 0
-  local IFS=$'\n'
-  assert_success "${__all_commands[*]}"
+  assert_success "${__all_commands[@]}"
 
   run "$TEST_GO_SCRIPT" complete 0 complete
-  assert_success 'complete'
+  assert_success 'complete '
 
   run "$TEST_GO_SCRIPT" complete 0 complete-not
   assert_failure ''
@@ -47,23 +47,22 @@ teardown() {
   mkdir -p "${subdirs[@]/#/$TEST_GO_SCRIPTS_DIR/}"
   touch "${files[@]/#/$TEST_GO_SCRIPTS_DIR/}"
 
-  run "$TEST_GO_SCRIPT" complete 1 cd ''
-  assert_success 'scripts'
+  run "$TEST_GO_SCRIPT" complete 1 cd
+  assert_success 'scripts/'
   run "$TEST_GO_SCRIPT" complete 1 pushd ''
-  assert_success 'scripts'
+  assert_success 'scripts/'
 
   local expected=()
   local item
 
   while IFS= read -r item; do
     expected+=("${item#$TEST_GO_ROOTDIR/}")
-  done<<<"$(compgen -d "$TEST_GO_SCRIPTS_DIR/")"
+  done<<<"$(@go.compgen -d "$TEST_GO_SCRIPTS_DIR/")"
 
   run "$TEST_GO_SCRIPT" complete 1 cd 'scripts/'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
   run "$TEST_GO_SCRIPT" complete 1 pushd 'scripts/'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: edit, run, and aliases complete directories and files" {
@@ -78,26 +77,25 @@ teardown() {
 
   while IFS= read -r item; do
     top_level+=("${item#$TEST_GO_ROOTDIR/}")
-  done <<<"$(compgen -f "$TEST_GO_ROOTDIR/")"
+  done <<<"$(@go.compgen -f "$TEST_GO_ROOTDIR/")"
 
   while IFS= read -r item; do
     all_scripts_entries+=("${item#$TEST_GO_ROOTDIR/}")
-  done <<<"$(compgen -f "$TEST_GO_SCRIPTS_DIR/")"
+  done <<<"$(@go.compgen -f "$TEST_GO_SCRIPTS_DIR/")"
 
   run "$TEST_GO_SCRIPT" complete 1 edit ''
-  local IFS=$'\n'
-  assert_success "${top_level[*]}"
+  assert_success "${top_level[@]}"
   run "$TEST_GO_SCRIPT" complete 1 run ''
-  assert_success "${top_level[*]}"
+  assert_success "${top_level[@]}"
   run "$TEST_GO_SCRIPT" complete 1 ls ''
-  assert_success "${top_level[*]}"
+  assert_success "${top_level[@]}"
 
   run "$TEST_GO_SCRIPT" complete 1 edit 'scripts/'
-  assert_success "${all_scripts_entries[*]}"
+  assert_success "${all_scripts_entries[@]}"
   run "$TEST_GO_SCRIPT" complete 1 run 'scripts/'
-  assert_success "${all_scripts_entries[*]}"
+  assert_success "${all_scripts_entries[@]}"
   run "$TEST_GO_SCRIPT" complete 1 ls 'scripts/'
-  assert_success "${all_scripts_entries[*]}"
+  assert_success "${all_scripts_entries[@]}"
 }
 
 @test "$SUITE: unenv, unknown flags, and unknown commands return errors" {
@@ -119,19 +117,18 @@ teardown() {
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo
-  assert_success 'foo'
+  assert_success 'foo '
 
   local expected=('bar' 'baz' 'quux')
-  local IFS=$'\n'
   run "$TEST_GO_SCRIPT" complete 1 foo ''
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   expected=('bar' 'baz')
   run "$TEST_GO_SCRIPT" complete 1 foo 'b'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 foo 'b' 'q'
-  assert_success 'quux'
+  assert_success 'quux '
 
   run "$TEST_GO_SCRIPT" complete 1 foo 'x'
   assert_failure ''
@@ -144,7 +141,7 @@ teardown() {
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo
-  assert_success 'foo'
+  assert_success 'foo '
 
   run "$TEST_GO_SCRIPT" complete 1 foo ''
   assert_failure ''
@@ -166,30 +163,29 @@ teardown() {
     'fi'
 
   run "$TEST_GO_SCRIPT" complete 0 foo
-  assert_success 'foo'
+  assert_success 'foo '
 
   # Note that 'bar' should show up automatically because it is in foo.d, even
   # though it isn't in the compgen word list inside foo.
   local expected=('bar' 'baz' 'quux')
-  local IFS=$'\n'
   run "$TEST_GO_SCRIPT" complete 1 foo ''
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 1 foo bar
-  assert_success 'bar'
+  assert_success 'bar '
 
   local expected=('plugh' 'xyzzy')
   run "$TEST_GO_SCRIPT" complete 2 foo bar ''
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: -h, -help, and --help invoke help command completion" {
   run "$TEST_GO_SCRIPT" complete 1 -h 'complet'
-  assert_success 'complete'
+  assert_success 'complete '
 
   run "$TEST_GO_SCRIPT" complete 1 -help 'complet'
-  assert_success 'complete'
+  assert_success 'complete '
 
   run "$TEST_GO_SCRIPT" complete 1 --help 'complet'
-  assert_success 'complete'
+  assert_success 'complete '
 }

--- a/tests/complete/command-path.bats
+++ b/tests/complete/command-path.bats
@@ -4,6 +4,8 @@ load ../environment
 load ../commands/helpers
 
 setup() {
+  test_filter
+
   # We add a prefix to each of the echo statements to ensure that blank lines
   # are not elided from the Bats `lines` array.
   @go.create_test_go_script '. "$_GO_CORE_DIR/lib/internal/complete"' \

--- a/tests/complete/compgen.bats
+++ b/tests/complete/compgen.bats
@@ -1,0 +1,74 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '. "$_GO_USE_MODULES" complete' \
+    '@go.compgen "$@"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: does nothing for empty argument list" {
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: returns all word list arguments for empty string" {
+  run "$TEST_GO_SCRIPT" -W 'foo bar baz' -- ''
+  local expected=($(compgen -W 'foo bar baz' -- ''))
+  assert_success "${expected[@]}"
+}
+
+@test "$SUITE: appends space to single word list match" {
+  run "$TEST_GO_SCRIPT" -W 'foo bar baz' -- 'f'
+  assert_success 'foo '
+}
+
+@test "$SUITE: doesn't add space to single match with trailing space or slash" {
+  # This emulates the case where output from a command script using
+  # `@go.compgen` is fed through `@go.compgen` again in `libexec/complete'.
+  run "$TEST_GO_SCRIPT" -W 'foo\ ' -- 'f'
+  assert_success 'foo '
+  run "$TEST_GO_SCRIPT" -W 'foo/' -- 'f'
+  assert_success 'foo/'
+}
+
+@test "$SUITE: returns error when word doesn't match word list" {
+  run "$TEST_GO_SCRIPT" -W 'foo bar baz' -- 'q'
+  assert_failure ''
+}
+
+@test "$SUITE: doesn't add trailing slashes when not called with -d or -f" {
+  mkdir -p "${TEST_GO_ROOTDIR}"/{foo,bar,baz}
+  run "$TEST_GO_SCRIPT" -W 'foo bar baz' -- ''
+  local expected=($(cd "$TEST_GO_ROOTDIR"; compgen -W 'foo bar baz' -- ''))
+  assert_success "${expected[@]}"
+}
+
+@test "$SUITE: adds trailing slashes when called with -d" {
+  mkdir -p "${TEST_GO_ROOTDIR}"/{foo,bar,baz}
+  run "$TEST_GO_SCRIPT" -d -- ''
+
+  # Remember that `compgen` won't add trailing slashes by itself.
+  local expected=($(cd "$TEST_GO_ROOTDIR"; compgen -d -- ''))
+  assert_success "${expected[@]/%//}"
+}
+
+@test "$SUITE: adds trailing slashes when called with -f" {
+  mkdir -p "${TEST_GO_ROOTDIR}"/{foo,bar,baz}
+  run "$TEST_GO_SCRIPT" -f -- ''
+
+  # Remember that `compgen` won't add trailing slashes by itself.
+  local expected=($(cd "$TEST_GO_ROOTDIR"; compgen -f -- ''))
+  local i
+  for ((i=0; i != "${#expected[@]}"; ++i)); do
+    if [[ -d "$TEST_GO_ROOTDIR/${expected[$i]}" ]]; then
+      expected[$i]+='/'
+    fi
+  done
+  assert_success "${expected[@]}"
+}

--- a/tests/complete/remove-completions.bats
+++ b/tests/complete/remove-completions.bats
@@ -2,7 +2,7 @@
 
 load ../environment
 
-. "$_GO_ROOTDIR/lib/complete"
+. "$_GO_USE_MODULES" 'complete'
 
 @test "$SUITE: empty args, empty completions" {
   local argv=()

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -12,10 +12,10 @@ teardown() {
 
 @test "$SUITE: tab completions" {
   run "$TEST_GO_SCRIPT" complete 1 env ''
-  assert_success '-'
+  assert_success '- '
 
   run "$TEST_GO_SCRIPT" complete 1 env '-'
-  assert_success '-'
+  assert_success '- '
 
   run "$TEST_GO_SCRIPT" complete 1 env '--foo'
   assert_failure ''
@@ -96,11 +96,10 @@ teardown() {
   run declare -f "_$script_name"
   assert_success
   assert_line_equals 0 "_$script_name () "
-  assert_output_matches "\"$go_script\" 'complete'"
-  assert_line_matches -2 "cd \\\"$TEST_GO_ROOTDIR\\\""
+  assert_line_matches -2 "done < <\(\\\"$go_script\\\" 'complete'"
 
   run complete -p "$script_name"
-  assert_success "complete -o filenames -F _$script_name $script_name"
+  assert_success "complete -o nospace -F _$script_name $script_name"
 
   "$script_name" 'unenv'
   ! command -v "_$script_name"
@@ -128,11 +127,10 @@ teardown() {
   run declare -f "_$func_name"
   assert_success
   assert_line_equals 0 "_$func_name () "
-  assert_output_matches "\"$TEST_GO_SCRIPT\" 'complete'"
-  assert_line_matches -2 "cd \\\"$TEST_GO_ROOTDIR\\\""
+  assert_line_matches -2 "done < <\(\\\"$TEST_GO_SCRIPT\\\" 'complete'"
 
   run complete -p "$func_name"
-  assert_success "complete -o filenames -F _$func_name $func_name"
+  assert_success "complete -o nospace -F _$func_name $func_name"
 
   "$func_name" 'unenv'
   ! command -v "_$func_name"

--- a/tests/env/bash.bats
+++ b/tests/env/bash.bats
@@ -3,6 +3,7 @@
 load ../environment
 
 setup () {
+  test_filter
   . 'lib/internal/env/bash'
 }
 
@@ -11,7 +12,7 @@ setup () {
   command -v _go_func
 
   run complete -p _go_func
-  assert_success "complete -o filenames -F __go_func _go_func"
+  assert_success "complete -o nospace -F __go_func _go_func"
 
   _go_func 'unenv'
   ! command -v __go_func
@@ -46,46 +47,35 @@ setup () {
   assert_equal "$orig_pwd" "$PWD" 'original working dir'
 }
 
-@test "$SUITE: complete first argument lists commands, cd to _GO_ROOTDIR" {
+@test "$SUITE: complete first argument lists commands" {
   local COMP_WORDS=('_go_func')
   local COMP_CWORD='1'
-  local COMPREPLY
+  local COMPREPLY=()
 
-  cd 'scripts'
   __go_func
   assert_equal 'awk' "${COMPREPLY[0]}" 'first alias'
   assert_equal 'vars' "${COMPREPLY[$((${#COMPREPLY[@]} - 1))]}" 'last builtin'
-  assert_equal "$_GO_ROOTDIR" "$PWD" 'current working dir'
-  cd -
 }
 
-@test "$SUITE: complete second argument, cd to _GO_ROOTDIR" {
+@test "$SUITE: complete second argument" {
   # Complete the flags for the 'commands' builtin.
   local COMP_WORDS=('_go_func' 'commands' '-')
   local COMP_CWORD='2'
-  local COMPREPLY
+  local COMPREPLY=()
 
-  cd 'scripts'
   __go_func
   assert_equal '2' "${#COMPREPLY[@]}" 'number of tab completion entries'
   assert_equal '--paths' "${COMPREPLY[0]}" 'first tab completion entry'
   assert_equal '--summaries' "${COMPREPLY[1]}" 'second tab completion entry'
-
-  assert_equal "$_GO_ROOTDIR" "$PWD" 'current working dir'
-  cd -
 }
 
 @test "$SUITE: complete alias completes filenames in _GO_ROOTDIR" {
   # Complete the '$_GO_ROOTIDR/scripts' directory name.
   local COMP_WORDS=('_go_func' 'ls' 'scrip')
   local COMP_CWORD='2'
-  local COMPREPLY
+  local COMPREPLY=()
 
-  cd 'scripts'
   __go_func
   assert_equal '1' "${#COMPREPLY[@]}" 'number of tab completion entries'
-  assert_equal 'scripts' "${COMPREPLY[0]}" 'first tab completion entry'
-
-  assert_equal "$_GO_ROOTDIR" "$PWD" 'current working dir'
-  cd -
+  assert_equal 'scripts/' "${COMPREPLY[0]}" 'first tab completion entry'
 }

--- a/tests/fullpath.bats
+++ b/tests/fullpath.bats
@@ -2,25 +2,29 @@
 
 load environment
 
+setup() {
+  test_filter
+}
+
 teardown() {
   @go.remove_test_go_rootdir
 }
 
 @test "$SUITE: tab completions" {
+  . "$_GO_USE_MODULES" 'complete'
   local expected=('--existing')
-  expected+=($(compgen -f))
+  expected+=($(@go.compgen -f))
 
   run ./go complete 1 fullpath ''
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run ./go complete 1 fullpath '-'
-  assert_success '--existing'
+  assert_success '--existing '
 
-  expected=($(compgen -f -- 'li'))
-  [ "${#expected[@]}" -ne '0' ]
+  expected=($(@go.compgen -f -- 'li'))
+  fail_if equal '0' "${#expected[@]}"
   run ./go complete 1 fullpath 'li'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: prints rootdir when no arguments" {

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -27,13 +27,14 @@ teardown() {
 
   local expected=()
   local item
+
+  . "$_GO_USE_MODULES" 'complete'
   while IFS= read -r item; do
     expected+=("$item")
-  done <<<"$(compgen -f -- "$TEST_GO_ROOTDIR/")"
-  test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
+  done <<<"$(@go.compgen -f -- "$TEST_GO_ROOTDIR/")"
 
   run "$TEST_GO_SCRIPT" get file --complete 1 -f
-  assert_success "$expected"
+  assert_success "${expected[@]#$TEST_GO_ROOTDIR/}"
 }
 
 @test "$SUITE: fail if neither curl nor wget installed" {

--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -24,15 +24,13 @@ teardown() {
   run "$TEST_GO_SCRIPT" get git-repo --complete 1
   assert_success ''
 
-  local expected=()
-  local item
+  . "$_GO_USE_MODULES" 'complete'
   while IFS= read -r item; do
     expected+=("$item")
-  done <<<"$(compgen -f -- "$TEST_GO_ROOTDIR/")"
-  test_join $'\n' expected "${expected[@]#$TEST_GO_ROOTDIR/}"
+  done <<<"$(@go.compgen -f -- "$TEST_GO_ROOTDIR/")"
 
   run "$TEST_GO_SCRIPT" get git-repo --complete 2
-  assert_success "$expected"
+  assert_success "${expected[@]#$TEST_GO_ROOTDIR/}"
 }
 
 @test "$SUITE: fail if git not installed" {

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -3,6 +3,7 @@
 load environment
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
 }
 
@@ -14,14 +15,13 @@ teardown() {
   local subcommands=('plugh' 'quux' 'xyzzy')
   @go.create_parent_and_subcommands foo "${subcommands[@]}"
   run "$TEST_GO_SCRIPT" complete 1 help 'foo'
-  assert_success 'foo'
+  assert_success 'foo '
 
-  local IFS=$'\n'
   run "$TEST_GO_SCRIPT" complete 2 help 'foo' ''
-  assert_success "${subcommands[*]}"
+  assert_success "${subcommands[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 help 'foo' 'q'
-  assert_success 'quux'
+  assert_success 'quux '
 }
 
 @test "$SUITE: produce message with successful return for help command" {
@@ -97,8 +97,7 @@ teardown() {
   local expected_errors=(
     'ERROR: command script "bogus/path/to/nowhere" does not exist'
     'ERROR: failed to parse description from bogus/path/to/nowhere')
-  local IFS=$'\n'
-  assert_failure "${expected_errors[*]}"
+  assert_failure "${expected_errors[@]}"
 }
 
 @test "$SUITE: parse description from command script" {
@@ -116,8 +115,7 @@ teardown() {
     "$TEST_GO_SCRIPT foo - Does foo stuff in $TEST_GO_ROOTDIR"
     ''
     "Usage: $TEST_GO_SCRIPT foo <argument>")
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: call help filter on command script" {
@@ -151,8 +149,7 @@ teardown() {
     "$TEST_GO_SCRIPT foo - Does foo stuff"
     ''
     "Usage: $TEST_GO_SCRIPT foo <bar|baz|quux>")
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: add subcommand summaries" {
@@ -177,6 +174,5 @@ teardown() {
     '  bar   Does bar stuff'
     '  baz   Does baz stuff'
     '  quux  Does quux stuff')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }

--- a/tests/modules/arg-completion.bats
+++ b/tests/modules/arg-completion.bats
@@ -4,6 +4,7 @@ load ../environment
 load helpers
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
   setup_test_modules
 }
@@ -16,27 +17,24 @@ teardown() {
   run "$TEST_GO_SCRIPT" complete 1 modules ''
   local expected=('-h' '-help' '--help' '--paths' '--summaries' '--imported'
     "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: first argument matches help flags" {
   run "$TEST_GO_SCRIPT" complete 1 modules -h _foo
   local expected=('-h' '-help')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: first argument matches modules" {
   run "$TEST_GO_SCRIPT" complete 1 modules _f
   local expected=('_frobozz' '_frotz' '_foo/')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: only complete first flag" {
   run "$TEST_GO_SCRIPT" complete 1 modules --pat --sum
-  assert_success '--paths'
+  assert_success '--paths '
 
   run "$TEST_GO_SCRIPT" complete 2 modules --paths --sum
   assert_failure ''
@@ -62,36 +60,31 @@ teardown() {
   local expected=(
     "${CORE_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGINS[@]/%//}")
   run "$TEST_GO_SCRIPT" complete 2 modules --help ''
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: return matching plugins and modules" {
   local expected=('_frobozz' '_frotz' '_foo/')
   run "$TEST_GO_SCRIPT" complete 2 modules help '_f'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: return only matching plugin names" {
   local expected=('_bar/' '_baz/')
   run "$TEST_GO_SCRIPT" complete 2 modules help '_b'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: return all matches for a plugin when no other matches" {
   local expected=('_foo/_plugh' '_foo/_quux' '_foo/_xyzzy')
   run "$TEST_GO_SCRIPT" complete 2 modules help '_fo'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: return matches for a plugin when arg ends with a slash" {
   local expected=('_baz/_plugh' '_baz/_quux' '_baz/_xyzzy')
   run "$TEST_GO_SCRIPT" complete 2 modules help '_baz/'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: no matches" {
@@ -107,26 +100,24 @@ teardown() {
 @test "$SUITE: complete subsequent args for flags other than help" {
   # Note that matches already on command line are not completed.
   run "$TEST_GO_SCRIPT" complete 3 modules --paths '_frobozz' '_fr'
-  assert_success '_frotz'
+  assert_success '_frotz '
 }
 
 @test "$SUITE: complete subsequent args if first arg not a flag" {
   # Note that matches already on command line are not completed.
   run "$TEST_GO_SCRIPT" complete 2 modules '_frobozz' '_fr'
-  assert_success '_frotz'
+  assert_success '_frotz '
 }
 
 @test "$SUITE: remove plugin completions already present" {
   local expected=('_foo/_quux' '_foo/_xyzzy')
   run "$TEST_GO_SCRIPT" complete 2 modules '_foo/_plugh' '_foo/'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: don't complete plugins when all modules already present" {
   local expected=("${CORE_MODULES[@]}" '_frobozz' '_frotz' '_bar/' '_baz/')
   run "$TEST_GO_SCRIPT" complete 4 modules \
     '_foo/_plugh' '_foo/_quux' '_foo/_xyzzy' ''
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }

--- a/tests/path.bats
+++ b/tests/path.bats
@@ -3,6 +3,7 @@
 load environment
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
 }
 
@@ -14,14 +15,13 @@ teardown() {
   local subcommands=('plugh' 'quux' 'xyzzy')
   @go.create_parent_and_subcommands foo "${subcommands[@]}"
   run "$TEST_GO_SCRIPT" complete 1 path 'foo'
-  assert_success 'foo'
+  assert_success 'foo '
 
-  local IFS=$'\n'
   run "$TEST_GO_SCRIPT" complete 2 path 'foo' ''
-  assert_success "${subcommands[*]}"
+  assert_success "${subcommands[@]}"
 
   run "$TEST_GO_SCRIPT" complete 2 path 'foo' 'q'
-  assert_success 'quux'
+  assert_success 'quux '
 }
 
 @test "$SUITE: shell alias" {

--- a/tests/plugins.bats
+++ b/tests/plugins.bats
@@ -3,6 +3,7 @@
 load environment
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
   mkdir "$TEST_GO_PLUGINS_DIR"
 }
@@ -20,11 +21,10 @@ teardown() {
 @test "$SUITE: tab completion returns flags if plugins dir present" {
   run "$TEST_GO_SCRIPT" complete 1 plugins ''
   local expected=('--paths' '--summaries')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 
   run "$TEST_GO_SCRIPT" complete 1 plugins '--paths'
-  assert_success '--paths'
+  assert_success '--paths '
 }
 
 @test "$SUITE: error if no scripts/plugin directory" {
@@ -50,7 +50,6 @@ teardown() {
   local longest_plugin_len=0
   local plugin_path
   local summary
-  local IFS=$'\n'
 
   for plugin in "${plugins[@]}"; do
     @go.create_test_command_script "plugins/$plugin" \
@@ -63,7 +62,7 @@ teardown() {
   done
 
   run "$TEST_GO_SCRIPT" plugins
-  assert_success "${plugins[*]##*/}"
+  assert_success "${plugins[@]##*/}"
 
   local paths=(
     'bar    scripts/plugins/bar/bin/bar'
@@ -73,7 +72,7 @@ teardown() {
     'xyzzy  scripts/plugins/xyzzy')
 
   run "$TEST_GO_SCRIPT" plugins --paths
-  assert_success "${paths[*]}"
+  assert_success "${paths[@]}"
 
   local summaries=(
     '  bar    Does bar stuff'
@@ -83,5 +82,5 @@ teardown() {
     '  xyzzy  Does xyzzy stuff')
 
   run "$TEST_GO_SCRIPT" plugins --summaries
-  assert_success "${summaries[*]}"
+  assert_success "${summaries[@]}"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -5,6 +5,10 @@
 load environment
 load "$_GO_CORE_DIR/lib/testing/stubbing"
 
+setup() {
+  test_filter
+}
+
 teardown() {
   @go.remove_test_go_rootdir
 }
@@ -12,8 +16,7 @@ teardown() {
 @test "$SUITE: tab complete flags" {
   run ./go complete 1 test '-'
   local expected=('--coverage' '--edit' '--list')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: tab complete flags, first-level tests and directories" {
@@ -23,15 +26,13 @@ teardown() {
   [ "${#expected[@]}" -ne 1 ]
 
   run ./go complete 1 test ''
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: tab completion matches test file and matching directory" {
   expected=('core' 'core/')
   run ./go complete 1 test 'core'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 _trim_expected() {
@@ -44,8 +45,7 @@ _trim_expected() {
   _trim_expected
 
   run ./go complete 1 test 'core/'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: no arguments after --list lists all tests" {
@@ -54,8 +54,7 @@ _trim_expected() {
   [ "${#expected[@]}" -ne 0 ]
 
   run ./go test --list
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list specific files and directories" {
@@ -64,8 +63,7 @@ _trim_expected() {
   local expected=(test aliases builtins tests/builtins/*)
   _trim_expected
 
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: open EDITOR on --edit" {


### PR DESCRIPTION
Closes #123. Tab completion will no longer change the working directory to `_GO_ROOTDIR`, the tradeoff being:

- The compspec specifies `-o nospace` now instead of `-o filenames`.
- This means that the `./go` framework must add traling slashes to directory name completions, as well as add a space when returning a single completion (unless it ends with a `/`).
- Tab-completed paths now won't trim the directory prefix from multiple matches when completing into more than one directory.

To this last point, per @jeffkole, having longer completion paths seems less surprising and annoying than having the working directory change. I'd originally thought it would mean completing absolute paths, but it turns out that wasn't necessary after all. In fact, the completed path on the command line stays the same length as before this change; it's just the values displayed when multiple matches exist that are longer.

The core of the `@go.compgen` solution from `lib/complete` is pretty straightforward, but since `./go complete` will now add trailing slashes for directories, and trailing spaces when there is only one match, a lot of tests needed very minor updates.

Another bonus of this solution: Previously I named the test directory `tests` because tab-completing the `test` command would cause the previous implementation to add a slash if a `test` directory existed. Since we're not setting `-o filenames`, and are now filtering filename completions through `@go.compgen`, this should not be an issue for other projects. The "doesn't add trailing slashes when not called with -d or -f" test case from `tests/complete/compgen.bats` covers this.

While touching all these test files, I decided to apply a few other convenient updates, namely:

- adding `test_filter` to `setup`
- Replacing `IFS=$'\n'` with the updated `assert_{success,failure}` that accept multiple arguments to check for line-by-line equality