### PR TITLE
Add plugin scope tests, new test helper, other related improvements

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -259,7 +259,7 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     return 1
   fi
 
-  if [[ "${__go_cmd_path#$_GO_SCRIPTS_DIR}" =~ /plugins/ ]]; then
+  if [[ "${__go_cmd_path#$_GO_SCRIPTS_DIR}" =~ /plugins/[^/]+/bin/ ]]; then
     _@go.run_plugin_command_script "$__go_cmd_path" "${__go_argv[@]}"
   else
     _@go.run_command_script "$__go_cmd_path" "${__go_argv[@]}"

--- a/lib/bats/assertions
+++ b/lib/bats/assertions
@@ -149,7 +149,7 @@ fail_if() {
   local constraints=()
   local constraint
   local i
-  local bats_fail_no_output='true'
+  local bats_fail_no_output=''
 
   if [[ "$assertion" =~ _match ]]; then
     operation='match'
@@ -157,11 +157,13 @@ fail_if() {
 
   case "$assertion" in
   assert_equal|assert_matches)
+    bats_fail_no_output='true'
     label="${3:-value}"
     constraints=("$1")
     value="$2"
     ;;
   assert_output*|assert_status)
+    bats_fail_no_output='true'
     label="${assertion#assert_}"
     label="${label%_*}"
     constraints=("$@")
@@ -173,12 +175,10 @@ fail_if() {
     value="${lines[$1]}"
     ;;
   assert_lines_*)
-    bats_fail_no_output=
     label="lines"
     constraints=("${@}")
     ;;
   assert_file_*)
