### PR TITLE
Implement correct scope for executing `@go` commands in plugin modules

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -248,9 +248,6 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
 @go.search_plugins() {
   local __gsp_plugins_dir="$_GO_SCRIPTS_DIR/plugins"
 
-  # Set `_GO_PLUGINS_DIR` if called from a top-level `./go` script before `@go`.
-  _GO_PLUGINS_DIR="${_GO_PLUGINS_DIR:-$_GO_SCRIPTS_DIR/plugins}"
-
   while true; do
     if "$1" "$__gsp_plugins_dir"; then
       return
@@ -412,3 +409,4 @@ elif [[ -z "$COLUMNS" ]]; then
   fi
   export COLUMNS="${COLUMNS:-80}"
 fi
+_GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"

--- a/lib/bats-main
+++ b/lib/bats-main
@@ -77,7 +77,7 @@ export _GO_COVERALLS_URL="${_GO_COVERALLS_URL}"
 
 # Collect coverage on Travis. Doesn't seem to slow anything down substantially.
 if [[ -n "$_GO_COVERALLS_URL" && "$TRAVIS_OS_NAME" == 'linux' ]]; then
-  declare _GO_COLLECT_BATS_COVERAGE='true'
+  _GO_COLLECT_BATS_COVERAGE='true'
 fi
 
 # Array of `./go glob` arguments to select Bats test files in `_GO_TEST_DIR`

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -30,7 +30,6 @@ _@go.set_search_paths() {
 }
 
 if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
-  _GO_PLUGINS_DIR="$_GO_SCRIPTS_DIR/plugins"
   _@go.set_search_paths
 fi
 

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -1,37 +1,6 @@
 #! /bin/bash
 
-_@go.set_search_paths_add_plugin_paths() {
-  local plugin_paths=("$1"/*/bin)
-  if [[ "${plugin_paths[0]}" != "$1/*/bin" ]]; then
-    _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")
-  fi
-  return 1
-}
-
-_@go.set_search_paths() {
-  local plugin_path
-
-  if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
-    _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
-  fi
-  _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
-
-  # A plugin's own local plugin paths will appear before inherited ones. If
-  # there is a version incompatibility issue with other installed plugins, this
-  # allows a plugin's preferred version to take precedence.
-  @go.search_plugins '_@go.set_search_paths_add_plugin_paths'
-
-  # Ensure a plugin's _GO_SCRIPTS_DIR isn't duplicated in _GO_SEARCH_PATHS.
-  for plugin_path in "${_GO_PLUGINS_PATHS[@]}"; do
-    if [[ "$plugin_path" != "$_GO_SCRIPTS_DIR" ]]; then
-      _GO_SEARCH_PATHS+=("$plugin_path")
-    fi
-  done
-}
-
-if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
-  _@go.set_search_paths
-fi
+. "$_GO_CORE_DIR/lib/internal/set-search-paths"
 
 _@go.list_available_commands() {
   . "$_GO_CORE_DIR/lib/internal/commands"

--- a/lib/internal/set-search-paths
+++ b/lib/internal/set-search-paths
@@ -2,8 +2,15 @@
 
 _@go.set_search_paths_add_plugin_paths() {
   local plugin_paths=("$1"/*/bin)
+  local plugin_path
+
   if [[ "${plugin_paths[0]}" != "$1/*/bin" ]]; then
-    _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")
+    # Ensure a plugin's _GO_SCRIPTS_DIR isn't duplicated in _GO_PLUGINS_PATHS.
+    for plugin_path in "${plugin_paths[@]}"; do
+      if [[ "$plugin_path" != "$_GO_SCRIPTS_DIR" ]]; then
+        _GO_PLUGINS_PATHS+=("$plugin_path")
+      fi
+    done
   fi
   return 1
 }
@@ -20,13 +27,7 @@ _@go.set_search_paths() {
   # there is a version incompatibility issue with other installed plugins, this
   # allows a plugin's preferred version to take precedence.
   @go.search_plugins '_@go.set_search_paths_add_plugin_paths'
-
-  # Ensure a plugin's _GO_SCRIPTS_DIR isn't duplicated in _GO_SEARCH_PATHS.
-  for plugin_path in "${_GO_PLUGINS_PATHS[@]}"; do
-    if [[ "$plugin_path" != "$_GO_SCRIPTS_DIR" ]]; then
-      _GO_SEARCH_PATHS+=("$plugin_path")
-    fi
-  done
+  _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}")
 }
 
 if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then

--- a/lib/internal/set-search-paths
+++ b/lib/internal/set-search-paths
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+_@go.set_search_paths_add_plugin_paths() {
+  local plugin_paths=("$1"/*/bin)
+  if [[ "${plugin_paths[0]}" != "$1/*/bin" ]]; then
+    _GO_PLUGINS_PATHS+=("${plugin_paths[@]}")
+  fi
+  return 1
+}
+
+_@go.set_search_paths() {
+  local plugin_path
+
+  if [[ -n "$_GO_INJECT_SEARCH_PATH" ]]; then
+    _GO_SEARCH_PATHS+=("$_GO_INJECT_SEARCH_PATH")
+  fi
+  _GO_SEARCH_PATHS+=("$_GO_CORE_DIR/libexec" "$_GO_SCRIPTS_DIR")
+
+  # A plugin's own local plugin paths will appear before inherited ones. If
+  # there is a version incompatibility issue with other installed plugins, this
+  # allows a plugin's preferred version to take precedence.
+  @go.search_plugins '_@go.set_search_paths_add_plugin_paths'
+
+  # Ensure a plugin's _GO_SCRIPTS_DIR isn't duplicated in _GO_SEARCH_PATHS.
+  for plugin_path in "${_GO_PLUGINS_PATHS[@]}"; do
+    if [[ "$plugin_path" != "$_GO_SCRIPTS_DIR" ]]; then
+      _GO_SEARCH_PATHS+=("$plugin_path")
+    fi
+  done
+}
+
+if [[ "${#_GO_SEARCH_PATHS[@]}" -eq 0 ]]; then
+  _@go.set_search_paths
+fi

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -78,13 +78,6 @@ _@go.find_plugin_module() {
 }
 
 _@go.find_module() {
-  # If a script imports a plugin module, and that module (`__go_use_caller`)
-  # tries to import another module from the same plugin, this block will adjust
-  # the search parameters accordingly.
-  if [[ "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
-    local _GO_SCRIPTS_DIR="${__go_use_caller%/lib/*}/bin"
-    local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
-  fi
   __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
 
   if [[ ! -f "$__go_module_file" ]]; then
@@ -104,8 +97,16 @@ _@go.use_modules() {
   local loaded_module
   local loaded_file
   local module_index
-  local __go_use_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
+  local current_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
   local prev_caller
+
+  # If a script imports a plugin module, and that module (`current_caller`)
+  # tries to import another module from the same plugin, this block will adjust
+  # the search parameters accordingly.
+  if [[ "$current_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
+    local _GO_SCRIPTS_DIR="${current_caller%/lib/*}/bin"
+    local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
+  fi
 
   for __go_module_name in "$@"; do
     __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
@@ -132,7 +133,7 @@ _@go.use_modules() {
     # functions and variables get redefined. Keeping a flat module name
     # namespace allows us to detect such potential collisions and issue a
     # warning below.
-    if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
+    if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR/ ]]; then
       __go_module_name="${__go_module_file##*/plugins/}"
       __go_module_name="${__go_module_name/\/bin\///}"
       __go_module_name="${__go_module_name/\/lib\///}"
@@ -147,7 +148,7 @@ _@go.use_modules() {
         # This may happen if a plugin appears more than once in a project tree.
         if [[ "$__go_module_file" != "$loaded_file" ]]; then
           @go.printf '%s\n' "WARNING: Module: $__go_module_name" \
-            "imported at: $__go_use_caller" \
+            "imported at: $current_caller" \
             "from file: $__go_module_file" \
             "previously imported at: $prev_caller" \
             "from file: $loaded_file" >&2
@@ -160,7 +161,7 @@ _@go.use_modules() {
     # Prevent self- and circular importing by registering info before sourcing.
     _GO_IMPORTED_MODULES+=("$__go_module_name")
     _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
-    _GO_IMPORTED_MODULE_CALLERS+=("$__go_use_caller")
+    _GO_IMPORTED_MODULE_CALLERS+=("$current_caller")
 
     if ! . "$__go_module_file"; then
       @go.printf 'ERROR: Failed to import %s module from %s at:\n' \

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -78,15 +78,25 @@ _@go.find_plugin_module() {
 }
 
 _@go.find_module() {
-  __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
+  if [[ -n "$_GO_INJECT_MODULE_PATH" ]]; then
+    __go_module_file="$_GO_INJECT_MODULE_PATH/$__go_module_name"
+    if [[ -f "$__go_module_file" ]]; then
+      return
+    fi
+  fi
+  __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
 
   if [[ ! -f "$__go_module_file" ]]; then
-    __go_module_file="$_GO_ROOTDIR/lib/$__go_module_name"
+    __go_module_file="$_GO_SCRIPTS_DIR/lib/$__go_module_name"
 
     if [[ ! -f "$__go_module_file" ]]; then
-      # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
-      __go_module_file="${__go_module_name/\///lib/}"
-      @go.search_plugins '_@go.find_plugin_module'
+      __go_module_file="$_GO_ROOTDIR/lib/$__go_module_name"
+
+      if [[ ! -f "$__go_module_file" ]]; then
+        # Convert <plugin>/<module> to plugins/<plugin>/lib/<module>
+        __go_module_file="${__go_module_name/\///lib/}"
+        @go.search_plugins '_@go.find_plugin_module'
+      fi
     fi
   fi
 }
@@ -109,16 +119,7 @@ _@go.use_modules() {
   fi
 
   for __go_module_name in "$@"; do
-    __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
-
-    if [[ -n "$_GO_INJECT_MODULE_PATH" ]]; then
-      __go_module_file="$_GO_INJECT_MODULE_PATH/$__go_module_name"
-      if [[ ! -f "$__go_module_file" ]]; then
-        __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
-      fi
-    fi
-
-    if [[ ! -f "$__go_module_file" ]] && ! _@go.find_module; then
+    if ! _@go.find_module; then
       @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
       @go.print_stack_trace 1 >&2
       exit 1

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -94,8 +94,7 @@ _@go.find_module() {
   # If a script imports a plugin module, and that module (`__go_use_caller`)
   # tries to import another module from the same plugin, this block will adjust
   # the search parameters accordingly.
-  if [[ -n "$_GO_PLUGINS_DIR" &&
-        "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
+  if [[ "$__go_use_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
     local _GO_SCRIPTS_DIR="${__go_use_caller%/lib/*}/bin"
     local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
   fi
@@ -139,8 +138,7 @@ for __go_module_name in "$@"; do
   # namespace itself is flat, this might lead to hard-to-debug collisions if
   # functions and variables get redefined. Keeping a flat module name namespace
   # allows us to detect such potential collisions and issue a warning below.
-  if [[ -n "$_GO_PLUGINS_DIR" &&
-        "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
+  if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
     __go_module_name="${__go_module_file##*/plugins/}"
     __go_module_name="${__go_module_name/\/bin\///}"
     __go_module_name="${__go_module_name/\/lib\///}"

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -101,6 +101,21 @@ _@go.find_module() {
   fi
 }
 
+_@go.import_module() {
+  if [[ "${__go_module_file#$_GO_SCRIPTS_DIR}" =~ /plugins/[^/]+/lib/ ]]; then
+    local _GO_SCRIPTS_DIR="${__go_module_file%/lib/*}/bin"
+    local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
+    local _GO_PLUGINS_PATHS=()
+    local _GO_SEARCH_PATHS=()
+  fi
+
+  # Prevent self- and circular importing by registering info before sourcing.
+  _GO_IMPORTED_MODULES+=("$__go_module_name")
+  _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
+  _GO_IMPORTED_MODULE_CALLERS+=("$current_caller")
+  . "$__go_module_file"
+}
+
 _@go.use_modules() {
   local __go_module_name
   local __go_module_file
@@ -109,14 +124,6 @@ _@go.use_modules() {
   local module_index
   local current_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
   local prev_caller
-
-  # If a script imports a plugin module, and that module (`current_caller`)
-  # tries to import another module from the same plugin, this block will adjust
-  # the search parameters accordingly.
-  if [[ "$current_caller" =~ ^$_GO_PLUGINS_DIR/.*/lib/ ]]; then
-    local _GO_SCRIPTS_DIR="${current_caller%/lib/*}/bin"
-    local _GO_ROOTDIR="${_GO_SCRIPTS_DIR%/bin}"
-  fi
 
   for __go_module_name in "$@"; do
     if ! _@go.find_module; then
@@ -159,12 +166,7 @@ _@go.use_modules() {
       ((++module_index))
     done
 
-    # Prevent self- and circular importing by registering info before sourcing.
-    _GO_IMPORTED_MODULES+=("$__go_module_name")
-    _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
-    _GO_IMPORTED_MODULE_CALLERS+=("$current_caller")
-
-    if ! . "$__go_module_file"; then
+    if ! _@go.import_module; then
       @go.printf 'ERROR: Failed to import %s module from %s at:\n' \
         "$__go_module_name" "$__go_module_file" >&2
       @go.print_stack_trace 1 >&2

--- a/lib/internal/use
+++ b/lib/internal/use
@@ -73,19 +73,6 @@
 #   for modules imported within a Bash command script or function:
 #   @go modules --imported
 
-declare __go_module_name
-declare __go_module_file
-declare __go_loaded_module
-declare __go_loaded_file
-declare __go_module_index
-declare __go_use_caller
-declare __go_use_prev_caller
-
-# Wrapper function necessary due to BASH_SOURCE and FUNCNAME bug in Bash <4.3.
-_@go.set_use_caller() {
-  __go_use_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
-}
-
 _@go.find_plugin_module() {
   [[ -f "$1/$__go_module_file" ]] && __go_module_file="$1/$__go_module_file"
 }
@@ -111,75 +98,77 @@ _@go.find_module() {
   fi
 }
 
-for __go_module_name in "$@"; do
-  # Since every import is in the same scope, setting the caller each time is
-  # necessary in case any imported modules import other modules.
-  _@go.set_use_caller
-  __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
+_@go.use_modules() {
+  local __go_module_name
+  local __go_module_file
+  local loaded_module
+  local loaded_file
+  local module_index
+  local __go_use_caller="${BASH_SOURCE[2]}:${BASH_LINENO[1]} ${FUNCNAME[2]}"
+  local prev_caller
 
-  if [[ -n "$_GO_INJECT_MODULE_PATH" ]]; then
-    __go_module_file="$_GO_INJECT_MODULE_PATH/$__go_module_name"
-    if [[ ! -f "$__go_module_file" ]]; then
-      __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
-    fi
-  fi
+  for __go_module_name in "$@"; do
+    __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
 
-  if [[ ! -f "$__go_module_file" ]] && ! _@go.find_module; then
-    @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
-    @go.print_stack_trace 1 >&2
-    exit 1
-  fi
-
-  # If we found the module in our project, but we're installed as a plugin,
-  # change the loaded module name to reflect that.
-  #
-  # Using `##` to trim the string instead of `#` flattens the module name
-  # namespace. We could use `#` to keep it hierarchical, but since the Bash
-  # namespace itself is flat, this might lead to hard-to-debug collisions if
-  # functions and variables get redefined. Keeping a flat module name namespace
-  # allows us to detect such potential collisions and issue a warning below.
-  if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
-    __go_module_name="${__go_module_file##*/plugins/}"
-    __go_module_name="${__go_module_name/\/bin\///}"
-    __go_module_name="${__go_module_name/\/lib\///}"
-  fi
-
-  __go_module_index=0
-  for __go_loaded_module in "${_GO_IMPORTED_MODULES[@]}"; do
-    if [[ "$__go_module_name" == "$__go_loaded_module" ]]; then
-      __go_loaded_file="${_GO_IMPORTED_MODULE_FILES[$__go_module_index]}"
-      __go_use_prev_caller="${_GO_IMPORTED_MODULE_CALLERS[$__go_module_index]}"
-
-      # This may happen if a plugin appears more than once in a project tree.
-      if [[ "$__go_module_file" != "$__go_loaded_file" ]]; then
-        @go.printf '%s\n' "WARNING: Module: $__go_module_name" \
-          "imported at: $__go_use_caller" \
-          "from file: $__go_module_file" \
-          "previously imported at: $__go_use_prev_caller" \
-          "from file: $__go_loaded_file" >&2
+    if [[ -n "$_GO_INJECT_MODULE_PATH" ]]; then
+      __go_module_file="$_GO_INJECT_MODULE_PATH/$__go_module_name"
+      if [[ ! -f "$__go_module_file" ]]; then
+        __go_module_file="$_GO_CORE_DIR/lib/$__go_module_name"
       fi
-      continue 2
     fi
-    ((++__go_module_index))
+
+    if [[ ! -f "$__go_module_file" ]] && ! _@go.find_module; then
+      @go.printf 'ERROR: Module %s not found at:\n' "$__go_module_name" >&2
+      @go.print_stack_trace 1 >&2
+      exit 1
+    fi
+
+    # If we found the module in our project, but we're installed as a plugin,
+    # change the loaded module name to reflect that.
+    #
+    # Using `##` to trim the string instead of `#` flattens the module name
+    # namespace. We could use `#` to keep it hierarchical, but since the Bash
+    # namespace itself is flat, this might lead to hard-to-debug collisions if
+    # functions and variables get redefined. Keeping a flat module name
+    # namespace allows us to detect such potential collisions and issue a
+    # warning below.
+    if [[ "$__go_module_file" =~ ^$_GO_PLUGINS_DIR ]]; then
+      __go_module_name="${__go_module_file##*/plugins/}"
+      __go_module_name="${__go_module_name/\/bin\///}"
+      __go_module_name="${__go_module_name/\/lib\///}"
+    fi
+
+    module_index=0
+    for loaded_module in "${_GO_IMPORTED_MODULES[@]}"; do
+      if [[ "$__go_module_name" == "$loaded_module" ]]; then
+        loaded_file="${_GO_IMPORTED_MODULE_FILES[$module_index]}"
+        prev_caller="${_GO_IMPORTED_MODULE_CALLERS[$module_index]}"
+
+        # This may happen if a plugin appears more than once in a project tree.
+        if [[ "$__go_module_file" != "$loaded_file" ]]; then
+          @go.printf '%s\n' "WARNING: Module: $__go_module_name" \
+            "imported at: $__go_use_caller" \
+            "from file: $__go_module_file" \
+            "previously imported at: $prev_caller" \
+            "from file: $loaded_file" >&2
+        fi
+        continue 2
+      fi
+      ((++module_index))
+    done
+
+    # Prevent self- and circular importing by registering info before sourcing.
+    _GO_IMPORTED_MODULES+=("$__go_module_name")
+    _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
+    _GO_IMPORTED_MODULE_CALLERS+=("$__go_use_caller")
+
+    if ! . "$__go_module_file"; then
+      @go.printf 'ERROR: Failed to import %s module from %s at:\n' \
+        "$__go_module_name" "$__go_module_file" >&2
+      @go.print_stack_trace 1 >&2
+      exit 1
+    fi
   done
+}
 
-  # Prevent self- and circular importing by registering info before sourcing.
-  _GO_IMPORTED_MODULES+=("$__go_module_name")
-  _GO_IMPORTED_MODULE_FILES+=("$__go_module_file")
-  _GO_IMPORTED_MODULE_CALLERS+=("$__go_use_caller")
-
-  if ! . "$__go_module_file"; then
-    @go.printf 'ERROR: Failed to import %s module from %s at:\n' \
-      "$__go_module_name" "$__go_module_file" >&2
-    @go.print_stack_trace 1 >&2
-    exit 1
-  fi
-done
-
-unset __go_use_prev_caller
-unset __go_use_caller
-unset __go_module_index
-unset __go_loaded_file
-unset __go_loaded_module
-unset __go_module_file
-unset __go_module_name
+_@go.use_modules "$@"

--- a/lib/kcov-ubuntu
+++ b/lib/kcov-ubuntu
@@ -9,7 +9,7 @@
 # This may eventually be extracted into a plugin library of its own, which is
 # why its exported functions don't contain a `@go.` prefix.
 
-readonly __KCOV_DEV_PACKAGES=(
+__KCOV_DEV_PACKAGES=(
   'binutils-dev'
   'cmake'
   'libcurl4-openssl-dev'
@@ -18,6 +18,7 @@ readonly __KCOV_DEV_PACKAGES=(
   'libiberty-dev'
   'zlib1g-dev'
 )
+readonly __KCOV_DEV_PACKAGES
 readonly __KCOV_URL='https://github.com/SimonKagstrom/kcov'
 readonly __KCOV_VERSION='master'
 

--- a/tests/core/plugin-scope-variable-values.bats
+++ b/tests/core/plugin-scope-variable-values.bats
@@ -104,7 +104,6 @@ assert_scope_values_equal() {
     '_GO_SCRIPTS_DIR:' \
     "$TEST_GO_PLUGINS_DIR/first/bin" \
     '_GO_PLUGINS_PATHS:' \
-    "$TEST_GO_PLUGINS_DIR/first/bin" \
     "$TEST_GO_PLUGINS_DIR/second/bin" \
     '_GO_SEARCH_PATHS:' \
     "$_GO_CORE_DIR/libexec" \
@@ -131,7 +130,6 @@ assert_scope_values_equal() {
     '_GO_SCRIPTS_DIR:' \
     "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
     '_GO_PLUGINS_PATHS:' \
-    "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
     "$TEST_GO_PLUGINS_DIR/first/bin" \
     "$TEST_GO_PLUGINS_DIR/second/bin" \
     '_GO_SEARCH_PATHS:' \
@@ -151,7 +149,6 @@ assert_scope_values_equal() {
     '_GO_PLUGINS_PATHS:' \
     "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
     "$TEST_GO_PLUGINS_DIR/first/bin" \
-    "$TEST_GO_PLUGINS_DIR/second/bin" \
     '_GO_SEARCH_PATHS:' \
     "$_GO_CORE_DIR/libexec" \
     "$TEST_GO_PLUGINS_DIR/second/bin" \
@@ -173,7 +170,6 @@ assert_scope_values_equal() {
     '_GO_SCRIPTS_DIR:' \
     "$TEST_GO_PLUGINS_DIR/first/bin" \
     '_GO_PLUGINS_PATHS:' \
-    "$TEST_GO_PLUGINS_DIR/first/bin" \
     "$TEST_GO_PLUGINS_DIR/second/bin" \
     '_GO_SEARCH_PATHS:' \
     "$_GO_CORE_DIR/libexec" \
@@ -189,7 +185,6 @@ assert_scope_values_equal() {
     '_GO_PLUGINS_PATHS:' \
     "$TEST_GO_PLUGINS_DIR/second/bin/plugins/third/bin" \
     "$TEST_GO_PLUGINS_DIR/first/bin" \
-    "$TEST_GO_PLUGINS_DIR/second/bin" \
     '_GO_SEARCH_PATHS:' \
     "$_GO_CORE_DIR/libexec" \
     "$TEST_GO_PLUGINS_DIR/second/bin" \

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -1,10 +1,14 @@
 #! /usr/bin/env bats
 
 load ../environment
+load "$_GO_CORE_DIR/lib/testing/stack-trace"
 
 FILE_PATH="$TEST_GO_ROOTDIR/hello.txt"
+GO_USE_MODULES_STACK_ITEM="$(@go.stack_trace_item "$_GO_USE_MODULES" source \
+  '_@go.use_modules "$@"')"
 
 setup() {
+  test_filter
   mkdir -p "$TEST_GO_ROOTDIR"
   echo "Hello, World!" >"$FILE_PATH"
 }
@@ -115,9 +119,9 @@ create_file_open_test_go_script() {
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "foobar", must be a number greater than 3.'
+    "$GO_USE_MODULES_STACK_ITEM"
     "  $TEST_GO_SCRIPT:3 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: error if _GO_MAX_FILE_DESCRIPTORS isn't greater than 3" {
@@ -126,9 +130,9 @@ create_file_open_test_go_script() {
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "3", must be a number greater than 3.'
+    "$GO_USE_MODULES_STACK_ITEM"
     "  $TEST_GO_SCRIPT:3 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: validates file_path_or_fd contains no meta or control chars" {
@@ -143,8 +147,7 @@ create_file_open_test_go_script() {
 
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: error if mode is unknown" {
@@ -154,8 +157,7 @@ create_file_open_test_go_script() {
 
   local expected=('Unknown mode: bogus'
     "  $TEST_GO_SCRIPT:5 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: error if no file descriptor variable reference given" {
@@ -168,8 +170,7 @@ create_file_open_test_go_script() {
 
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: validates variable reference contains no meta or control chars" {
@@ -185,8 +186,7 @@ create_file_open_test_go_script() {
 
   local expected=("$err_msg"
     "  $TEST_GO_SCRIPT:5 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }
 
 @test "$SUITE: error opening file path with escaped \`" {
@@ -213,6 +213,5 @@ create_file_open_test_go_script() {
 
   local expected=("No file descriptors < 10 available; failed at:"
     "  $TEST_GO_SCRIPT:7 main")
-  local IFS=$'\n'
-  assert_failure "${expected[*]}"
+  assert_failure "${expected[@]}"
 }

--- a/tests/file/open-or-dup.bats
+++ b/tests/file/open-or-dup.bats
@@ -4,8 +4,10 @@ load ../environment
 load "$_GO_CORE_DIR/lib/testing/stack-trace"
 
 FILE_PATH="$TEST_GO_ROOTDIR/hello.txt"
-GO_USE_MODULES_STACK_ITEM="$(@go.stack_trace_item "$_GO_USE_MODULES" source \
-  '_@go.use_modules "$@"')"
+GO_USE_MODULES_STACK_ITEMS=(
+  "$(@go.stack_trace_item "$_GO_USE_MODULES" '_@go.use_modules' \
+    '    if ! _@go.import_module; then')"
+  "$(@go.stack_trace_item "$_GO_USE_MODULES" source '_@go.use_modules "$@"')")
 
 setup() {
   test_filter
@@ -119,7 +121,7 @@ create_file_open_test_go_script() {
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "foobar", must be a number greater than 3.'
-    "$GO_USE_MODULES_STACK_ITEM"
+    "${GO_USE_MODULES_STACK_ITEMS[@]}"
     "  $TEST_GO_SCRIPT:3 main")
   assert_failure "${expected[@]}"
 }
@@ -130,7 +132,7 @@ create_file_open_test_go_script() {
 
   local expected=(
     '_GO_MAX_FILE_DESCRIPTORS is "3", must be a number greater than 3.'
-    "$GO_USE_MODULES_STACK_ITEM"
+    "${GO_USE_MODULES_STACK_ITEMS[@]}"
     "  $TEST_GO_SCRIPT:3 main")
   assert_failure "${expected[@]}"
 }

--- a/tests/modules/use.bats
+++ b/tests/modules/use.bats
@@ -1,6 +1,7 @@
 #! /usr/bin/env bats
 
 load ../environment
+load "$_GO_CORE_DIR/lib/testing/stack-trace"
 load "$_GO_CORE_DIR/lib/testing/stubbing"
 
 BUILTIN_MODULE_FILE="$_GO_CORE_DIR/lib/builtin-test"
@@ -39,6 +40,9 @@ EXPECTED=(
   'module: export-test'
   "source: $EXPORT_MODULE_FILE"
   "caller: $CALLER")
+
+GO_USE_MODULES_STACK_ITEM="$(@go.stack_trace_item "$_GO_USE_MODULES" source \
+  '_@go.use_modules "$@"')"
 
 setup() {
   test_filter
@@ -94,6 +98,7 @@ teardown() {
   run "$TEST_GO_SCRIPT" 'bogus-test-module'
 
   local expected=('ERROR: Module bogus-test-module not found at:'
+    "$GO_USE_MODULES_STACK_ITEM"
     "  $TEST_GO_SCRIPT:3 main")
   assert_failure
   assert_lines_equal "${expected[@]}"
@@ -163,6 +168,7 @@ teardown() {
   local expected=("${IMPORTS[0]##*/} loaded"
     "$module_file: line 1: This: command not found"
     "ERROR: Failed to import $module module from $module_file at:"
+    "$GO_USE_MODULES_STACK_ITEM"
     "  $TEST_GO_SCRIPT:3 main")
   assert_failure "${expected[@]}"
 }
@@ -180,6 +186,7 @@ teardown() {
   local expected=("${IMPORTS[0]##*/} loaded"
     "$error_message"
     "ERROR: Failed to import $module module from $module_file at:"
+    "$GO_USE_MODULES_STACK_ITEM"
     "  $TEST_GO_SCRIPT:3 main")
   assert_failure "${expected[@]}"
 }

--- a/tests/modules/use/plugins.bats
+++ b/tests/modules/use/plugins.bats
@@ -6,7 +6,7 @@ PRINT_SOURCE='printf -- "%s\n" "$BASH_SOURCE"'
 
 setup() {
   test_filter
-  @go.create_test_go_script '@go "$@"' \
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "$@"' \
     'printf "%s\n" "${_GO_IMPORTED_MODULES[@]}"'
 }
 
@@ -15,129 +15,136 @@ teardown() {
 }
 
 @test "$SUITE: plugin imports own internal module" {
-  local module_path='foo/bin/lib/foo'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
-    '. "$_GO_USE_MODULES" foo'
+  local module_path='foo/bin/lib/bar'
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
+    '. "$_GO_USE_MODULES" bar'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo' 'foo/bar'
 }
 
 @test "$SUITE: plugin imports own exported module" {
-  local module_path='foo/lib/foo'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
-    '. "$_GO_USE_MODULES" foo'
+  local module_path='foo/lib/bar'
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
+    '. "$_GO_USE_MODULES" bar'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo' 'foo/bar'
 }
 
 @test "$SUITE: plugin imports module from own plugin" {
   local module_path='foo/bin/plugins/bar/lib/bar'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo' 'bar/bar'
 }
 
 @test "$SUITE: plugin imports module from other plugin in _GO_PLUGINS_DIR" {
   local module_path='bar/lib/bar'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'foo/foo' 'bar/bar'
 }
 
 @test "$SUITE: nested plugin imports own internal module" {
   local module_path='foo/bin/plugins/bar/bin/lib/bar-2'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" bar-2'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'bar/bar-2'
 }
 
 @test "$SUITE: nested plugin imports own exported module" {
   local module_path='foo/bin/plugins/bar/lib/bar-2'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" bar-2'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'bar/bar-2'
 }
 
 @test "$SUITE: nested plugin imports module from own plugin" {
   local module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" baz/baz'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'baz/baz'
 }
 
 @test "$SUITE: nested plugin imports own module instead of parent module" {
   local module_path='foo/bin/plugins/bar/lib/bar-2'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" bar-2'
   @go.create_test_command_script "plugins/foo/lib/bar-2" "$PRINT_SOURCE"
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'bar/bar-2'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'bar/bar-2'
 }
 
 @test "$SUITE: nested plugin imports module from parent plugin" {
-  local module_path='foo/lib/foo'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  local module_path='foo/lib/baz'
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
-    '. "$_GO_USE_MODULES" foo/foo'
+    '. "$_GO_USE_MODULES" foo/baz'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'foo/foo'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'foo/baz'
 }
 
 @test "$SUITE: nested plugin imports module from _GO_PLUGINS_DIR" {
   local module_path='baz/lib/baz'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" baz/baz'
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'baz/baz'
 }
 
 @test "$SUITE: nested plugin imports own module before _GO_PLUGINS_DIR copy" {
   local module_path='foo/bin/plugins/bar/bin/plugins/baz/lib/baz'
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar'
   @go.create_test_command_script 'plugins/foo/bin/plugins/bar/lib/bar' \
     '. "$_GO_USE_MODULES" baz/baz'
   @go.create_test_command_script 'plugins/baz/lib/baz' "$PRINT_SOURCE"
   @go.create_test_command_script "plugins/$module_path" "$PRINT_SOURCE"
 
-  run "$TEST_GO_SCRIPT" 'foo'
-  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" 'bar/bar' 'baz/baz'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
+  assert_success "$TEST_GO_PLUGINS_DIR/$module_path" \
+    'foo/foo' 'bar/bar' 'baz/baz'
 }
 
 @test "$SUITE: module collision produces warning message, top level first" {
@@ -149,11 +156,11 @@ teardown() {
   @go.create_test_command_script "plugins/$top_module_path" "$PRINT_SOURCE"
   @go.create_test_command_script "plugins/$nested_module_path" "$PRINT_SOURCE"
 
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" baz/baz bar/bar'
-  run "$TEST_GO_SCRIPT" 'foo'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
 
-  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/bin/foo:2"
+  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/lib/foo:2"
   local nested_importer="$TEST_GO_PLUGINS_DIR/foo/bin/plugins/bar/lib/bar:2"
   assert_success
   assert_lines_equal "$TEST_GO_PLUGINS_DIR/$top_module_path" \
@@ -162,6 +169,7 @@ teardown() {
     "from file: $TEST_GO_PLUGINS_DIR/$nested_module_path" \
     "previously imported at: $parent_importer source" \
     "from file: $TEST_GO_PLUGINS_DIR/$top_module_path" \
+    'foo/foo' \
     'baz/baz' \
     'bar/bar'
 }
@@ -175,11 +183,11 @@ teardown() {
   @go.create_test_command_script "plugins/$top_module_path" "$PRINT_SOURCE"
   @go.create_test_command_script "plugins/$nested_module_path" "$PRINT_SOURCE"
 
-  @go.create_test_command_script 'plugins/foo/bin/foo' \
+  @go.create_test_command_script 'plugins/foo/lib/foo' \
     '. "$_GO_USE_MODULES" bar/bar baz/baz'
-  run "$TEST_GO_SCRIPT" 'foo'
+  run "$TEST_GO_SCRIPT" 'foo/foo'
 
-  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/bin/foo:2"
+  local parent_importer="$TEST_GO_PLUGINS_DIR/foo/lib/foo:2"
   local nested_importer="$TEST_GO_PLUGINS_DIR/foo/bin/plugins/bar/lib/bar:2"
   assert_success
   assert_lines_equal "$TEST_GO_PLUGINS_DIR/$nested_module_path" \
@@ -188,6 +196,7 @@ teardown() {
     "from file: $TEST_GO_PLUGINS_DIR/$top_module_path" \
     "previously imported at: $nested_importer source" \
     "from file: $TEST_GO_PLUGINS_DIR/$nested_module_path" \
+    'foo/foo' \
     'bar/bar' \
     'baz/baz'
 }


### PR DESCRIPTION
This updates `_GO_USE_MODULES` to provide correct `@go` command script scope for plugin modules. It is germane to #120.

Whereas #136 implemented correctly-scoped lookup of other plugin modules, this allows any module, plugin or otherwise, to invoke its own command scripts or plugin command scripts via `@go`.

This PR contains lots of granular commits that contain individual refactoring steps building up to the final one that implements correct `@go` command scope. The last commit is the only one that introduces fundamentally new behavior.