### PR TITLE
core: Implement `_GO_STANDALONE` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ under Bash 3.2, 4.2, 4.3, and 4.4 across OS X, Ubuntu Linux, Arch Linux, Alpine
 Linux, FreeBSD 9.3, FreeBSD 10.3, and Windows 10 (using all the environments
 described in the "Will this work on Windows?" section above).
 
+#### Can I use it to write standalone programs that aren't project scripts?
+
+Actually, yes. See the [Standalone mode](#standalone-mode) section below.
+
+Also see the following question...
+
+#### Can I have more than one ./go script in the same project source tree?
+
+Yes. You can share one copy of the go-bash-framework sources, and even have
+common code in the `lib/` directory, but set each script to use its own command
+scripts dir.
+
+This may be especially useful if you're writing a [standalone](#standalone-mode)
+program, in which one script provides the actual program interface, and the
+other provides the development-only interface.
+
 #### How is it tested?
 
 The project's own `./go test` command does it all. Combined with automatic
@@ -297,6 +313,20 @@ better yet, [send a pull request](#feedback-and-contributions)!
 To learn the API for adding tab completion to your own command scripts, run
 `./go help complete`. You can also learn by reading the scripts for the builtin
 commands.
+
+#### Standalone mode
+
+If you wish to use the framework to write a standalone program, rather than a
+project-specific development script, set `_GO_STANDALONE` in your top-level
+script to prevent alias commands, builtin commands, and plugin commands from
+showing up in `help` output or from being offered as tab completions. (`help`
+will still appear as a top-level tab completion.) All of these commands will
+still be available, but users won't be presented with them directly.
+
+`_GO_STANDALONE` also prevents the script from setting `PWD` to `_GO_ROOTDIR`,
+enabling the script to process relative file path arguments anywhere in the file
+system. Note that then you'll have to add `_GO_ROOTDIR` manually to any
+`_GO_ROOTDIR`-relative paths in your own scripts.
 
 #### Including common code
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -50,7 +50,8 @@ cd "${0%/*}" || exit 1
 # Path to the project's root directory
 #
 # This is directory containing the main ./go script. All functions, commands,
-# and scripts are invoked relative to this directory.
+# and scripts are invoked relative to this directory (unless `_GO_STANDALONE`
+# is set).
 declare -x _GO_ROOTDIR="$PWD"
 
 if [[ "${BASH_SOURCE[0]:0:1}" != '/' ]]; then
@@ -58,11 +59,19 @@ if [[ "${BASH_SOURCE[0]:0:1}" != '/' ]]; then
 else
   cd "${BASH_SOURCE[0]%/*}" || exit 1
 fi
-unset __go_orig_dir
 
 # Path to the ./go script framework's directory
 declare -r -x _GO_CORE_DIR="$PWD"
-cd "$_GO_ROOTDIR" || exit 1
+
+# Set _GO_STANDALONE if your script is a standalone program.
+#
+# See the "Standalone mode" section of README.md for more information.
+if [[ -z "$_GO_STANDALONE" ]]; then
+  cd "$_GO_ROOTDIR" || exit 1
+else
+  cd "$__go_orig_dir" || exit 1
+fi
+unset __go_orig_dir
 
 # Path to the script used to import optional library modules.
 #

--- a/lib/internal/commands
+++ b/lib/internal/commands
@@ -56,11 +56,15 @@ _@go.find_commands() {
         scripts+=("$script")
       fi
     done
-    _@go.merge_scripts_into_list "${scripts[@]#$_GO_ROOTDIR/}"
+    _@go.merge_scripts_into_list "${scripts[@]}"
   done
 
   if [[ "${#__go_command_scripts[@]}" -eq '0' ]]; then
     return 1
+  elif [[ -z "$_GO_STANDALONE" ]]; then
+    __go_command_scripts=("${__go_command_scripts[@]#$_GO_ROOTDIR/}")
+  else
+    __go_command_scripts=("${__go_command_scripts[@]#$PWD/}")
   fi
 
   __go_command_names=("${__go_command_scripts[@]##*/}")

--- a/lib/internal/complete
+++ b/lib/internal/complete
@@ -1,8 +1,13 @@
 #! /bin/bash
 
 _@go.complete_top_level_commands() {
-  _@go.source_builtin 'aliases'
-  _@go.source_builtin 'commands'
+  if [[ -z "$_GO_STANDALONE" ]]; then
+    _@go.source_builtin 'aliases'
+    _@go.source_builtin 'commands'
+  else
+    printf 'help\n'
+    _@go.source_builtin 'commands' "$_GO_SCRIPTS_DIR"
+  fi
 }
 
 # A successful return status from this function is a signal that __go_cmd_path

--- a/libexec/complete
+++ b/libexec/complete
@@ -15,8 +15,9 @@
 #   <command>     is the command supporting argument completion
 #
 # Aliases and some builtin commands will complete file and directory paths
-# relative to {{root}}. Other commands may implement their own specific
-# completion schemes.
+# relative to {{root}} (unless `_GO_STANDALONE` is set, in which case they'll be
+# relative to the caller's `PWD`). Other commands may implement their own
+# specific completion schemes.
 #
 # This behavior is normally accessible by using `{{go}} env` to set up your
 # shell environment for argument completion. Running `{{go}} {{cmd}}` or `{{go}}

--- a/libexec/help
+++ b/libexec/help
@@ -55,9 +55,13 @@
 # enforced.
 
 _@go.usage() {
-  local cmd_paths=("${_GO_PLUGINS_PATHS[@]}" "$_GO_SCRIPTS_DIR")
+  local cmd_paths=("$_GO_SCRIPTS_DIR")
   local summaries
   local summaries_status=0
+
+  if [[ -z "$_GO_STANDALONE" ]]; then
+    cmd_paths+=("${_GO_PLUGINS_PATHS[@]}")
+  fi
 
   . "$_GO_USE_MODULES" 'strings'
   @go.join ':' 'cmd_paths' "${cmd_paths[@]}"
@@ -69,14 +73,18 @@ _@go.usage() {
     summaries_status=1
   fi
 
-  @go.printf "%s\n\n%s\n\n%s\n\n%s %s\n\n%s %s\n\n" \
+  @go.printf "%s\n\n%s\n\n%s\n\n%s %s\n\n" \
     "Usage: $_GO_CMD <command> [arguments...]" \
     "Where <command> is one of:" \
     "$summaries" \
     "Use \"$_GO_CMD help <command>\" for more information about that command," \
-    "if available." \
-    "Use \"$_GO_CMD help builtins\" for help on builtin commands," \
-    "and \"$_GO_CMD help aliases\" for information on shell alias commands."
+    "if available."
+
+  if [[ -z "$_GO_STANDALONE" ]]; then
+    @go.printf '%s %s\n\n' \
+      "Use \"$_GO_CMD help builtins\" for help on builtin commands," \
+      "and \"$_GO_CMD help aliases\" for information on shell alias commands."
+  fi
   [[ "$?" -eq '0' && "$summaries_status" -eq '0' ]]
 }
 

--- a/tests/commands/helpers.bash
+++ b/tests/commands/helpers.bash
@@ -10,7 +10,7 @@ find_builtins() {
   local cmd_script
   local cmd_name
 
-  for cmd_script in "$_GO_ROOTDIR"/libexec/*; do
+  for cmd_script in "$_GO_CORE_DIR"/libexec/*; do
     if [[ ! (-f "$cmd_script" && -x "$cmd_script") ]]; then
       continue
     fi
@@ -22,9 +22,6 @@ find_builtins() {
       LONGEST_BUILTIN_NAME="$cmd_name"
     fi
   done
-
-  # Strip the rootdir to make output less noisy.
-  BUILTIN_SCRIPTS=("${BUILTIN_SCRIPTS[@]#$_GO_ROOTDIR/}")
 }
 
 merge_scripts() {
@@ -58,9 +55,9 @@ merge_scripts() {
 add_scripts() {
   local script_names=("$@")
 
-  merge_scripts "${script_names[@]/#/$TEST_GO_SCRIPTS_RELATIVE_DIR/}"
+  merge_scripts "${script_names[@]/#/$TEST_GO_SCRIPTS_DIR/}"
 
   for script_path in "${script_names[@]}"; do
-    @go.create_test_command_script "$script_path"
+    @go.create_test_command_script "${script_path#$TEST_GO_ROOTDIR/}"
   done
 }

--- a/tests/core/standalone.bats
+++ b/tests/core/standalone.bats
@@ -1,0 +1,20 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script 'printf "PWD: %s\n" "$PWD"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: don't change to _GO_ROOTDIR when _GO_STANDALONE is set" {
+  cd "$HOME"
+  run "$TEST_GO_SCRIPT"
+  assert_success "PWD: $TEST_GO_ROOTDIR"
+  _GO_STANDALONE='true' run "$TEST_GO_SCRIPT"
+  assert_success "PWD: $HOME"
+}

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -27,7 +27,7 @@ teardown() {
 @test "$SUITE: produce message with successful return for help command" {
   @go.create_test_command_script 'foo' '# Does foo stuff'
   @go.create_test_command_script 'bar' '# Does bar stuff'
-  @go.create_test_command_script 'baz' '# Does baz stuff'
+  @go.create_test_command_script 'plugins/baz/bin/baz' '# Does baz stuff'
   run "$TEST_GO_SCRIPT" help
 
   assert_success
@@ -35,6 +35,22 @@ teardown() {
   assert_output_matches '  foo  Does foo stuff'
   assert_output_matches '  bar  Does bar stuff'
   assert_output_matches '  baz  Does baz stuff'
+  assert_output_matches "Use \"$TEST_GO_SCRIPT help builtins\" for help on "
+}
+
+@test "$SUITE: only show top-level commands when _GO_STANDALONE is set" {
+  @go.create_test_command_script 'foo' '# Does foo stuff'
+  @go.create_test_command_script 'bar' '# Does bar stuff'
+  @go.create_test_command_script 'plugins/baz/bin/baz' '# Does baz stuff'
+  cd "$HOME"
+  _GO_STANDALONE='true' run "$TEST_GO_SCRIPT" help
+
+  assert_success
+  assert_line_equals 0 "Usage: $TEST_GO_SCRIPT <command> [arguments...]"
+  assert_output_matches '  foo  Does foo stuff'
+  assert_output_matches '  bar  Does bar stuff'
+  fail_if output_matches '  baz  Does baz stuff'
+  fail_if output_matches "Use \"$TEST_GO_SCRIPT help builtins\" for help on "
 }
 
 @test "$SUITE: produce usage message when error retrieving command summaries" {


### PR DESCRIPTION
Closes #147. Whereas that issue describes a `_GO_NO_CD_ROOTDIR` variable, I realized the implications of the change were bit more far-reaching, and also provided the opportunity to clean up the `help` and tab completion interfaces for standalone programs.

See the updates to `README.md`, most notably the new "Standalone mode" section, for details.