### PR TITLE
Support scoped _GO_* variables for plugins

### DIFF
--- a/lib/internal/path
+++ b/lib/internal/path
@@ -1,20 +1,12 @@
 #! /bin/bash
 
 _@go.set_search_paths() {
-  local plugins_paths=("$_GO_SCRIPTS_DIR"/plugins/*/bin)
   local plugin_path
 
   if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
     _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
   fi
   _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
-
-  # A plugin's own local plugin paths will appear before inherited ones. If
-  # there is a version incompatibility issue with other installed plugins, this
-  # allows a plugin's preferred version to take precedence.
-  if [[ "${plugins_paths[0]}" != "$_GO_SCRIPTS_DIR/plugins/*/bin" ]]; then
-    _GO_PLUGINS_PATHS=("${plugins_paths[@]}" "${_GO_PLUGINS_PATHS[@]}")
-  fi
 
   # A plugin's _GO_SCRIPTS_DIR may continue to appear in _GO_PLUGINS_PATHS so
   # that it's available to other plugins that depend upon it as a circular
@@ -28,8 +20,13 @@ _@go.set_search_paths() {
 }
 
 if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
-  _@go.set_search_paths
   _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
+  _GO_PLUGINS_PATHS=("$_GO_PLUGINS_DIR"/*/bin)
+
+  if [[ "${_GO_PLUGINS_PATHS[0]}" == "$_GO_PLUGINS_DIR/*/bin" ]]; then
+    unset '_GO_PLUGINS_PATHS[0]'
+  fi
+  _@go.set_search_paths
 fi
 
 _@go.list_available_commands() {

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -1,19 +1,22 @@
 #! /bin/bash
 
-if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
+_@go.set_search_paths() {
+  local plugins_paths=("$_GO_SCRIPTS_DIR"/plugins/*/bin)
+
   if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
     _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
   fi
-  _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec")
-  _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
+  _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
 
-  if [[ -d "$_GO_PLUGINS_DIR" ]]; then
-    _GO_PLUGINS_PATHS=("$_GO_PLUGINS_DIR"/*/bin)
-    if [[ "${_GO_PLUGINS_PATHS[0]}" == "$_GO_PLUGINS_DIR/*/bin" ]]; then
-      unset '_GO_PLUGINS_PATHS'
-    fi
+  if [[ "${plugins_paths[0]}" != "$_GO_SCRIPTS_DIR/plugins/*/bin" ]]; then
+    _GO_PLUGINS_PATHS=("${plugins_paths[@]}" "${_GO_PLUGINS_PATHS[@]}")
+    _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}")
   fi
-  _GO_SEARCH_PATHS+=("$_GO_SCRIPTS_DIR" "${_GO_PLUGINS_PATHS[@]}")
+}
+
+if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
+  _@go.set_search_paths
+  _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
 fi
 
 _@go.list_available_commands() {

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -2,16 +2,29 @@
 
 _@go.set_search_paths() {
   local plugins_paths=("$_GO_SCRIPTS_DIR"/plugins/*/bin)
+  local plugin_path
 
   if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
     _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
   fi
   _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
 
+  # A plugin's own local plugin paths will appear before inherited ones. If
+  # there is a version incompatibility issue with other installed plugins, this
+  # allows a plugin's preferred version to take precedence.
   if [[ "${plugins_paths[0]}" != "$_GO_SCRIPTS_DIR/plugins/*/bin" ]]; then
     _GO_PLUGINS_PATHS=("${plugins_paths[@]}" "${_GO_PLUGINS_PATHS[@]}")
-    _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}")
   fi
+
+  # A plugin's _GO_SCRIPTS_DIR may continue to appear in _GO_PLUGINS_PATHS so
+  # that it's available to other plugins that depend upon it as a circular
+  # dependency (though such dependencies are strongly discouraged). However, we
+  # will ensure its _GO_SCRIPTS_DIR isn't duplicated in _GO_SEARCH_PATHS.
+  for plugin_path in "${_GO_PLUGINS_PATHS[@]}"; do
+    if [[ "$plugin_path" != "$_GO_SCRIPTS_DIR" ]]; then
+      _GO_SEARCH_PATHS+=("$plugin_path")
+    fi
+  done
 }
 
 if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then

--- a/tests/core/plugin-scope-execution.bats
+++ b/tests/core/plugin-scope-execution.bats
@@ -1,0 +1,142 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+PRINT_SOURCE='printf -- "%s\n" "$BASH_SOURCE"'
+
+setup() {
+  test_filter
+  @go.create_test_go_script '@go "$@"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: project script takes precedence over plugin" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' "$PRINT_SOURCE"
+  @go.create_test_command_script 'foo' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/foo"
+}
+
+@test "$SUITE: plugin can't use script from top-level _GO_SCRIPTS_DIR" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'bar' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_failure
+  assert_line_equals 0 'Unknown command: bar'
+}
+
+@test "$SUITE: plugin can use script from top-level _GO_PLUGINS_DIR" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/bar/bin/bar' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/bar/bin/bar"
+}
+
+@test "$SUITE: plugin can use plugin from own plugin dir" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' \
+    "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/plugins/bar/bin/bar"
+}
+
+@test "$SUITE: plugin's local _GO_SCRIPTS_DIR scripts take precedence" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/bar' "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/bar/bin/bar' "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' \
+    "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/bar"
+}
+
+@test "$SUITE: local plugins take precedence over top-level _GO_PLUGINS_DIR" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/bar/bin/bar' "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' \
+    "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/plugins/bar/bin/bar"
+}
+
+@test "$SUITE: circular dependencies in nested plugin dirs" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/baz' "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/baz"
+}
+
+@test "$SUITE: circular dependencies in top-level _GO_PLUGINS_DIR" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/baz' "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/bar/bin/bar' '@go baz'
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/baz"
+}
+
+@test "$SUITE: nested plugin's _GO_SCRIPTS_DIR precedes plugins" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script \
+    'plugins/foo/bin/plugins/bar/bin/plugins/baz/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/foo/bin/plugins/baz/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/baz/bin/baz' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/plugins/bar/bin/baz"
+}
+
+@test "$SUITE: nested plugin's plugins precede parents' plugins" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+
+  @go.create_test_command_script \
+    'plugins/foo/bin/plugins/bar/bin/plugins/baz/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/foo/bin/plugins/baz/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/baz/bin/baz' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success \
+    "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/plugins/bar/bin/plugins/baz/bin/baz"
+}
+
+@test "$SUITE: nested plugin's sibling precedes top-level _GO_PLUGINS_DIR" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+
+  @go.create_test_command_script 'plugins/foo/bin/plugins/baz/bin/baz' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/baz/bin/baz' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/foo/bin/plugins/baz/bin/baz"
+}
+
+@test "$SUITE: nested plugin finds top-level _GO_PLUGINS_DIR plugin" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+
+  @go.create_test_command_script 'plugins/baz/bin/baz' "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_SCRIPTS_DIR/plugins/baz/bin/baz"
+}

