### PR TITLE
path: Search `_GO_SCRIPTS_DIR` before plugin dirs

### DIFF
--- a/lib/internal/path
+++ b/lib/internal/path
@@ -13,7 +13,7 @@ if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
       unset '_GO_PLUGINS_PATHS'
     fi
   fi
-  _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}" "$_GO_SCRIPTS_DIR")
+  _GO_SEARCH_PATHS+=("$_GO_SCRIPTS_DIR" "${_GO_PLUGINS_PATHS[@]}")
 fi
 
 _@go.list_available_commands() {

--- a/tests/path/init-constants.bats
+++ b/tests/path/init-constants.bats
@@ -39,8 +39,8 @@ teardown() {
 
   local expected_paths=(
     "$_GO_ROOTDIR/libexec"
-    "${plugin_bindirs[@]}"
-    "$TEST_GO_SCRIPTS_DIR")
+    "$TEST_GO_SCRIPTS_DIR"
+    "${plugin_bindirs[@]}")
 
   assert_line_equals 0 "_GO_PLUGINS_DIR: $TEST_GO_PLUGINS_DIR"
   assert_line_equals 1 \

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -86,10 +86,10 @@ quotify_expected() {
     "[2]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\"")
   local search_paths=("[0]=\"$TEST_GO_ROOTDIR/bin\""
     "[1]=\"$_GO_CORE_DIR/libexec\""
-    "[2]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
-    "[3]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
-    "[4]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\""
-    "[5]=\"$TEST_GO_SCRIPTS_DIR\"")
+    "[2]=\"$TEST_GO_SCRIPTS_DIR\""
+    "[3]=\"$TEST_GO_PLUGINS_DIR/plugin0/bin\""
+    "[4]=\"$TEST_GO_PLUGINS_DIR/plugin1/bin\""
+    "[5]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\"")
 
   # Note that the `format` module imports `strings` and `validation`.
   local expected_modules=('[0]="module_0"'


### PR DESCRIPTION
Part of #120, and similar to #122, searching the local `_GO_SCRIPT_DIR` before plugin dirs seems like a more natural and scalable model. `_GO_CORE_DIR/libexec` for builtins still comes first.

The idea behind this model is that when reading a script within the `./go` script framework, it should be clear that:

- core framework scripts are the same everywhere; they can't be shadowed by scripts with the same name
- project-local scripts take precedence before any plugin scripts

The implications of this last point are that:

- a script that is installed as a plugin will find its own scripts before those that share the same name with other installed plugins, avoiding collisions and possibly obscure bugs
- the parent project can determine the precedence of plugin scripts sharing the same name, as the plugins can be installed using directory names that force a particular order (e.g. '00-', '01-', '02-' prefixes).
- as an alternative to the approach in the preceding point, the parent project can potentially resolve conflicts by installing its own scripts that then delegate to a specific plugin script

And to this last point, I've filed #127 to facilitate help text discovery.