### PR TITLE
Add common prefix functions to `lib/strings`

### DIFF
--- a/lib/strings
+++ b/lib/strings
@@ -9,6 +9,9 @@
 #   @go.join
 #     Joins multiple items into a string variable defined by the caller
 #
+#   @go.common_prefix
+#     Determines the common prefix for a set of strings
+#
 # These functions help avoid `IFS`-related pitfalls as described by:
 #
 #   http://mywiki.wooledge.org/Arguments
@@ -53,4 +56,36 @@
   @go.validate_identifier_or_die 'Result variable name' "$2"
   local IFS="$1"
   printf -v "$2" -- '%s' "${*:3}"
+}
+
+# Determines the common prefix for a set of strings
+#
+# Will return the empty string for a single argument. This facilitates prefix
+# removal without requiring that the caller check that there is more than one
+# element in an array of strings to avoid checking for the special case of a
+# single string being its own prefix.
+#
+# Arguments:
+#   var_name:   Name of caller's variable to which to assign the common prefix
+#   ...:        Strings to examine to determine the common prefix
+@go.common_prefix() {
+  @go.validate_identifier_or_die 'Result variable name' "$1"
+  local _gcp_prefix="$2"
+  local _gcp_prefix_len="${#_gcp_prefix}"
+  local _gcp_item
+
+  for _gcp_item in "${@:3}"; do
+    while [[ "${_gcp_item:0:$_gcp_prefix_len}" != "$_gcp_prefix" ]]; do
+      ((--_gcp_prefix_len))
+      _gcp_prefix="${_gcp_prefix:0:$_gcp_prefix_len}"
+    done
+    if [[ "$_gcp_prefix_len" -eq '0' ]]; then
+      break
+    fi
+  done
+
+  if [[ "$#" -lt '3' ]]; then
+    _gcp_prefix=''
+  fi
+  printf -v "$1" -- '%s' "$_gcp_prefix"
 }

--- a/lib/strings
+++ b/lib/strings
@@ -96,7 +96,7 @@
 # Removes the common path prefix from a set of file paths
 #
 # Arguments:
-#   array_name:  Name of caller's array variable into which to store fields
+#   array_name:  Name of caller's array into which to store the updated paths
 #   ...:         File paths from which to remove the common path prefix
 @go.remove_common_path_prefix() {
   @go.validate_identifier_or_die 'Result variable name' "$1"

--- a/lib/strings
+++ b/lib/strings
@@ -12,6 +12,9 @@
 #   @go.common_prefix
 #     Determines the common prefix for a set of strings
 #
+#   @go.remove_common_path_prefix
+#     Removes the common path prefix from a set of file paths
+#
 # These functions help avoid `IFS`-related pitfalls as described by:
 #
 #   http://mywiki.wooledge.org/Arguments
@@ -88,4 +91,26 @@
     _gcp_prefix=''
   fi
   printf -v "$1" -- '%s' "$_gcp_prefix"
+}
+
+# Removes the common path prefix from a set of file paths
+#
+# Arguments:
+#   array_name:  Name of caller's array variable into which to store fields
+#   ...:         File paths from which to remove the common path prefix
+@go.remove_common_path_prefix() {
+  @go.validate_identifier_or_die 'Result variable name' "$1"
+  local _grcpp_prefix
+  local _grcpp_paths=("${@:2}")
+
+  @go.common_prefix '_grcpp_prefix' "${_grcpp_paths[@]}"
+
+  if [[ "$_grcpp_prefix" =~ / ]]; then
+    _grcpp_prefix="${_grcpp_prefix%/*}/"
+  else
+    _grcpp_prefix=''
+  fi
+
+  local IFS=$'\x1f'
+  read -ra "$1" <<<"${_grcpp_paths[*]#$_grcpp_prefix}"
 }