--- a/tests/core/plugin-scope-execution.bats
+++ b/tests/core/plugin-scope-execution.bats
@@ -140,3 +140,15 @@ teardown() {
   run "$TEST_GO_SCRIPT" 'foo'
   assert_success "$TEST_GO_SCRIPTS_DIR/plugins/baz/bin/baz"
 }
+
+@test "$SUITE: nested plugins dir doesn't leak to sibling plugin" {
+  @go.create_test_command_script 'plugins/foo/bin/foo' '@go bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/bin/bar' '@go baz'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/quux/bin/quux' \
+    "$PRINT_SOURCE"
+  @go.create_test_command_script 'plugins/baz/bin/baz' '@go quux'
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_failure
+  assert_line_equals 0 'Unknown command: quux'
+}

--- a/tests/core/plugin-scope-variable-values.bats
+++ b/tests/core/plugin-scope-variable-values.bats
@@ -1,0 +1,160 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+EXPECTED_ROOT_SCOPE_VALUES=()
+EXPECTED_ROOT_SCOPE_PLUGINS_PATHS=()
+
+setup() {
+  test_filter
+
+  local print_scope_implementation=(
+    'printf -- "_GO_ROOTDIR:\n%s\n" "$_GO_ROOTDIR"'
+    'printf -- "_GO_SCRIPTS_DIR:\n%s\n" "$_GO_SCRIPTS_DIR"'
+    'printf -- "_GO_PLUGINS_PATHS:\n"'
+    'printf -- "%s\n" "${_GO_PLUGINS_PATHS[@]}"'
+    'printf -- "_GO_SEARCH_PATHS:\n"'
+    'printf -- "%s\n" "${_GO_SEARCH_PATHS[@]}"'
+    'printf -- "\n"')
+
+  @go.create_test_go_script '@go "$@"' \
+    'printf "ROOT LEVEL SCOPE:\n"' \
+    "${print_scope_implementation[@]}"
+
+  @go.create_test_command_script 'top' \
+    'printf "TOP LEVEL SCOPE:\n"' \
+    "${print_scope_implementation[@]}"
+  @go.create_test_command_script 'plugins/first/bin/first' \
+    'printf "FIRST LEVEL PLUGIN SCOPE:\n"' \
+    "${print_scope_implementation[@]}"
+  @go.create_test_command_script 'plugins/second/bin/second' \
+    "@go third" \
+    'printf "FIRST LEVEL PLUGIN SCOPE:\n"' \
+    "${print_scope_implementation[@]}"
+  @go.create_test_command_script 'plugins/second/bin/plugins/third/bin/third' \
+    'printf "SECOND LEVEL PLUGIN SCOPE:\n"' \
+    "${print_scope_implementation[@]}"
+
+  EXPECTED_ROOT_SCOPE_PLUGINS_PATHS=("$TEST_GO_PLUGINS_DIR/first/bin"
+    "$TEST_GO_PLUGINS_DIR/second/bin")
+
+  EXPECTED_ROOT_SCOPE_VALUES=('_GO_ROOTDIR:'
+    "$TEST_GO_ROOTDIR"
+    '_GO_SCRIPTS_DIR:'
+    "$TEST_GO_SCRIPTS_DIR"
+    '_GO_PLUGINS_PATHS:'
+    "${EXPECTED_ROOT_SCOPE_PLUGINS_PATHS[@]}"
+    '_GO_SEARCH_PATHS:'
+    "$_GO_CORE_DIR/libexec"
+    "$TEST_GO_SCRIPTS_DIR"
+    "${EXPECTED_ROOT_SCOPE_PLUGINS_PATHS[@]}")
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+assert_scope_values_equal() {
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+  local scope="$1"
+  shift
+  local orig_lines=("${lines[@]}")
+  local result='0'
+  local i
+
+  for ((i=0; i != "${#lines[@]}"; ++i)); do
+    if [[ "${lines[$i]}" == "$scope SCOPE:" ]]; then
+      lines=("${lines[@]:$((i + 1)):$#}")
+      if ! assert_lines_equal "$@"; then
+        result='1'
+      fi
+      lines=("${orig_lines[@]}")
+      return_from_bats_assertion "$result"
+      return
+    fi
+  done
+
+  if [[ "$i" -eq "${#lines[@]}" ]]; then
+    printf 'ERROR: could not find "%s" in output.\nOUTPUT:\n%s\n' \
+      "$scope SCOPE:" "$output" >&2
+    return_from_bats_assertion '1'
+  fi
+}
+
+@test "$SUITE: top-level script" {
+  run "$TEST_GO_SCRIPT" top
+  assert_success
+  assert_scope_values_equal 'TOP LEVEL' "${EXPECTED_ROOT_SCOPE_VALUES[@]}"
+  assert_scope_values_equal 'ROOT LEVEL' "${EXPECTED_ROOT_SCOPE_VALUES[@]}"
+}
+
+@test "$SUITE: first-level plugin script" {
+  run "$TEST_GO_SCRIPT" first
+  assert_success
+
+  # _GO_PLUGINS_PATHS is inherited to support installing a single instance of a
+  # common plugin in the top-level _GO_PLUGINS_DIR. The plugin's _GO_SCRIPTS_DIR
+  # will still appear in _GO_PLUGINS_PATHS, but won't be duplicated in
+  # _GO_SEARCH_PATHS.
+  assert_scope_values_equal 'FIRST LEVEL PLUGIN' \
+    '_GO_ROOTDIR:' \
+    "$TEST_GO_PLUGINS_DIR/first" \
+    '_GO_SCRIPTS_DIR:' \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    '_GO_PLUGINS_PATHS:' \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin" \
+    '_GO_SEARCH_PATHS:' \
+    "$_GO_CORE_DIR/libexec" \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin"
+
+  assert_scope_values_equal 'ROOT LEVEL' "${EXPECTED_ROOT_SCOPE_VALUES[@]}"
+}
+
+@test "$SUITE: second-level plugin script" {
+  run "$TEST_GO_SCRIPT" second
+  assert_success
+
+  # As with the previous test case, _GO_PLUGINS_PATHS is inherited, and the
+  # second level plugin's _GO_SCRIPTS_DIR will still appear in
+  # _GO_PLUGINS_PATHS, but won't be duplicated in _GO_SEARCH_PATHS.
+  #
+  # Its parent's _GO_SCRIPTS_DIR is in both _GO_PLUGINS_PATHS and
+  # _GO_SEARCH_PATHS, since its parent is also a plugin. This could support a
+  # circular dependency, though such dependencies are strongly discouraged.
+  assert_scope_values_equal 'SECOND LEVEL PLUGIN' \
+    '_GO_ROOTDIR:' \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third" \
+    '_GO_SCRIPTS_DIR:' \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
+    '_GO_PLUGINS_PATHS:' \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin" \
+    '_GO_SEARCH_PATHS:' \
+    "$_GO_CORE_DIR/libexec" \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin"
+
+  # The first level plugin's own plugin paths will appear before any inherited
+  # _GO_PLUGINS_PATHS, to support a plugin's own installed plugin version to
+  # take precedence over other installed versions.
+  assert_scope_values_equal 'FIRST LEVEL PLUGIN' \
+    '_GO_ROOTDIR:' \
+    "$TEST_GO_PLUGINS_DIR/second" \
+    '_GO_SCRIPTS_DIR:' \
+    "$TEST_GO_PLUGINS_DIR/second/bin" \
+    '_GO_PLUGINS_PATHS:' \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
+    "$TEST_GO_PLUGINS_DIR/first/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin" \
+    '_GO_SEARCH_PATHS:' \
+    "$_GO_CORE_DIR/libexec" \
+    "$TEST_GO_PLUGINS_DIR/second/bin" \
+    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
+    "$TEST_GO_PLUGINS_DIR/first/bin"
+
+  assert_scope_values_equal 'ROOT LEVEL' "${EXPECTED_ROOT_SCOPE_VALUES[@]}"
+}

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -49,7 +49,7 @@ quotify_expected() {
     "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
     "declare -- _GO_PLUGINS_DIR=\"$TEST_GO_PLUGINS_DIR\""
     'declare -a _GO_PLUGINS_PATHS=()'
-    "declare -rx _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
+    "declare -x _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
@@ -113,7 +113,7 @@ quotify_expected() {
     "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
     "declare -- _GO_PLUGINS_DIR=\"$TEST_GO_PLUGINS_DIR\""
     "declare -a _GO_PLUGINS_PATHS=(${plugins_paths[*]})"
-    "declare -rx _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
+    "declare -x _GO_ROOTDIR=\"$TEST_GO_ROOTDIR\""
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"


### PR DESCRIPTION
Part of #120. Plugin command scripts now have their own scoped `_GO_ROOTDIR`, `_GO_SCRIPTS_DIR`, `_GO_SEARCH_PATHS`, and `_GO_PLUGINS_PATHS`. This will encourage more composable plugins, some of which may even operate as standalone applications that can be incorporated wholesale into other applications.

Notice that the search path precedence is:

- `_GO_INJECT_SEARCH_PATH`
- `_GO_CORE_DIR/libexec`
- `_GO_SCRIPTS_DIR`
- `_GO_SCRIPTS_DIR/plugins/*/bin`
- any inherited `_GO_PLUGINS_PATHS` from the parent environment

The implication of the last two points is that plugin command scripts will first search for other command scripts in their own `_GO_SCRIPTS_DIR`, for plugins in their own `_GO_SCRIPTS_DIR/plugins/*/bin`, then through the `_GO_PLUGINS_PATHS` inherited from the parent script. These `_GO_PLUGINS_PATHS` search paths effectively build a command path search that recurses up to the top-level `_GO_PLUGINS_DIR`.

This lays the groundwork for:

- sharing a single copy of a plugin between all plugins that may depend on it
- installing specific versions of a plugin within plugins themselves to resolve version incompatibilities with other installed versions of a plugin
- circular dependency support, though such dependencies are strongly discouraged

A future PR/commit will support a similar mechanism for plugin module (`plugin/lib`) imports.