### PR TITLE
core, path: Refactor plugin path handling

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -259,7 +259,7 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     return 1
   fi
 
-  if [[ "$__go_cmd_path" =~ ^$_GO_PLUGINS_DIR/ ]]; then
+  if [[ "${__go_cmd_path#$_GO_SCRIPTS_DIR}" =~ /plugins/ ]]; then
     _@go.run_plugin_command_script "$__go_cmd_path" "${__go_argv[@]}"
   else
     _@go.run_command_script "$__go_cmd_path" "${__go_argv[@]}"
@@ -273,26 +273,10 @@ _@go.source_builtin() {
 }
 
 _@go.run_plugin_command_script() {
-  local _GO_SCRIPTS_DIR="${__go_cmd_path%/*}"
+  local _GO_SCRIPTS_DIR="${__go_cmd_path%/bin/*}/bin"
   local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/*}"
-  local _GO_SEARCH_PATHS=()
   local _GO_PLUGINS_PATHS=()
-  local plugins_dir="$_GO_SCRIPTS_DIR/plugins"
-  local plugin_paths=()
-
-  # A plugin's own local plugin paths will appear before inherited ones. If
-  # there is a version incompatibility issue with other installed plugins, this
-  # allows a plugin's preferred version to take precedence.
-  while true; do
-    plugin_paths=("$plugins_dir"/*/bin)
-    if [[ "${plugin_paths[0]}" != "$plugins_dir/*/bin" ]]; then
-      _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")
-    fi
-    if [[ "$plugins_dir" == "$_GO_PLUGINS_DIR" ]]; then
-      break
-    fi
-    plugins_dir="${plugins_dir%/plugins/*}/plugins"
-  done
+  local _GO_SEARCH_PATHS=()
 
   _@go.set_search_paths
   _@go.run_command_script "$__go_cmd_path" "${__go_argv[@]}"

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -1,12 +1,28 @@
 #! /bin/bash
 
 _@go.set_search_paths() {
+  local plugins_dir="$_GO_SCRIPTS_DIR/plugins"
+  local plugins_paths=()
   local plugin_path
 
   if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
     _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
   fi
   _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
+
+  # A plugin's own local plugin paths will appear before inherited ones. If
+  # there is a version incompatibility issue with other installed plugins, this
+  # allows a plugin's preferred version to take precedence.
+  while true; do
+    plugin_paths=("$plugins_dir"/*/bin)
+    if [[ "${plugin_paths[0]}" != "$plugins_dir/*/bin" ]]; then
+      _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")
+    fi
+    if [[ "$plugins_dir" == "$_GO_PLUGINS_DIR" ]]; then
+      break
+    fi
+    plugins_dir="${plugins_dir%/plugins/*}/plugins"
+  done
 
   # A plugin's _GO_SCRIPTS_DIR may continue to appear in _GO_PLUGINS_PATHS so
   # that it's available to other plugins that depend upon it as a circular
@@ -21,11 +37,6 @@ _@go.set_search_paths() {
 
 if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
   _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
-  _GO_PLUGINS_PATHS=("$_GO_PLUGINS_DIR"/*/bin)
-
-  if [[ "${_GO_PLUGINS_PATHS[0]}" == "$_GO_PLUGINS_DIR/*/bin" ]]; then
-    unset '_GO_PLUGINS_PATHS[0]'
-  fi
   _@go.set_search_paths
 fi
 


### PR DESCRIPTION
I realized the `while true` loop from `_@go.run_plugin_command_script` could live comfortably in `_@go.set_search_paths` and handle the top-level `_GO_PLUGINS_PATHS` case as well.

Also, I realized that there was no need for `@go` to invoke `_@go.run_plugin_command_script` if the command script in question was from the `_GO_SCRIPTS_DIR` of the current plugin and not in `_GO_SCRIPTS_DIR/plugins`.

Plus, there was a bug whereby it'd been presumed that the plugin command path would always reside in the top-level `_GO_SCRIPTS_DIR` of the plugin. Now the plugin's `_GO_SCRIPTS_DIR` is correctly set to the `/bin` parent directory of the command script. I'll add thorough tests for this in a future commit/PR.