### PR TITLE
Add parent-recursive plugin module search

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -92,6 +92,14 @@ declare -r -x _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
 # See `./go vars` and `./go help vars`.
 declare _GO_IMPORTED_MODULES=()
 
+# Tracks the locations of files corresponding to _GO_IMPORTED_MODULES
+# Used for to detect and warn about plugin module namespace collisions.
+declare _GO_IMPORTED_MODULE_FILES=()
+
+# Tracks where each module _GO_IMPORTED_MODULES was first imported
+# Used in the plugin module namespace collision warning message.
+declare _GO_IMPORTED_MODULE_CALLERS=()
+
 # Path to the project's script directory
 declare _GO_SCRIPTS_DIR=
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -93,7 +93,7 @@ declare -r -x _GO_USE_MODULES="$_GO_CORE_DIR/lib/internal/use"
 declare _GO_IMPORTED_MODULES=()
 
 # Tracks the locations of files corresponding to _GO_IMPORTED_MODULES
-# Used for to detect and warn about plugin module namespace collisions.
+# Used to detect and warn about plugin module namespace collisions.
 declare _GO_IMPORTED_MODULE_FILES=()
 
 # Tracks where each module _GO_IMPORTED_MODULES was first imported

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -76,25 +76,54 @@
 declare __go_module_name
 declare __go_module_file
 declare __go_loaded_module
