### PR TITLE
Disable commit.gpgsign in get/git-repo test

### DIFF
--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -72,6 +72,7 @@ teardown() {
   git init
   git config user.email 'mbland@example.com'
   git config user.name 'Mike Bland'
+  git config commit.gpgsign false
   printf '# This is a test\n' >README.md
   git add README.md
   git commit -m 'Initial commit'


### PR DESCRIPTION
Without this, if the user has `commit.gpgsign` set to `true`, creating the test repo in the "get/git-repo: use the real git to create and clone a repo" test case will produce "You need a passphrase to unlock the secret key" messages.