### PR TITLE
Add 2017 to copyright, fix @go.printf unconditional newline and infinite loop bugs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Mike Bland <mbland@acm.org>
+Copyright (c) 2016-2017 Mike Bland <mbland@acm.org>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/go-core.bash
+++ b/go-core.bash
@@ -154,7 +154,6 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   local result
   local line
   local prefix
-  local IFS=
 
   if [[ "$#" -eq 0 ]]; then
     format="${format//\%/%%}"
@@ -162,11 +161,11 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   printf -v result -- "$format" "$@"
   result="${result//$'\r\n'/$'\n'}"
 
-  # If `result` ends with a newline, chomp it, since the loop will add one.
-  while read -r line; do
+  # Use the ASCII Unit Separator as a delimiter to preserve true line endings.
+  while IFS= read -r -d $'\x1f' line; do
     while [[ "${#line}" -gt "$COLUMNS" ]]; do
       prefix="${line:0:$COLUMNS}"
-      prefix="${prefix% *}"
+      prefix="${prefix%[[:space:]]*}"
       line="${line#$prefix}"
 
       if [[ "$prefix" =~ [[:space:]]+$ ]]; then
@@ -177,8 +176,8 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
       fi
       printf '%s\n' "$prefix"
     done
-    printf '%s\n' "$line"
-  done <<<"${result%$'\n'}"
+    printf '%s' "$line"
+  done <<<"${result//$'\n'/$'\n\x1f'}"$'\x1f'
 }
 
 # Prints the stack trace at the point of the call.

--- a/go-core.bash
+++ b/go-core.bash
@@ -166,7 +166,9 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     while [[ "${#line}" -gt "$COLUMNS" ]]; do
       prefix="${line:0:$COLUMNS}"
       prefix="${prefix%[[:space:]]*}"
-      line="${line#$prefix}"
+
+      # Trim `line` using an index in case `prefix` contains pattern characters.
+      line="${line:${#prefix}}"
 
       if [[ "$prefix" =~ [[:space:]]+$ ]]; then
         prefix="${prefix%${BASH_REMATCH[0]}}"

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -96,7 +96,7 @@ _@go.get_file_download_command() {
     if [[ -n "$dl_cmd" ]]; then
       @go.printf 'Download program not supported: %s\n' "$dl_cmd" >&2
     fi
-    @go.printf 'Please install curl or wget before running "%s".' \
+    @go.printf 'Please install curl or wget before running "%s".\n' \
       "${_GO_CMD_NAME[*]}" >&2
     return 1
     ;;
@@ -144,7 +144,7 @@ _@go.get_file_impl() {
   if ! "${__go_get_file_download_cmd[@]}" "$url" 2>"$errfile"; then
     errmsg="$(< "$errfile")"
     printf '%s\n' "$errmsg" >&2
-    @go.printf 'Failed to download using %s: %s' \
+    @go.printf 'Failed to download using %s: %s\n' \
       "${__go_get_file_download_cmd[0]}" "$url" >&2
 
     if [[ "${__go_get_file_download_cmd[0]}" != 'curl' ]]; then

--- a/tests/core/printf.bats
+++ b/tests/core/printf.bats
@@ -57,3 +57,18 @@ teardown() {
   run "$TEST_GO_SCRIPT"
   assert_success 'foobarbaz'
 }
+
+@test "$SUITE: don't loop infinitely if line contains pattern characters" {
+  # `[alias]` and `[builtin]` were previously interpreted as character sets, not
+  # literal strings in and of themselves, when appering in `$prefix` in the
+  # expression `${line#$prefix}`.
+  local test_string='  path       '
+  test_string+='Prints the path to the <command> script, [alias] or [builtin]'
+
+  @go.create_test_go_script "@go.printf '%s' '$test_string'"
+  COLUMNS=27 run "$TEST_GO_SCRIPT"
+  assert_success '  path       Prints the' \
+    'path to the <command>' \
+    'script, [alias] or' \
+    '[builtin]'
+}

--- a/tests/core/printf.bats
+++ b/tests/core/printf.bats
@@ -49,3 +49,11 @@ teardown() {
   COLUMNS=15 run "$TEST_GO_SCRIPT"
   assert_success $'123456789012345\n67890\n1234567890'
 }
+
+@test "$SUITE: don't add newline if format doesn't include one" {
+  @go.create_test_go_script "@go.printf '%s' 'foo'" \
+    "@go.printf '%s' 'bar'" \
+    "@go.printf '%s' 'baz'"
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foobarbaz'
+}


### PR DESCRIPTION
Closes #143 and closes #146. See the commit messages for excruciating details.