+declare __go_loaded_file
+declare __go_module_index
+declare __go_use_caller
+declare __go_use_prev_caller
+
+# Wrapper function necessary due to BASH_SOURCE and FUNCNAME bug in Bash <4.3.
+_@go.set_use_caller() {
+  __go_use_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
+}
+
+_@go.find_plugin_module_impl() {
+  [[ -f "$1/$__go_module_file" ]] && __go_module_file="$1/$__go_module_file"
+}
+
+_@go.find_plugin_module() {
+  # If a script imports a plugin module, and that module (`__go_use_caller`)
+  # tries to import another module from the same plugin, this block will adjust
+  # the search parameters accordingly.
+  if [[ "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
+    local _GO_SCRIPTS_DIR="${__go_use_caller%/lib/*}/bin"
+
+    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
+    if [[ -f "$__go_module_file" ]]; then
+      return
+    fi
+    __go_module_file="${__go_module_file%/bin/*}/lib/$__go_module_name"
+    if [[ -f "$__go_module_file" ]]; then
+      return
+    fi
+  fi
+
+  # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
+  __go_module_file="${__go_module_name/\///lib/}"
+  @go.search_plugins '_@go.find_plugin_module_impl'
+}
 
 for __go_module_name in "$@"; do
-  for __go_loaded_module in "${_GO_IMPORTED_MODULES[@]}"; do
-    if [[ "$__go_module_name" == "$__go_loaded_module" ]]; then
-      continue 2
-    fi
-  done
-
-  # Prevent self- and circular importing by registering name before sourcing.
-  _GO_IMPORTED_MODULES+=("$__go_module_name")
-  __go_module_file=''
+  # Since every import is in the same scope, setting the caller each time is
+  # necessary in case any imported modules import other modules.
+  _@go.set_use_caller
+  __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
 
   if [[ -n "$_GO_INJECT_MODULE_PATH" ]]; then
     __go_module_file="$_GO_INJECT_MODULE_PATH/$__go_module_name"
     if [[ ! -f "$__go_module_file" ]]; then
-      __go_module_file=''
+      __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
     fi
   fi
-  __go_module_file="${__go_module_file:-$_GO_CORE_DIR/lib/$__go_module_name}"
 
   if [[ ! -f "$__go_module_file" ]]; then
     __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
@@ -102,18 +131,51 @@ for __go_module_name in "$@"; do
     if [[ ! -f "$__go_module_file" ]]; then
       __go_module_file="$_GO_ROOTDIR/lib/$__go_module_name"
 
-      if [[ ! -f "$__go_module_file" ]]; then
-        # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
-        __go_module_file="$_GO_SCRIPTS_DIR/plugins/${__go_module_name/\///lib/}"
-
-        if [[ ! -f "$__go_module_file" ]]; then
-          @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
-          @go.print_stack_trace 1 >&2
-          exit 1
-        fi
+      if [[ ! -f "$__go_module_file" ]] && ! _@go.find_plugin_module; then
+        @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
+        @go.print_stack_trace 1 >&2
+        exit 1
       fi
     fi
   fi
+
+  # If we found the module in our project, but we're installed as a plugin,
+  # change the loaded module name to reflect that.
+  #
+  # Using `##` to trim the string instead of `#` flattens the module name
+  # namespace. We could use `#` to keep it hierarchical, but since the Bash
+  # namespace itself is flat, this might lead to hard-to-debug collisions if
+  # functions and variables get redefined. Keeping a flat module name namespace
+  # allows us to detect such potential collisions and issue a warning below.
+  if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
+    __go_module_name="${__go_module_file##*/plugins/}"
+    __go_module_name="${__go_module_name/\/bin\///}"
+    __go_module_name="${__go_module_name/\/lib\///}"
+  fi
+
+  __go_module_index=0
+  for __go_loaded_module in "${_GO_IMPORTED_MODULES[@]}"; do
+    if [[ "$__go_module_name" == "$__go_loaded_module" ]]; then
+      __go_loaded_file="${_GO_IMPORTED_MODULE_FILES[$__go_module_index]}"
+      __go_use_prev_caller="${_GO_IMPORTED_MODULE_CALLERS[$__go_module_index]}"
+
+      # This may happen if a plugin appears more than once in a project tree.
+      if [[ "$__go_module_file" != "$__go_loaded_file" ]]; then
+        @go.printf '%s\n' "WARNING: Module: $__go_module_name" \
+          "imported at: $__go_use_caller" \
+          "from file: $__go_module_file" \
+          "previously imported at: $__go_use_prev_caller" \
+          "from file: $__go_loaded_file" >&2
+      fi
+      continue 2
+    fi
+    ((++__go_module_index))
+  done
+
+  # Prevent self- and circular importing by registering info before sourcing.
+  _GO_IMPORTED_MODULES+=("$__go_module_name")
+  _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
+  _GO_IMPORTED_MODULE_CALLERS+=("$__go_use_caller")
 
   if ! . "$__go_module_file"; then
     @go.printf 'ERROR: Failed to import %s module from %s at:\n' \
@@ -123,6 +185,10 @@ for __go_module_name in "$@"; do
   fi
 done
 
+unset __go_use_prev_caller
+unset __go_use_caller
+unset __go_module_index
+unset __go_loaded_file
 unset __go_loaded_module
 unset __go_module_file
 unset __go_module_name

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -86,30 +86,30 @@ _@go.set_use_caller() {
   __go_use_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
 }
 
-_@go.find_plugin_module_impl() {
+_@go.find_plugin_module() {
   [[ -f "$1/$__go_module_file" ]] && __go_module_file="$1/$__go_module_file"
 }
 
-_@go.find_plugin_module() {
+_@go.find_module() {
   # If a script imports a plugin module, and that module (`__go_use_caller`)
   # tries to import another module from the same plugin, this block will adjust
   # the search parameters accordingly.
-  if [[ "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
+  if [[ -n "$_GO_PLUGINS_DIR" &&
+        "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
     local _GO_SCRIPTS_DIR="${__go_use_caller%/lib/*}/bin"
+    local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
+  fi
+  __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
 
-    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
-    if [[ -f "$__go_module_file" ]]; then
-      return
-    fi
-    __go_module_file="${__go_module_file%/bin/*}/lib/$__go_module_name"
-    if [[ -f "$__go_module_file" ]]; then
-      return
+  if [[ ! -f "$__go_module_file" ]]; then
+    __go_module_file="$_GO_ROOTDIR/lib/$__go_module_name"
+
+    if [[ ! -f "$__go_module_file" ]]; then
+      # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
+      __go_module_file="${__go_module_name/\///lib/}"
+      @go.search_plugins '_@go.find_plugin_module'
     fi
   fi
-
-  # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
-  __go_module_file="${__go_module_name/\///lib/}"
-  @go.search_plugins '_@go.find_plugin_module_impl'
 }
 
 for __go_module_name in "$@"; do
@@ -125,18 +125,10 @@ for __go_module_name in "$@"; do
     fi
   fi
 
-  if [[ ! -f "$__go_module_file" ]]; then
-    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
-
-    if [[ ! -f "$__go_module_file" ]]; then
-      __go_module_file="$_GO_ROOTDIR/lib/$__go_module_name"
-
-      if [[ ! -f "$__go_module_file" ]] && ! _@go.find_plugin_module; then
-        @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
-        @go.print_stack_trace 1 >&2
-        exit 1
-      fi
-    fi
+  if [[ ! -f "$__go_module_file" ]] && ! _@go.find_module; then
+    @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
+    @go.print_stack_trace 1 >&2
+    exit 1
   fi
 
   # If we found the module in our project, but we're installed as a plugin,

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -147,7 +147,8 @@ for __go_module_name in "$@"; do
   # namespace itself is flat, this might lead to hard-to-debug collisions if
   # functions and variables get redefined. Keeping a flat module name namespace
   # allows us to detect such potential collisions and issue a warning below.
-  if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
+  if [[ -n "$_GO_PLUGINS_DIR" &&
+        "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
     __go_module_name="${__go_module_file##*/plugins/}"
     __go_module_name="${__go_module_name/\/bin\///}"
     __go_module_name="${__go_module_name/\/lib\///}"

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -10,6 +10,7 @@ FIRST_CORE_MOD_SUMMARY=
 LAST_CORE_MOD_SUMMARY=
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
   setup_test_modules
 
@@ -78,8 +79,7 @@ get_first_and_last_core_module_summaries() {
   )
 
   run "$TEST_GO_SCRIPT" modules --imported
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list by class, all modules" {
@@ -94,8 +94,7 @@ get_first_and_last_core_module_summaries() {
   )
 
   run "$TEST_GO_SCRIPT" modules
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list using glob, all modules" {
@@ -105,8 +104,7 @@ get_first_and_last_core_module_summaries() {
   )
 
   run "$TEST_GO_SCRIPT" modules '*'
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list by class, only core modules present" {
@@ -117,16 +115,14 @@ get_first_and_last_core_module_summaries() {
   rm "${TEST_PLUGIN_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}" \
     "${TEST_PROJECT_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}"
   run "$TEST_GO_SCRIPT" modules
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list using glob, only core modules present" {
   rm "${TEST_PLUGIN_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}" \
     "${TEST_PROJECT_MODULES_PATHS[@]/#/$TEST_GO_ROOTDIR/}"
   run "$TEST_GO_SCRIPT" modules '*'
-  local IFS=$'\n'
-  assert_success "${CORE_MODULES[*]}"
+  assert_success "${CORE_MODULES[@]}"
 }
 
 @test "$SUITE: paths by class" {
@@ -224,21 +220,18 @@ get_first_and_last_core_module_summaries() {
 
 @test "$SUITE: list only test modules" {
   run "$TEST_GO_SCRIPT" modules '_*'
-  local IFS=$'\n'
-  assert_success "${TEST_PLUGIN_MODULES[*]}"$'\n'"${TEST_PROJECT_MODULES[*]}"
+  assert_success "${TEST_PLUGIN_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}"
 }
 
 @test "$SUITE: list only test project modules" {
   run "$TEST_GO_SCRIPT" modules '_fr*'
-  local IFS=$'\n'
-  assert_success "${TEST_PROJECT_MODULES[*]}"
+  assert_success "${TEST_PROJECT_MODULES[@]}"
 }
 
 @test "$SUITE: list only modules in the _bar and _baz plugins" {
   run "$TEST_GO_SCRIPT" modules '_ba*/_*u*'
   local expected=('_bar/_plugh' '_bar/_quux' '_baz/_plugh' '_baz/_quux')
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }
 
 @test "$SUITE: list test modules using multiple globs" {
@@ -253,6 +246,5 @@ get_first_and_last_core_module_summaries() {
     '_bar/_quux'
     '_bar/_xyzzy'
   )
-  local IFS=$'\n'
-  assert_success "${expected[*]}"
+  assert_success "${expected[@]}"
 }

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -19,6 +19,8 @@ EXPECTED=(
 )
 
 setup() {
+  test_filter
+
   local core_test_module
   for core_test_module in 'builtin-test' 'go-use-modules-test'; do
     if [[ -e "$_GO_CORE_DIR/lib/$core_test_module" ]]; then
@@ -59,20 +61,17 @@ teardown() {
 
   local expected=('ERROR: Module bogus-test-module not found at:'
     "  $TEST_GO_SCRIPT:3 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: import modules successfully" {
   run "$TEST_GO_SCRIPT" "${IMPORTS[@]}"
-  local IFS=$'\n'
-  assert_success "${EXPECTED[*]}"
+  assert_success "${EXPECTED[@]}"
 }
 
 @test "$SUITE: import each module only once" {
   run "$TEST_GO_SCRIPT" "${IMPORTS[@]}" "${IMPORTS[@]}" "${IMPORTS[@]}"
-  local IFS=$'\n'
-  assert_success "${EXPECTED[*]}"
+  assert_success "${EXPECTED[@]}"
 }
 
 @test "$SUITE: prevent self, circular, and multiple importing" {
@@ -83,8 +82,7 @@ teardown() {
   done
 
   run "$TEST_GO_SCRIPT" "${IMPORTS[@]}"
-  local IFS=$'\n'
-  assert_success "${EXPECTED[*]}"
+  assert_success "${EXPECTED[@]}"
 }
 
 @test "$SUITE: error if module contains errors" {
@@ -99,8 +97,7 @@ teardown() {
     "$module_file: line 1: This: command not found"
     "ERROR: Failed to import $module module from $module_file at:"
     "  $TEST_GO_SCRIPT:3 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: error if module returns an error" {
@@ -117,8 +114,7 @@ teardown() {
     "$error_message"
     "ERROR: Failed to import $module module from $module_file at:"
     "  $TEST_GO_SCRIPT:3 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: import order: injected; core; internal; exported; plugin" {

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -83,6 +83,13 @@ teardown() {
   assert_success ''
 }
 
+@test "$SUITE: import builtin module" {
+  run "$TEST_GO_SCRIPT" 'complete'
+  assert_success 'module: complete' \
+    "source: $_GO_CORE_DIR/lib/complete" \
+    "caller: $TEST_GO_SCRIPT:3 main"
+}
+
 @test "$SUITE: error if nonexistent module specified" {
   run "$TEST_GO_SCRIPT" 'bogus-test-module'
 

--- a/tests/modules/use/plugins.bats
+++ b/tests/modules/use/plugins.bats
@@ -1,0 +1,181 @@
+#! /usr/bin/env bats
+
+load ../../environment
+
+PRINT_SOURCE='printf -- "%s\n" "$BASH_SOURCE"'
+
+setup() {
+  test_filter
+  @go.create_test_go_script '@go "$@"' \
+    'printf "%s\n" "${_GO_IMPORTED_MODULES[@]}"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: plugin imports own internal module" {
+  local module_path='foo/bin/lib/foo'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" foo'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo'
+}
+
+@test "$SUITE: plugin imports own exported module" {
+  local module_path='foo/lib/foo'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" foo'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo'
+}
+
+@test "$SUITE: plugin imports module from own plugin" {
+  local module_path='foo/bin/plugins/bar/lib/bar'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar'
+}
+
+@test "$SUITE: plugin imports module from other plugin in _GO_PLUGINS_DIR" {
+  local module_path='bar/lib/bar'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar'
+}
+
+@test "$SUITE: nested plugin imports own internal module" {
+  local module_path='foo/bin/plugins/bar/bin/lib/bar-2'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" bar-2'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
+}
+
+
+@test "$SUITE: nested plugin imports own exported module" {
+  local module_path='foo/bin/plugins/bar/lib/bar-2'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" bar-2'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
+}
+
+@test "$SUITE: nested plugin imports module from own plugin" {
+  local module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" baz/baz'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+}
+
+@test "$SUITE: nested plugin imports module from parent plugin" {
+  local module_path='foo/lib/foo'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" foo/foo'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'foo/foo'
+}
+
+@test "$SUITE: nested plugin imports module from _GO_PLUGINS_DIR" {
+  local module_path='baz/lib/baz'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" baz/baz'
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+}
+
+@test "$SUITE: nested plugin imports own module before _GO_PLUGINS_DIR copy" {
+  local module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" baz/baz'
+  @go.create_test_command_script 'plugins/baz/lib/baz' "$PRINT_SOURCE"
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+}
+
+@test "$SUITE: module collision produces warning message, top level first" {
+  local top_module_path='baz/lib/baz'
+  local nested_module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
+
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" baz/baz'
+  @go.create_test_command_script "plugins/$top_module_path" "$PRINT_SOURCE"
+  @go.create_test_command_script "plugins/$nested_module_path" "$PRINT_SOURCE"
+
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" baz/baz bar/bar'
+  run "$TEST_GO_SCRIPT" 'foo'
+
+  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/bin/foo:2"
+  local nested_importer="$TEST_GO_PLUGINS_DIR/foo/bin/plugins/bar/lib/bar:2"
+  assert_success
+  assert_lines_equal "$TEST_GO_PLUGINS_DIR/$top_module_path" \
+    'WARNING: Module: baz/baz' \
+    "imported at: $nested_importer source" \
+    "from file: $TEST_GO_PLUGINS_DIR/$nested_module_path" \
+    "previously imported at: $parent_importer source" \
+    "from file: $TEST_GO_PLUGINS_DIR/$top_module_path" \
+    'baz/baz' \
+    'bar/bar'
+}
+
+@test "$SUITE: module collision produces warning message, nested level first" {
+  local top_module_path='baz/lib/baz'
+  local nested_module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
+
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" baz/baz'
+  @go.create_test_command_script "plugins/$top_module_path" "$PRINT_SOURCE"
+  @go.create_test_command_script "plugins/$nested_module_path" "$PRINT_SOURCE"
+
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar baz/baz'
+  run "$TEST_GO_SCRIPT" 'foo'
+
+  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/bin/foo:2"
+  local nested_importer="$TEST_GO_PLUGINS_DIR/foo/bin/plugins/bar/lib/bar:2"
+  assert_success
+  assert_lines_equal "$TEST_GO_PLUGINS_DIR/$nested_module_path" \
+    'WARNING: Module: baz/baz' \
+    "imported at: $parent_importer source" \
+    "from file: $TEST_GO_PLUGINS_DIR/$top_module_path" \
+    "previously imported at: $nested_importer source" \
+    "from file: $TEST_GO_PLUGINS_DIR/$nested_module_path" \
+    'bar/bar' \
+    'baz/baz'
+}

--- a/tests/modules/use/plugins.bats
+++ b/tests/modules/use/plugins.bats
@@ -66,7 +66,6 @@ teardown() {
   assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
 }
 
-
 @test "$SUITE: nested plugin imports own exported module" {
   local module_path='foo/bin/plugins/bar/lib/bar-2'
   @go.create_test_command_script 'plugins/foo/bin/foo' \
@@ -89,6 +88,19 @@ teardown() {
 
   run "$TEST_GO_SCRIPT" 'foo'
   assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+}
+
+@test "$SUITE: nested plugin imports own module instead of parent module" {
+  local module_path='foo/bin/plugins/bar/lib/bar-2'
+  @go.create_test_command_script 'plugins/foo/bin/foo' \
+    '. "$_GO_USE_MODULES" bar/bar'
+  @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
+    '. "$_GO_USE_MODULES" bar-2'
+  @go.create_test_command_script "plugins/foo/lib/bar-2" "$PRINT_SOURCE"
+  @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
 }
 
 @test "$SUITE: nested plugin imports module from parent plugin" {

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -44,6 +44,8 @@ quotify_expected() {
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
     "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
     'declare -a _GO_IMPORTED_MODULES=()'
+    'declare -a _GO_IMPORTED_MODULE_CALLERS=()'
+    'declare -a _GO_IMPORTED_MODULE_FILES=()'
     'declare -- _GO_INJECT_MODULE_PATH=""'
     'declare -- _GO_INJECT_SEARCH_PATH=""'
     "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""
@@ -92,8 +94,14 @@ quotify_expected() {
     "[5]=\"$TEST_GO_PLUGINS_DIR/plugin2/bin\"")
 
   # Note that the `format` module imports `strings` and `validation`.
+  local command_script_trace="$TEST_GO_SCRIPTS_DIR/"
+  command_script_trace+="test-command.d/test-subcommand:2 source"
   local expected_modules=('[0]="module_0"'
     '[1]="module_1"')
+  local expected_module_callers=("[0]=\"$command_script_trace\""
+    "[1]=\"$command_script_trace\"")
+  local expected_module_files=("[0]=\"$TEST_GO_ROOTDIR/lib/module_0\""
+    "[1]=\"$TEST_GO_ROOTDIR/lib/module_1\"")
   local expected=("declare -x _GO_BATS_COVERAGE_DIR=\"$_GO_BATS_COVERAGE_DIR\""
     "declare -x _GO_BATS_DIR=\"$_GO_BATS_DIR\""
     "declare -x _GO_BATS_PATH=\"$_GO_BATS_PATH\""
@@ -108,6 +116,8 @@ quotify_expected() {
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
     "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
     "declare -a _GO_IMPORTED_MODULES=(${expected_modules[*]})"
+    "declare -a _GO_IMPORTED_MODULE_CALLERS=(${expected_module_callers[*]})"
+    "declare -a _GO_IMPORTED_MODULE_FILES=(${expected_module_files[*]})"
     "declare -x _GO_INJECT_MODULE_PATH=\"$TEST_GO_ROOTDIR/lib\""
     "declare -x _GO_INJECT_SEARCH_PATH=\"$TEST_GO_ROOTDIR/bin\""
     "declare -x _GO_KCOV_DIR=\"$_GO_KCOV_DIR\""


### PR DESCRIPTION
Part of #120, built upon `@go.search_plugins`. This implements semantics similar to npm's `node_modules` for library modules.

Since Bash's flat namespace creates the potential for function redefinitions, a warning is emitted when a module collision occurs. The hope is that this will encourage good compatibility practices via semantic versioning, ultimately reducing the need for nested plugin module checkouts due to version incompatibilities.

Since command scripts should define their own functions using a project-specific namespace that prevents them from being treated as exported units when sourced by a parent script (especially those exported as plugins), command script namespace collisions should be less of a concern.

Also includes some touch-ups to other test files along the way.