--- a/libexec/glob
+++ b/libexec/glob
@@ -146,24 +146,15 @@ _@go.glob_tab_completion_parse_argv() {
 }
 
 _@go.glob_emit_completion_matches() {
-  local prefix="${__go_glob_matches[0]}"
-  local prefix_len="${#prefix}"
-  local match
-
-  for match in "${__go_glob_matches[@]}"; do
-    while [[ "${match:0:$prefix_len}" != "$prefix" ]]; do
-      ((--prefix_len))
-      prefix="${prefix:0:$prefix_len}"
-    done
-    if [[ "$prefix_len" -eq '0' ]]; then
-      break
-    fi
-  done
-
+  local prefix
   local suffix
   local trimmed_suffix
+  local match
   local prev
   local results=()
+
+  . "$_GO_USE_MODULES" 'strings'
+  @go.common_prefix 'prefix' "${__go_glob_matches[@]}"
 
   for match in "${__go_glob_matches[@]}"; do
     suffix="${match:${#prefix}}"

--- a/tests/strings/common-prefix.bats
+++ b/tests/strings/common-prefix.bats
@@ -1,0 +1,40 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+setup() {
+  test_filter
+  create_strings_test_script 'declare prefix' \
+    '@go.common_prefix "prefix" "$@"' \
+    'printf -- "%s\n" "$prefix"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: empty argument list produces empty string" {
+  run "$TEST_GO_SCRIPT"
+  assert_success
+}
+
+@test "$SUITE: empty string produces empty string" {
+  run "$TEST_GO_SCRIPT" ''
+  assert_success
+}
+
+@test "$SUITE: single string returns empty string" {
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success ''
+}
+
+@test "$SUITE: multiple strings with no common prefix returns empty string" {
+  run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  assert_success ''
+}
+
+@test "$SUITE: multiple strings with common prefix returns prefix substring" {
+  run "$TEST_GO_SCRIPT" 'bar' 'baz' 'baxter'
+  assert_success 'ba'
+}

--- a/tests/strings/remove-common-path-prefix.bats
+++ b/tests/strings/remove-common-path-prefix.bats
@@ -1,0 +1,56 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+setup() {
+  test_filter
+  create_strings_test_script 'declare result=()' \
+    '@go.remove_common_path_prefix "result" "$@"' \
+    'printf -- "%s\n" "${result[@]}"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: empty argument list produces empty string" {
+  run "$TEST_GO_SCRIPT"
+  assert_success
+}
+
+@test "$SUITE: empty string produces empty string" {
+  run "$TEST_GO_SCRIPT" ''
+  assert_success
+}
+
+@test "$SUITE: single string returns original string" {
+  run "$TEST_GO_SCRIPT" 'foo/bar/baz'
+  assert_success 'foo/bar/baz'
+}
+
+@test "$SUITE: multiple paths with no common prefix returns original paths" {
+  local paths=('foobar/baz'
+    'foobaz/quux'
+    'fooquux/xyzzy')
+  run "$TEST_GO_SCRIPT" "${paths[@]}"
+  assert_success "${paths[@]}"
+}
+
+@test "$SUITE: multiple absolute paths with only root dir in common" {
+  run "$TEST_GO_SCRIPT" '/foobar/baz' \
+    '/foobaz/quux' \
+    '/fooquux/xyzzy'
+  assert_success 'foobar/baz' \
+    'foobaz/quux' \
+    'fooquux/xyzzy'
+}
+
+@test "$SUITE: multiple paths with common path prefix returns suffixes" {
+  run "$TEST_GO_SCRIPT" 'foo/bar/baz' \
+    'foo/bar/quux/xyzzy' \
+    'foo/baz/plugh'
+  assert_success 'bar/baz'\
+    'bar/quux/xyzzy' \
+    'baz/plugh'
+}


### PR DESCRIPTION
This extracts `@go.common_prefix` from `libexec/glob`, and adds `@go.remove_common_path_prefix`. I originally created these commits during the course of implementing #123 and #124, when I thought that `./go complete` needed to do some path manipulation. They still seem like generally useful functions (even though I'm not using `@go.remove_common_path_prefix` yet).