### PR TITLE
Remove _GO_PLUGINS_DIR from _GO_SEARCH_PATHS

### DIFF
--- a/lib/internal/path
+++ b/lib/internal/path
@@ -5,11 +5,12 @@ if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
     _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
   fi
   _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec")
-  if [[ -d "$_GO_SCRIPTS_DIR/plugins" ]]; then
-    _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
-    _GO_PLUGINS_PATHS=("$_GO_PLUGINS_DIR" "$_GO_PLUGINS_DIR"/*/bin)
-    if [[ "${_GO_PLUGINS_PATHS[1]}" == "$_GO_PLUGINS_DIR/*/bin" ]]; then
-      unset '_GO_PLUGINS_PATHS[1]'
+  _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
+
+  if [[ -d "$_GO_PLUGINS_DIR" ]]; then
+    _GO_PLUGINS_PATHS=("$_GO_PLUGINS_DIR"/*/bin)
+    if [[ "${_GO_PLUGINS_PATHS[0]}" == "$_GO_PLUGINS_DIR/*/bin" ]]; then
+      unset '_GO_PLUGINS_PATHS'
     fi
   fi
   _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}" "$_GO_SCRIPTS_DIR")

--- a/tests/commands/helpers.bash
+++ b/tests/commands/helpers.bash
@@ -56,22 +56,11 @@ merge_scripts() {
 }
 
 add_scripts() {
-  local scripts_dir="$1/"
-  shift
-
-  local relative_dir="${scripts_dir#$TEST_GO_ROOTDIR/}"
   local script_names=("$@")
 
-  if [[ ! -d "$scripts_dir" ]]; then
-    mkdir "$scripts_dir"
-  fi
+  merge_scripts "${script_names[@]/#/$TEST_GO_SCRIPTS_RELATIVE_DIR/}"
 
-  merge_scripts "${script_names[@]/#/$relative_dir}"
-
-  # chmod is neutralized in MSYS2 on Windows; `#!` makes files executable.
-  local script_path
-  for script_path in "${script_names[@]/#/$scripts_dir}"; do
-    echo '#!' > "$script_path"
+  for script_path in "${script_names[@]}"; do
+    @go.create_test_command_script "$script_path"
   done
-  chmod 700 "${script_names[@]/#/$scripts_dir}"
 }

--- a/tests/commands/main.bats
+++ b/tests/commands/main.bats
@@ -127,37 +127,40 @@ teardown() {
 }
 
 @test "$SUITE: list top-level builtins, plugins, and scripts by default" {
-  local user_commands=('bar' 'baz' 'foo')
-  local plugin_commands=('plugh' 'quux' 'xyzzy')
   local __all_scripts=("${BUILTIN_SCRIPTS[@]}")
 
-  add_scripts "$TEST_GO_SCRIPTS_DIR" "${user_commands[@]}"
-  add_scripts "$TEST_GO_SCRIPTS_DIR/plugins" "${plugin_commands[@]}"
+  # Command script and plugin script names must remain hand-sorted.
+  add_scripts 'bar' 'baz' 'foo' \
+    'plugins/plugh/bin/plugh' \
+    'plugins/quux/bin/quux' \
+    'plugins/xyzzy/bin/xyzzy'
 
   local cmd_name
 
-  mkdir "$TEST_GO_SCRIPTS_DIR/"{bar,baz,foo}.d
   @go.create_test_command_script 'bar.d/child0'
   @go.create_test_command_script 'baz.d/child1'
   @go.create_test_command_script 'foo.d/child2'
-  mkdir "$TEST_GO_SCRIPTS_DIR/plugins/"{plugh,quux,xyzzy}.d
-  @go.create_test_command_script 'plugins/plugh.d/child3'
-  @go.create_test_command_script 'plugins/quux.d/child4'
-  @go.create_test_command_script 'plugins/xyzzy.d/child5'
+  @go.create_test_command_script 'plugins/plugh/bin/plugh.d/child3'
+  @go.create_test_command_script 'plugins/quux/bin/quux.d/child4'
+  @go.create_test_command_script 'plugins/xyzzy/bin/xyzzy.d/child5'
 
   run "$TEST_GO_SCRIPT" commands
   assert_success "${__all_scripts[@]##*/}"
 }
 
 @test "$SUITE: specify plugins and user search paths, omit builtins" {
-  local user_commands=('bar' 'baz' 'foo')
-  local plugin_commands=('plugh' 'quux' 'xyzzy')
   local __all_scripts=()
 
-  add_scripts "$TEST_GO_SCRIPTS_DIR" "${user_commands[@]}"
-  add_scripts "$TEST_GO_SCRIPTS_DIR/plugins" "${plugin_commands[@]}"
-  local search_paths="$TEST_GO_SCRIPTS_DIR/plugins:$TEST_GO_SCRIPTS_DIR"
+  # Command script and plugin script names must remain hand-sorted.
+  add_scripts 'bar' 'baz' 'foo' \
+    'plugins/plugh/bin/plugh' \
+    'plugins/quux/bin/quux' \
+    'plugins/xyzzy/bin/xyzzy'
+  local search_paths=()
 
+  test_join ':' search_paths \
+    "$TEST_GO_SCRIPTS_DIR/plugins/"{plugh,quux,xyzzy}"/bin" \
+    "$TEST_GO_SCRIPTS_DIR"
   run "$TEST_GO_SCRIPT" commands "${search_paths[*]}"
   assert_success "${__all_scripts[@]##*/}"
 }
@@ -185,8 +188,11 @@ generate_expected_paths() {
   local plugin_commands=('plugh' 'quux' 'xyzzy')
   local __all_scripts=("${BUILTIN_SCRIPTS[@]}")
 
-  add_scripts "$TEST_GO_SCRIPTS_DIR" "${user_commands[@]}"
-  add_scripts "$TEST_GO_SCRIPTS_DIR/plugins" "${plugin_commands[@]}"
+  # Command script and plugin script names must remain hand-sorted.
+  add_scripts 'bar' 'baz' 'foo' \
+    'plugins/plugh/bin/plugh' \
+    'plugins/quux/bin/quux' \
+    'plugins/xyzzy/bin/xyzzy'
 
   local __expected_paths=()
   generate_expected_paths

--- a/tests/complete/command-path.bats
+++ b/tests/complete/command-path.bats
@@ -69,13 +69,13 @@ assert_completions_match() {
 }
 
 @test "$SUITE: all top-level commands for zeroth or first argument" {
-  # user_commands and plugin_commands must remain hand-sorted.
-  local user_commands=('bar' 'baz' 'foo')
-  local plugin_commands=('plugh' 'quux' 'xyzzy')
   local __all_scripts=("${BUILTIN_SCRIPTS[@]}")
 
-  add_scripts "$TEST_GO_SCRIPTS_DIR" "${user_commands[@]}"
-  add_scripts "$TEST_GO_SCRIPTS_DIR/plugins" "${plugin_commands[@]}"
+  # Command script and plugin script names must remain hand-sorted.
+  add_scripts 'bar' 'baz' 'foo' \
+    'plugins/plugh/bin/plugh' \
+    'plugins/quux/bin/quux' \
+    'plugins/xyzzy/bin/xyzzy'
 
   # Aliases will get printed before all other commands.
   local __expected_results=($(./go 'aliases') "${__all_scripts[@]##*/}")

--- a/tests/path/init-constants.bats
+++ b/tests/path/init-constants.bats
@@ -14,24 +14,15 @@ teardown() {
   @go.remove_test_go_rootdir
 }
 
-@test "$SUITE: initialize constants without plugins" {
+@test "$SUITE: initialize constants without plugins dir" {
   run "$TEST_GO_SCRIPT"
   assert_success
 
   local expected_paths=("$_GO_ROOTDIR/libexec" "$TEST_GO_SCRIPTS_DIR")
 
-  assert_line_equals 0 '_GO_PLUGINS_DIR: '
-  assert_line_equals 1 '_GO_PLUGINS_PATHS: '
-  assert_line_equals 2 "_GO_SEARCH_PATHS: ${expected_paths[*]}"
-}
-
-@test "$SUITE: initialize constants with plugins dir" {
-  run "$TEST_GO_SCRIPT"
-  assert_success
-
-  local expected_paths=("$_GO_ROOTDIR/libexec" "$TEST_GO_SCRIPTS_DIR")
-
-  assert_line_equals 0 '_GO_PLUGINS_DIR: '
+  # Even if the plugins dir doesn't exist, we still set the value so its
+  # existence can be checked for generically.
+  assert_line_equals 0 "_GO_PLUGINS_DIR: $TEST_GO_PLUGINS_DIR"
   assert_line_equals 1 '_GO_PLUGINS_PATHS: '
   assert_line_equals 2 "_GO_SEARCH_PATHS: ${expected_paths[*]}"
 }
@@ -48,12 +39,11 @@ teardown() {
 
   local expected_paths=(
     "$_GO_ROOTDIR/libexec"
-    "$TEST_GO_PLUGINS_DIR"
     "${plugin_bindirs[@]}"
     "$TEST_GO_SCRIPTS_DIR")
 
   assert_line_equals 0 "_GO_PLUGINS_DIR: $TEST_GO_PLUGINS_DIR"
   assert_line_equals 1 \
-    "_GO_PLUGINS_PATHS: $TEST_GO_PLUGINS_DIR ${plugin_bindirs[*]}"
+    "_GO_PLUGINS_PATHS: ${plugin_bindirs[*]}"
   assert_line_equals 2 "_GO_SEARCH_PATHS: ${expected_paths[*]}"
 }

--- a/tests/plugins.bats
+++ b/tests/plugins.bats
@@ -18,7 +18,9 @@ teardown() {
   assert_failure ''
 }
 
-@test "$SUITE: tab completion returns flags if plugins dir present" {
+@test "$SUITE: tab completion returns flags if plugins present" {
+  @go.create_test_command_script 'plugins/foo/bin/foo'
+
   run "$TEST_GO_SCRIPT" complete 1 plugins ''
   local expected=('--paths' '--summaries')
   assert_success "${expected[@]}"
@@ -61,15 +63,14 @@ teardown() {
     fi
   done
 
+  # Note that only `/bin` scripts from each plugin directory are included.
   run "$TEST_GO_SCRIPT" plugins
-  assert_success "${plugins[@]##*/}"
+  assert_success 'bar' 'baz' 'plugh'
 
   local paths=(
     'bar    scripts/plugins/bar/bin/bar'
     'baz    scripts/plugins/bar/bin/baz'
-    'foo    scripts/plugins/foo'
-    'plugh  scripts/plugins/plugh/bin/plugh'
-    'xyzzy  scripts/plugins/xyzzy')
+    'plugh  scripts/plugins/plugh/bin/plugh')
 
   run "$TEST_GO_SCRIPT" plugins --paths
   assert_success "${paths[@]}"
@@ -77,9 +78,7 @@ teardown() {
   local summaries=(
     '  bar    Does bar stuff'
     '  baz    Does baz stuff'
-    '  foo    Does foo stuff'
-    '  plugh  Does plugh stuff'
-    '  xyzzy  Does xyzzy stuff')
+    '  plugh  Does plugh stuff')
 
   run "$TEST_GO_SCRIPT" plugins --summaries
   assert_success "${summaries[@]}"

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -47,7 +47,7 @@ quotify_expected() {
     'declare -- _GO_INJECT_MODULE_PATH=""'
     'declare -- _GO_INJECT_SEARCH_PATH=""'
     "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
-    'declare -- _GO_PLUGINS_DIR=""'
+    "declare -- _GO_PLUGINS_DIR=\"$TEST_GO_PLUGINS_DIR\""
     'declare -a _GO_PLUGINS_PATHS=()'
     "declare -rx _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
@@ -81,17 +81,15 @@ quotify_expected() {
   assert_success
 
   local cmd_argv=('[0]="foo"' '[1]="bar"' '[2]="baz quux"' '[3]="xyzzy"')
-  local plugins_paths=("[0]=\"$TEST_GO_PLUGINS_DIR\""
-    "[1]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
-    "[2]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
-    "[3]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\"")
+  local plugins_paths=("[0]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
+    "[1]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
+    "[2]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\"")
   local search_paths=("[0]=\"$TEST_GO_ROOTDIR/bin\""
     "[1]=\"$_GO_CORE_DIR/libexec\""
-    "[2]=\"$TEST_GO_PLUGINS_DIR\""
-    "[3]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
-    "[4]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
-    "[5]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\""
-    "[6]=\"$TEST_GO_SCRIPTS_DIR\"")
+    "[2]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
+    "[3]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
+    "[4]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\""
+    "[5]=\"$TEST_GO_SCRIPTS_DIR\"")
 
   # Note that the `format` module imports `strings` and `validation`.
   local expected_modules=('[0]="module_0"'


### PR DESCRIPTION
Part of #120. Now scripts that may be exported as plugins must reside in a project's `/bin` directory, not the root directory. Some implications of this:

The top-level `./go` scripts in plugins will not appear in the parent's available commands. This way a plugin can have its own `./go` script for development.

Applications intended to function both standalone and as a plugin are possible. There may be separate `./go` scripts and script directories for the standalone application interface and for the development interface (e.g. `./dev` with its own scripts dir, which could possibly even be `bin/dev`).

Applications that want to export plugins, but not the entire application, must extract a new project repository that is imported into the original application. In addition to freeing potential clients from the original application's dependencies, it's a forcing function to ensure the original application's team keeps the plugin interface up-to-date.

This change also ensures `_GO_PLUGINS_DIR` is always set. This will have implications in a future commit such that for scripts running as a plugin, this will be the plugin dir for the top-most script.

A bunch of the changes in this commit are to the `tests/commands/helpers.bats` functions and how they're called from the `commands/` tests.