-    bats_fail_no_output=
     label="'$1'"
     constraints=("${@:2}")
     ;;

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -257,7 +257,11 @@ export -f test_printf
 #     zero otherwise
 test_break_after_num_iterations() {
   local __tbani_num_iterations="$1"
-  local __tbani_id="${BASH_SOURCE[1]}_${BASH_LINENO[0]}_${FUNCNAME[1]}"
+
+  # In Bash versions earlier than 4.4, `BASH_SOURCE` isn't set properly for the
+  # main script, so it will be empty. So we use $0 in that case instead.
+  local __tbani_id="${BASH_SOURCE[1]:-$0}_${BASH_LINENO[0]}_${FUNCNAME[1]}"
+
   local __tbani_var="__tbani_current_iteration_${__tbani_id//[^[:alnum:]]/_}"
   local __tbani_caller_var
   local __tbani_do_exit
@@ -269,7 +273,7 @@ test_break_after_num_iterations() {
   elif [[ -z "$TEST_DEBUG" ]]; then
     return
   else
-    printf -v "$__tbani_var" -- '%d' "$((${!__tbani_var:-0} + 1))"
+    printf -v "$__tbani_var" -- '%d' "$((${!__tbani_var} + 1))"
     if [[ "${!__tbani_var}" -eq "$__tbani_num_iterations" ]]; then
       printf 'Breaking after iteration %d at:\n' "$__tbani_num_iterations" >&2
       __tbani_do_exit='true'
@@ -278,7 +282,8 @@ test_break_after_num_iterations() {
 
   if [[ -n "$__tbani_do_exit" ]]; then
     for ((__tbani_i=1; __tbani_i != "${#FUNCNAME[@]}"; ++__tbani_i)); do
-      printf '  %s:%s %s\n' "${BASH_SOURCE[$__tbani_i]}" \
+      # Again notice the use of $0 to cover the case when BASH_SOURCE isn't set.
+      printf '  %s:%s %s\n' "${BASH_SOURCE[$__tbani_i]:-$0}" \
         "${BASH_LINENO[$((__tbani_i-1))]}" "${FUNCNAME[$__tbani_i]}" >&2
     done
 

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -223,6 +223,9 @@ test_join() {
 # When debugging a piece of code, you may wish to source this file and
 # temporarily include `test_printf` to trace values in your program.
 #
+# Globals:
+#   TEST_DEBUG:  prints to stderr when not null, disables printing otherwise
+#
 # Arguments:
 #    ...:  Arguments to `printf`
 test_printf() {
@@ -231,6 +234,61 @@ test_printf() {
   fi
 }
 export -f test_printf
+
+# Breaks execution after a number of iterations and prints context to stderr
+#
+# After reaching the number of iterations, this function prints to standard
+# error the caller's stack trace, prints the names and values of any variables
+# specified in the argument list (one per line), and exits the program with an
+# error.
+#
+# Add this to a point in your program to determine how a program reached a
+# certain line of execution and to examine its context.
+#
+# Globals:
+#   TEST_DEBUG:  enables breaking when not null, disables breaking otherwise
+#
+# Arguments:
+#   num_iterations:  The number of iterations after which execution will break
+#   ...:             Names of variables to print to standard error on break
+#
+# Returns:
+#   Nonzero if `TEST_DEBUG` is set and `num_iterations` has been reached,
+#     zero otherwise
+test_break_after_num_iterations() {
+  local __tbani_num_iterations="$1"
+  local __tbani_id="${BASH_SOURCE[1]}_${BASH_LINENO[0]}_${FUNCNAME[1]}"
+  local __tbani_var="__tbani_current_iteration_${__tbani_id//[^[:alnum:]]/_}"
+  local __tbani_caller_var
+  local __tbani_do_exit
+  local __tbani_i
+
+  if [[ ! "$__tbani_num_iterations" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'The argument to %s must be a positive integer at:\n' "$FUNCNAME" >&2
+    __tbani_do_exit='true'
+  elif [[ -z "$TEST_DEBUG" ]]; then
+    return
+  else
+    printf -v "$__tbani_var" -- '%d' "$((${!__tbani_var:-0} + 1))"
+    if [[ "${!__tbani_var}" -eq "$__tbani_num_iterations" ]]; then
+      printf 'Breaking after iteration %d at:\n' "$__tbani_num_iterations" >&2
+      __tbani_do_exit='true'
+    fi
+  fi
+
+  if [[ -n "$__tbani_do_exit" ]]; then
+    for ((__tbani_i=1; __tbani_i != "${#FUNCNAME[@]}"; ++__tbani_i)); do
+      printf '  %s:%s %s\n' "${BASH_SOURCE[$__tbani_i]}" \
+        "${BASH_LINENO[$((__tbani_i-1))]}" "${FUNCNAME[$__tbani_i]}" >&2
+    done
+
+    for __tbani_caller_var in "${@:2}"; do
+      printf -- '%s: %s\n' "$__tbani_caller_var" "${!__tbani_caller_var}" >&2
+    done
+    exit 1
+  fi
+}
+export -f test_break_after_num_iterations
 
 # Skips a test if `TEST_FILTER` is set but doesn't match `BATS_TEST_DESCRIPTION`
 #

--- a/lib/internal/commands
+++ b/lib/internal/commands
@@ -23,9 +23,9 @@ _@go.merge_scripts_into_list() {
     rhs_name="${rhs_script##*/}"
 
     if [[ "$lhs_name" == "$rhs_name" ]]; then
-      printf "ERROR: duplicate command $lhs_name:\n\n  %s\n  %s\n" \
-        "$lhs_script" "$rhs_script" >&2
-      return 1
+      result+=("$lhs_script")
+      ((++i))
+      ((++j))
     elif [[ "$lhs_name" < "$rhs_name" ]]; then
       result+=("$lhs_script")
       ((++i))
@@ -56,10 +56,7 @@ _@go.find_commands() {
         scripts+=("$script")
       fi
     done
-
-    if ! _@go.merge_scripts_into_list "${scripts[@]#$_GO_ROOTDIR/}"; then
-      return 1
-    fi
+    _@go.merge_scripts_into_list "${scripts[@]#$_GO_ROOTDIR/}"
   done
 
   if [[ "${#__go_command_scripts[@]}" -eq '0' ]]; then

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -13,7 +13,7 @@ _@go.set_search_paths() {
   # A plugin's own local plugin paths will appear before inherited ones. If
   # there is a version incompatibility issue with other installed plugins, this
   # allows a plugin's preferred version to take precedence.
-  while true; do
+  while [[ "$plugins_dir" =~ ^$_GO_PLUGINS_DIR ]]; do
     plugin_paths=("$plugins_dir"/*/bin)
     if [[ "${plugin_paths[0]}" != "$plugins_dir/*/bin" ]]; then
       _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")

--- a/tests/assertions.bats
+++ b/tests/assertions.bats
@@ -613,7 +613,10 @@ teardown() {
   expect_assertion_failure "echo 'Hello, world!'" \
     "fail_if line_equals '0' 'Hello, world!'" \
     'Expected line 0 not to equal:' \
-    "  'Hello, world!'"
+    "  'Hello, world!'" \
+    'STATUS: 0' \
+    'OUTPUT:' \
+    'Hello, world!'
 }
 
 @test "$SUITE: fail_if succeeds when assert_line_matches fails" {
@@ -627,7 +630,10 @@ teardown() {
     'Expected line 0 not to match:' \
     "  'Hello'" \
     'Value:' \
-    "  'Hello, world!'"
+    "  'Hello, world!'" \
+    'STATUS: 0' \
+    'OUTPUT:' \
+    'Hello, world!'
 }
 
 @test "$SUITE: fail_if succeeds when assert_lines_match fails" {

--- a/tests/bats-helpers/test-break-after-num-iterations.bats
+++ b/tests/bats-helpers/test-break-after-num-iterations.bats
@@ -1,0 +1,126 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+}
+
+teardown() {
+  remove_bats_test_dirs
+}
+
+@test "$SUITE: error if argument not a positive integer" {
+  local err_msg='The argument to test_break_after_num_iterations '
+  err_msg+='must be a positive integer at:'
+
+  local top_stack_line="/bats-exec-test:[0-9]+ run"
+
+  run test_break_after_num_iterations
+  assert_failure
+  assert_line_equals 0 "$err_msg"
+  assert_line_matches 1 "$top_stack_line"
+
+  run test_break_after_num_iterations 0
+  assert_failure
+  assert_line_equals 0 "$err_msg"
+  assert_line_matches 1 "$top_stack_line"
+
+  run test_break_after_num_iterations -1
+  assert_failure
+  assert_line_equals 0 "$err_msg"
+  assert_line_matches 1 "$top_stack_line"
+
+  run test_break_after_num_iterations 2foobar7
+  assert_failure
+  assert_line_equals 0 "$err_msg"
+  assert_line_matches 1 "$top_stack_line"
+}
+
+@test "$SUITE: break after specified number of iterations" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  test_break_after_num_iterations "$1"' \
+    'done'
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 5
+  assert_failure 'Breaking after iteration 5 at:' \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:3 main"
+}
+
+@test "$SUITE: does nothing if count not reached" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  test_break_after_num_iterations "$1"' \
+    'done'
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 6
+  assert_success ''
+}
+
+@test "$SUITE: does nothing if TEST_DEBUG is null" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  test_break_after_num_iterations "$1"' \
+    'done'
+  TEST_DEBUG= run "$BATS_TEST_ROOTDIR/test-break-after-n" 5
+  assert_success ''
+}
+
+@test "$SUITE: break after recursive calls" {
+  create_bats_test_script 'test-break-after-n' \
+    'recursive_func() {' \
+    '  test_break_after_num_iterations "$N"' \
+    '  recursive_func' \
+    '}' \
+    'N="$1"' \
+    'recursive_func'
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 3
+  assert_failure 'Breaking after iteration 3 at:' \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:3 recursive_func" \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:4 recursive_func" \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:4 recursive_func" \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:7 main"
+}
+
+@test "$SUITE: counts isolated between lines in same file" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  test_break_after_num_iterations "$(($1+1))"' \
+    '  test_break_after_num_iterations "$1"' \
+    'done'
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 5
+  assert_failure 'Breaking after iteration 5 at:' \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:4 main"
+}
+
+@test "$SUITE: counts isolated across files" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  . "${BASH_SOURCE[0]%/*}/foo"' \
+    '  . "${BASH_SOURCE[0]%/*}/bar"' \
+    'done'
+  create_bats_test_script 'foo' \
+    '  test_break_after_num_iterations "$(($1+1))"'
+  create_bats_test_script 'bar' \
+    '  test_break_after_num_iterations "$1"'
+
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 5
+  assert_failure 'Breaking after iteration 5 at:' \
+    "  $BATS_TEST_ROOTDIR/bar:2 source" \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:4 main"
+}
+
+@test "$SUITE: prints values of variables on break" {
+  create_bats_test_script 'test-break-after-n' \
+    'for ((i=0; i != 5; ++i)); do' \
+    '  test_break_after_num_iterations "$@"' \
+    'done'
+
+  TEST_DEBUG='true' run "$BATS_TEST_ROOTDIR/test-break-after-n" 5 \
+    'BASH_SOURCE[1]' 'BASH_LINENO[0]' 'FUNCNAME[1]' 'i'
+  assert_failure 'Breaking after iteration 5 at:' \
+    "  $BATS_TEST_ROOTDIR/test-break-after-n:3 main" \
+    "BASH_SOURCE[1]: $BATS_TEST_ROOTDIR/test-break-after-n" \
+    'BASH_LINENO[0]: 3' \
+    'FUNCNAME[1]: main' \
+    'i: 4'
+}

--- a/tests/commands/find.bats
+++ b/tests/commands/find.bats
@@ -94,21 +94,19 @@ assert_command_scripts_equal() {
   assert_command_scripts_equal "${__all_scripts[@]}"
 }
 
-@test "$SUITE: return error if duplicates exists" {
+@test "$SUITE: commands from earlier paths precede duplicates in later paths" {
+  # In this case, we're trying to duplicate a builtin. Since
+  # `_GO_CORE_DIR/libexec` comes first in `_GO_SEARCH_PATHS`, it takes
+  # precedence over the duplicate we add.
   local duplicate_cmd="${BUILTIN_SCRIPTS[0]##*/}"
   local __all_scripts=("${BUILTIN_SCRIPTS[@]}")
 
   add_scripts "$duplicate_cmd"
   run "$TEST_GO_SCRIPT"
-  assert_failure
-
-  assert_line_equals 0 "ERROR: duplicate command $duplicate_cmd:"
-
-  # Because the go-core.bash file is in the test's $_GO_ROOTDIR, and the test
-  # script has a different $_GO_ROOTDIR, the builtin scripts will retain their
-  # absolute path, whereas user scripts will be relative.
-  assert_line_equals 1 "  $_GO_ROOTDIR/${BUILTIN_SCRIPTS[0]}"
-  assert_line_equals 2 "  scripts/$duplicate_cmd"
+  assert_success
+  assert_line_equals 0 "LONGEST NAME LEN: ${#LONGEST_BUILTIN_NAME}"
+  assert_line_equals 1 "COMMAND_NAMES: ${__all_scripts[*]##*/}"
+  assert_command_scripts_equal "${__all_scripts[@]}"
 }
 
 @test "$SUITE: return subcommands only" {


### PR DESCRIPTION
Closes #132. Adds test cases missing from #131.

As demonstrated by the "plugin subcommand finds correct command in own plugin" test case, not setting `_GO_SCRIPTS_DIR` correctly for a plugin could've caused serious bugs:

- showstopper (best case): no other command script of that name exists outside the plugin
- obscure (medium case): finding the wrong script could cause confusing error messages when the interface between the caller and callee don't match
- subtle (worst case): finding the wrong version of a script could exhibit confusing behaviors that might only become apparent after-the-fact

In the process of writing these tests, I made some other improvements along the way which are well-documented in the commit messages. At a high level:

- Command scripts are invoked correctly even when `/plugins/` appears in `_GO_ROOTDIR`, in `_GO_SCRIPTS_DIR`, in the command script path relative to `_GO_SCRIPTS_DIR`, or in one or more combined. While such cases would be pathological, it was easy to handle them.
- `./go commands` no longer insists there be no duplicate script names, in light of `_GO_SEARCH_PATHS` and the role it plays in the plugin model.
- `fail_if line_*` now prints the full output on error, just as if the corresponding `assert_line_*` function failed.
- Added the new `test_break_after_num_iterations` function to `lib/bats/helpers`, and hit yet another obscure Bash bug in the process (Bash <4.4 doesn't set the `BASH_SOURCE` entry for the `main` script.