### PR TITLE
Refactor `./go modules`, list project modules before plugins

### DIFF
--- a/lib/strings
+++ b/lib/strings
@@ -27,9 +27,12 @@ export __GO_STRINGS_VALIDATION_SKIP_CALLERS=2
 # Splits fields from a delimited string into an array defined by the caller
 #
 # While `IFS= read -ra array_name <<<"$value"` is idiomatic, this function
-# guards against a bug in Bash 4.2.25 (the version in the Ubuntu Precise image
-# used by Travis CI) and not fixed until 4.2.41 whereby the temporary
-# environment of `IFS= read` isn't honored when running in a process
+# handles two situations. First, it handles splitting strings whose items
+# themselves contain newline characters.
+#
+# Second, it guards against a bug in Bash 4.2.25 (the version in the Ubuntu
+# Precise image used by Travis CI) and not fixed until 4.2.41 whereby the
+# temporary environment of `IFS= read` isn't honored when running in a process
 # substitution. For details, see the message for commit
 # 99ab7805e6ef0a14568d8a100eec03bb2cb03631.
 #
@@ -46,7 +49,22 @@ export __GO_STRINGS_VALIDATION_SKIP_CALLERS=2
 @go.split() {
   @go.validate_identifier_or_die 'Result array name' "$3"
   local IFS="$1"
-  read -ra "$3" <<<"$2"
+
+  # There are a few subtle interactions handled here.
+  #
+  # To handle items containing newlines, we set `-d ''` so that `read` will
+  # read the entire `value` string (i.e. `$2`). To avoid an EOF error on what
+  # should be a successful read with `-d ''`, we set `-n "${#2}"` to read
+  # exactly the number of characters in `value`.
+  #
+  # When `value` is the empty string, `<<<` will add a newline which will be
+  # read even with `read -n 0` being in effect. Consequently, we `unset` the
+  # result array explicitly (something normally handled by `read -a`) and only
+  # call `read` when the string is not empty.
+  unset "$3"
+  if [[ "${#2}" -ne '0' ]]; then
+    read -ra "$3" -n "${#2}" -d '' <<<"$2"
+  fi
 }
 
 # Joins multiple items into a string variable defined by the caller

--- a/libexec/modules
+++ b/libexec/modules
@@ -136,25 +136,20 @@ _@go.modules_produce_listing() {
     return
   fi
 
-  . "$_GO_CORE_DIR/lib/format"
-
-  local padded_modules=()
-  local zipped_modules=()
-
-  @go.pad_items padded_modules "${modules[@]}"
-  modules=("${padded_modules[@]}")
+  . "$_GO_USE_MODULES" 'format'
+  @go.pad_items modules "${modules[@]}"
 
   case "$action" in
   paths)
     local relative_paths=("${__go_modules[@]#$_GO_ROOTDIR/}")
-    @go.zip_items modules relative_paths '  ' zipped_modules
+    @go.zip_items modules relative_paths '  ' modules
     ;;
   summaries)
     local __go_modules_summaries=()
     if ! _@go.modules_summaries; then
       return 1
     fi
-    @go.zip_items modules __go_modules_summaries '  ' zipped_modules
+    @go.zip_items modules __go_modules_summaries '  ' modules
     ;;
   *)
     # Should only happen if _@go.modules is updated and this case statement
@@ -162,7 +157,7 @@ _@go.modules_produce_listing() {
     @go.printf 'ERROR: Unknown action: %s\n' "$action" >&2
     return 1
   esac
-  __go_modules_listing=("${zipped_modules[@]}")
+  __go_modules_listing=("${modules[@]}")
 }
 
 _@go.modules_search_plugins() {
@@ -204,8 +199,8 @@ _@go.modules_emit_class() {
 
   if [[ "${#__go_modules[@]}" -ne '0' ]] &&
         _@go.modules_produce_listing "$action"; then
-    local IFS=$'\n'
-    printf "From the %s:\n%s\n\n" "$class" "${__go_modules_listing[*]/#/  }"
+    printf 'From the %s:\n' "$class"
+    printf '%s\n' "${__go_modules_listing[@]/#/  }" ''
   fi
 }
 
@@ -253,12 +248,10 @@ _@go.modules_list() {
   done
 
   local __go_modules_listing=()
-  if _@go.modules_produce_listing "$action"; then
-    local IFS=$'\n'
-    echo "${__go_modules_listing[*]}"
-  else
+  if ! _@go.modules_produce_listing "$action"; then
     return 1
   fi
+  printf '%s\n' "${__go_modules_listing[@]}"
 }
 
 _@go.modules_tab_completion_plugins() {
@@ -342,15 +335,31 @@ _@go.modules_tab_completion() {
   fi
 
   local __go_modules_listing=()
-  if _@go.modules_produce_listing; then
-    completions+=("${__go_modules_listing[@]}")
-    @go.complete_remove_completions_already_present \
-      'args' 'completions' "${#completions[@]}"
-    echo "${completions[@]}"
-  else
+  if ! _@go.modules_produce_listing; then
     # Shouldn't happen, since modules_produce_listing isn't parsing summaries.
     return 1
   fi
+  completions+=("${__go_modules_listing[@]}")
+  @go.complete_remove_completions_already_present \
+    'args' 'completions' "${#completions[@]}"
+  echo "${completions[@]}"
+}
+
+_@go.modules_list_imported() {
+  if [[ "$#" -ne 0 ]]; then
+    @go.printf 'The --imported option takes no other arguments.\n' >&2
+    return 1
+  fi
+
+  # Collect imported module info before _GO_USE_MODULES imports possibly more.
+  local imported_modules=("${_GO_IMPORTED_MODULES[@]}")
+  local imported_files=("${_GO_IMPORTED_MODULE_FILES[@]#$_GO_ROOTDIR/}")
+  local imported_listing=()
+
+  . "$_GO_USE_MODULES" 'format'
+  @go.pad_items imported_modules "${imported_modules[@]}"
+  @go.zip_items imported_modules imported_files '  ' imported_listing
+  printf '%s\n' "${imported_listing[@]}"
 }
 
 _@go.modules() {
@@ -374,12 +383,7 @@ _@go.modules() {
     fi
     ;;
   --imported)
-    if [[ "$#" -ne 0 ]]; then
-      @go.printf 'The --imported option takes no other arguments.\n' >&2
-      return 1
-    elif [[ "${#_GO_IMPORTED_MODULES[@]}" -ne '0' ]]; then
-      _@go.modules_list 'paths' "${_GO_IMPORTED_MODULES[@]}"
-    fi
+    _@go.modules_list_imported "$@"
     ;;
   -*)
     @go.printf "Unknown option: $action\n" >&2

--- a/libexec/modules
+++ b/libexec/modules
@@ -182,11 +182,11 @@ _@go.modules_search() {
   _@go.modules_find_all_in_dir "$_GO_CORE_DIR" "$glob"
   __go_core_modules_end="${#__go_modules[@]}"
 
-  @go.search_plugins '_@go.modules_search_plugins'
-  __go_plugin_modules_end="${#__go_modules[@]}"
-
   _@go.modules_find_all_in_dir "$_GO_SCRIPTS_DIR" "$glob"
   __go_project_modules_end="${#__go_modules[@]}"
+
+  @go.search_plugins '_@go.modules_search_plugins'
+  __go_plugin_modules_end="${#__go_modules[@]}"
 }
 
 _@go.modules_emit_class() {
@@ -208,18 +208,18 @@ _@go.modules_list_by_class() {
   local action="$1"
   local __go_modules=()
   local __go_core_modules_end=0
-  local __go_plugin_modules_end=0
   local __go_project_modules_end=0
+  local __go_plugin_modules_end=0
   local __go_all_modules
 
   _@go.modules_search
   __go_all_modules=("${__go_modules[@]}")
   _@go.modules_emit_class 'core framework library' "$action" \
     0 "$__go_core_modules_end"
-  _@go.modules_emit_class 'installed plugin libraries' "$action" \
-    "$__go_core_modules_end" "$__go_plugin_modules_end"
   _@go.modules_emit_class 'project library' "$action" \
-    "$__go_plugin_modules_end" "$__go_project_modules_end"
+    "$__go_core_modules_end" "$__go_project_modules_end"
+  _@go.modules_emit_class 'installed plugin libraries' "$action" \
+    "$__go_project_modules_end" "$__go_plugin_modules_end"
 }
 
 _@go.modules_list() {

--- a/libexec/modules
+++ b/libexec/modules
@@ -46,17 +46,25 @@
 # For detailed information about the module system, run `{{go}} {{cmd}} --help`
 # without a `<module-name>` argument.
 
+# Imports the functions from `lib/internal/use`. Since the last line invokes
+# `_@go.use_modules`, this wrapper ensures the argument list is empty to avoid
+# having it attempt to process this command script's argument array.
+_@go.modules_import_use_modules_functions() {
+  . "$_GO_USE_MODULES"
+}
+_@go.modules_import_use_modules_functions
+
 _@go.modules_help() {
-  local module_name="$1"
-  local __go_module_path
+  local __go_module_name="$1"
+  local __go_module_file
 
   if [[ "$#" -eq '0' ]]; then
-    module_name='$_GO_USE_MODULES'
-    __go_module_path="$_GO_USE_MODULES"
+    __go_module_name='$_GO_USE_MODULES'
+    __go_module_file="$_GO_USE_MODULES"
   elif [[ "$#" -ne '1' ]]; then
     @go.printf "Please specify only one module name.\n" >&2
     return 1
-  elif ! _@go.modules_path "$module_name"; then
+  elif ! _@go.find_module; then
     @go.printf "Unknown module: $1\n" >&2
     return 1
   fi
@@ -65,33 +73,12 @@ _@go.modules_help() {
 
   . "$_GO_CORE_DIR/lib/internal/command_descriptions"
 
-  if ! _@go.command_description "$__go_module_path"; then
+  if ! _@go.command_description "$__go_module_file"; then
     @go.printf "ERROR: failed to parse description from %s\n" \
-      "$__go_module_path" >&2
+      "$__go_module_file" >&2
     return 1
   fi
-  @go.printf "$module_name - $__go_cmd_desc\n"
-}
-
-_@go.modules_path() {
-  local module_name="$1"
-
-  __go_module_path="$_GO_CORE_DIR/lib/$module_name"
-  if [[ -f "$__go_module_path" ]]; then
-    return
-  fi
-
-  # Convert <plugin>/<module> to _GO_PLUGINS_DIR/<plugin>/lib/<module>
-  __go_module_path="$_GO_PLUGINS_DIR/${module_name/\///lib/}"
-  if [[ -n "$_GO_PLUGINS_DIR" && -f "$__go_module_path" ]]; then
-    return
-  fi
-
-  __go_module_path="$_GO_SCRIPTS_DIR/lib/$module_name"
-  if [[ -f "$__go_module_path" ]]; then
-    return
-  fi
-  return 1
+  @go.printf "$__go_module_name - $__go_cmd_desc\n"
 }
 
 _@go.modules_find_all_in_dir() {
@@ -178,6 +165,12 @@ _@go.modules_produce_listing() {
   __go_modules_listing=("${zipped_modules[@]}")
 }
 
+_@go.modules_search_plugins() {
+  for plugin in "$1/"${plugin_glob[0]:-*}; do
+    _@go.modules_find_all_in_dir "$plugin" "${plugin_glob[1]:-*}"
+  done
+}
+
 _@go.modules_search() {
   local glob="${1:-*}"
   # Default to matching modules within any plugin.
@@ -194,11 +187,7 @@ _@go.modules_search() {
   _@go.modules_find_all_in_dir "$_GO_CORE_DIR" "$glob"
   __go_core_modules_end="${#__go_modules[@]}"
 
-  if [[ -n "$_GO_PLUGINS_DIR" ]]; then
-    for plugin in "$_GO_PLUGINS_DIR/"${plugin_glob[0]:-*}; do
-      _@go.modules_find_all_in_dir "$plugin" "${plugin_glob[1]:-*}"
-    done
-  fi
+  @go.search_plugins '_@go.modules_search_plugins'
   __go_plugin_modules_end="${#__go_modules[@]}"
 
   _@go.modules_find_all_in_dir "$_GO_SCRIPTS_DIR" "$glob"
@@ -243,23 +232,23 @@ _@go.modules_list() {
   shift
   local module_specs=("$@")
   local __go_modules=()
-  local __go_module_path
-  local module_spec
+  local __go_module_name
+  local __go_module_file
 
-  for module_spec in "${module_specs[@]}"; do
-    if [[ "$module_spec" == '*' ]]; then
+  for __go_module_name in "${module_specs[@]}"; do
+    if [[ "$__go_module_name" == '*' ]]; then
       if [[ "${#module_specs[@]}" -ne 1 ]]; then
         @go.printf "Do not specify other patterns when '*' is present.\n" >&2
         return 1
       fi
       _@go.modules_search
-    elif [[ "$module_spec" =~ \*|/$ ]]; then
-      _@go.modules_search "$module_spec"
-    elif ! _@go.modules_path "$module_spec"; then
-      @go.printf "Unknown module: $module_spec\n" >&2
+    elif [[ "$__go_module_name" =~ \*|/$ ]]; then
+      _@go.modules_search "$__go_module_name"
+    elif ! _@go.find_module; then
+      @go.printf "Unknown module: $__go_module_name\n" >&2
       return 1
     else
-      __go_modules+=("$__go_module_path")
+      __go_modules+=("$__go_module_file")
     fi
   done
 
@@ -270,6 +259,37 @@ _@go.modules_list() {
   else
     return 1
   fi
+}
+
+_@go.modules_tab_completion_plugins() {
+  local plugin
+
+  # `glob` indicates specific plugin module.
+  if [[ "$glob" =~ / ]]; then
+    plugin="${glob%/*}"
+    _@go.modules_find_all_in_dir "$1/$plugin" "${glob#*/}*"
+    return
+  fi
+
+  # Otherwise collect all plugin modules and the names of the plugins to
+  # which they belong. Which set gets returned will be decided at the end.
+  for plugin in "$1"/$glob; do
+    _@go.modules_find_all_in_dir "$plugin"
+    if [[ "${#__go_modules[@]}" -eq '0' ]]; then
+      continue
+    fi
+
+    __go_modules=("${__go_modules[@]#$1/}")
+    __go_modules=("${__go_modules[@]/\/lib\///}")
+    @go.complete_remove_completions_already_present 'args' '__go_modules' \
+      "${#__go_modules[@]}"
+
+    if [[ "${#__go_modules[@]}" -ne '0' ]]; then
+      plugins+=("$plugin/")
+      plugin_modules+=("${__go_modules[@]}")
+      __go_modules=()
+    fi
+  done
 }
 
 _@go.modules_tab_completion() {
@@ -304,37 +324,7 @@ _@go.modules_tab_completion() {
   local plugin_modules=()
 
   . "$_GO_USE_MODULES" 'complete'
-
-  if [[ -n "$_GO_PLUGINS_DIR" ]]; then
-    local plugin
-
-    # Complete a specific plugin module (word contains a '/').
-    if [[ "$glob" =~ / ]]; then
-      plugin="${glob%/*}"
-      _@go.modules_find_all_in_dir "$_GO_PLUGINS_DIR/$plugin" "${glob#*/}*"
-
-    else
-      # Otherwise collect all plugin modules and the names of the plugins to
-      # which they belong. Which set gets returned will be decided at the end.
-      for plugin in "$_GO_PLUGINS_DIR"/$glob; do
-        _@go.modules_find_all_in_dir "$plugin"
-        if [[ "${#__go_modules[@]}" -eq '0' ]]; then
-          continue
-        fi
-
-        __go_modules=("${__go_modules[@]#$_GO_PLUGINS_DIR/}")
-        __go_modules=("${__go_modules[@]/\/lib\///}")
-        @go.complete_remove_completions_already_present \
-          'args' '__go_modules' "${#__go_modules[@]}"
-
-        if [[ "${#__go_modules[@]}" -ne '0' ]]; then
-          plugins+=("$plugin/")
-          plugin_modules+=("${__go_modules[@]}")
-          __go_modules=()
-        fi
-      done
-    fi
-  fi
+  @go.search_plugins '_@go.modules_tab_completion_plugins'
 
   # Don't search other dirs if completing a plugin (word contains a '/').
   if [[ ! "$glob" =~ / ]]; then

--- a/libexec/modules
+++ b/libexec/modules
@@ -354,11 +354,15 @@ _@go.modules_list_imported() {
   # Collect imported module info before _GO_USE_MODULES imports possibly more.
   local imported_modules=("${_GO_IMPORTED_MODULES[@]}")
   local imported_files=("${_GO_IMPORTED_MODULE_FILES[@]#$_GO_ROOTDIR/}")
+  local imported_callers=("${_GO_IMPORTED_MODULE_CALLERS[@]#$_GO_ROOTDIR/}")
+  local caller_pad
   local imported_listing=()
 
   . "$_GO_USE_MODULES" 'format'
   @go.pad_items imported_modules "${imported_modules[@]}"
   @go.zip_items imported_modules imported_files '  ' imported_listing
+  printf -v 'caller_pad' -- "\n%$((${#imported_modules[0]} + 4))s" ''
+  @go.zip_items imported_listing imported_callers "$caller_pad" imported_listing
   printf '%s\n' "${imported_listing[@]}"
 }
 

--- a/tests/modules/help.bats
+++ b/tests/modules/help.bats
@@ -4,6 +4,7 @@ load ../environment
 load helpers
 
 setup() {
+  test_filter
   @go.create_test_go_script '@go "$@"'
   setup_test_modules
 }

--- a/tests/modules/helpers.bash
+++ b/tests/modules/helpers.bash
@@ -5,14 +5,14 @@
 CORE_MODULES=()
 CORE_MODULES_PATHS=()
 
+TEST_PROJECT_MODULES=('_frobozz' '_frotz')
+TEST_PROJECT_MODULES_PATHS=()
+
 # We start all the test plugin and module names with '_' to avoid collisions
 # with any potential module names added to the core framework.
 TEST_PLUGINS=('_bar' '_baz' '_foo')
 TEST_PLUGIN_MODULES=(_{bar,baz,foo}/_{plugh,quux,xyzzy})
 TEST_PLUGIN_MODULES_PATHS=()
-
-TEST_PROJECT_MODULES=('_frobozz' '_frotz')
-TEST_PROJECT_MODULES_PATHS=()
 
 TOTAL_NUM_MODULES=0
 
@@ -28,19 +28,19 @@ setup_test_modules() {
     fi
   done
 
-  for module in "${TEST_PLUGIN_MODULES[@]}"; do
-    module_file="$TEST_GO_PLUGINS_DIR/${module/\///lib/}"
-    mkdir -p "${module_file%/*}"
-    printf '# Summary for %s\n' "$module" > "$module_file"
-    TEST_PLUGIN_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
-    ((++TOTAL_NUM_MODULES))
-  done
-
   for module in "${TEST_PROJECT_MODULES[@]}"; do
     module_file="$TEST_GO_SCRIPTS_DIR/lib/$module"
     mkdir -p "${module_file%/*}"
     printf '# Summary for %s\n' "$module" > "$module_file"
     TEST_PROJECT_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
+    ((++TOTAL_NUM_MODULES))
+  done
+
+  for module in "${TEST_PLUGIN_MODULES[@]}"; do
+    module_file="$TEST_GO_PLUGINS_DIR/${module/\///lib/}"
+    mkdir -p "${module_file%/*}"
+    printf '# Summary for %s\n' "$module" > "$module_file"
+    TEST_PLUGIN_MODULES_PATHS+=("${module_file#$TEST_GO_ROOTDIR/}")
     ((++TOTAL_NUM_MODULES))
   done
 }

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -91,11 +91,11 @@ get_first_and_last_core_module_summaries() {
   local expected=('From the core framework library:'
     "${CORE_MODULES[@]/#/  }"
     ''
-    'From the installed plugin libraries:'
-    "${TEST_PLUGIN_MODULES[@]/#/  }"
-    ''
     'From the project library:'
     "${TEST_PROJECT_MODULES[@]/#/  }"
+    ''
+    'From the installed plugin libraries:'
+    "${TEST_PLUGIN_MODULES[@]/#/  }"
   )
 
   run "$TEST_GO_SCRIPT" modules
@@ -104,8 +104,8 @@ get_first_and_last_core_module_summaries() {
 
 @test "$SUITE: list using glob, all modules" {
   local expected=("${CORE_MODULES[@]}"
-    "${TEST_PLUGIN_MODULES[@]}"
     "${TEST_PROJECT_MODULES[@]}"
+    "${TEST_PLUGIN_MODULES[@]}"
   )
 
   run "$TEST_GO_SCRIPT" modules '*'
@@ -138,17 +138,17 @@ get_first_and_last_core_module_summaries() {
   assert_output_matches "  ${CORE_MODULES[0]} +${CORE_MODULES_PATHS[0]}"$'\n'
   assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MODULE_PATH"$'\n\n'
 
+  # Note the padding is relative to only the project modules.
+  assert_output_matches $'  _frobozz  scripts/lib/_frobozz\n'
+  assert_output_matches $'  _frotz    scripts/lib/_frotz\n\n'
+
   # Note the padding is relative to only the plugin modules. Use a variable to
-  # keep the assertion lines under 80 columns.
+  # keep the assertion lines under 80 columns. Bats trims the last newline of
+  # the output.
   local plugins='scripts/plugins'
   assert_output_matches "  _bar/_plugh  $plugins/_bar/lib/_plugh"$'\n'
   assert_output_matches "  _foo/_quux   $plugins/_foo/lib/_quux"$'\n'
-  assert_output_matches "  _foo/_xyzzy  $plugins/_foo/lib/_xyzzy"$'\n\n'
-
-  # Note the padding is relative to only the project modules. Bats trims
-  # the last newline of the output.
-  assert_output_matches $'  _frobozz  scripts/lib/_frobozz\n'
-  assert_output_matches "  _frotz    scripts/lib/_frotz$"
+  assert_output_matches "  _foo/_xyzzy  $plugins/_foo/lib/_xyzzy$"
 
   # Since the 'lines' array doesn't contain blank lines, we only add '3' to
   # account for the 'From the...' line starting each class section.
@@ -167,15 +167,15 @@ get_first_and_last_core_module_summaries() {
   assert_output_matches \
     $'\n'"$LAST_CORE_MODULE  +$LAST_CORE_MODULE_PATH"$'\n'
   assert_output_matches \
+    $'\n_frobozz     +scripts/lib/_frobozz\n'
+  assert_output_matches \
+    $'\n_frotz       +scripts/lib/_frotz\n'
+  assert_output_matches \
     $'\n_bar/_plugh  +scripts/plugins/_bar/lib/_plugh\n'
   assert_output_matches \
     $'\n_foo/_quux   +scripts/plugins/_foo/lib/_quux\n'
   assert_output_matches \
-    $'\n_foo/_xyzzy  +scripts/plugins/_foo/lib/_xyzzy\n'
-  assert_output_matches \
-    $'\n_frobozz     +scripts/lib/_frobozz\n'
-  assert_output_matches \
-    $'\n_frotz       +scripts/lib/_frotz$'
+    $'\n_foo/_xyzzy  +scripts/plugins/_foo/lib/_xyzzy$'
 
   assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
 }
@@ -189,15 +189,15 @@ get_first_and_last_core_module_summaries() {
   assert_output_matches "  ${CORE_MODULES[0]} +$FIRST_CORE_MOD_SUMMARY"$'\n'
   assert_output_matches "  $LAST_CORE_MODULE +$LAST_CORE_MOD_SUMMARY"$'\n\n'
 
-  # Note the padding is relative to only the plugin modules.
+  # Note the padding is relative to only the project modules.
+  assert_output_matches $'  _frobozz  Summary for _frobozz\n'
+  assert_output_matches $'  _frotz    Summary for _frotz\n'
+
+  # Note the padding is relative to only the plugin modules. Bats trims
+  # the last newline of the output.
   assert_output_matches $'  _bar/_plugh  Summary for _bar/_plugh\n'
   assert_output_matches $'  _foo/_quux   Summary for _foo/_quux\n'
-  assert_output_matches $'  _foo/_xyzzy  Summary for _foo/_xyzzy\n\n'
-
-  # Note the padding is relative to only the project modules. Bats trims
-  # the last newline of the output.
-  assert_output_matches $'  _frobozz  Summary for _frobozz\n'
-  assert_output_matches "  _frotz    Summary for _frotz$"
+  assert_output_matches '  _foo/_xyzzy  Summary for _foo/_xyzzy$'
 
   # Since the 'lines' array doesn't contain blank lines, we only add '3' to
   # account for the 'From the...' line starting each class section.
@@ -214,18 +214,18 @@ get_first_and_last_core_module_summaries() {
   get_first_and_last_core_module_summaries
   assert_output_matches "${CORE_MODULES[0]}  +$FIRST_CORE_MOD_SUMMARY"$'\n'
   assert_output_matches "$LAST_CORE_MODULE  +$LAST_CORE_MOD_SUMMARY"$'\n'
+  assert_output_matches $'_frobozz     +Summary for _frobozz\n'
+  assert_output_matches $'_frotz       +Summary for _frotz\n'
   assert_output_matches $'_bar/_plugh  +Summary for _bar/_plugh\n'
   assert_output_matches $'_foo/_quux   +Summary for _foo/_quux\n'
-  assert_output_matches $'_foo/_xyzzy  +Summary for _foo/_xyzzy\n'
-  assert_output_matches $'_frobozz     +Summary for _frobozz\n'
-  assert_output_matches $'_frotz       +Summary for _frotz$'
+  assert_output_matches $'_foo/_xyzzy  +Summary for _foo/_xyzzy$'
 
   assert_equal "$TOTAL_NUM_MODULES" "${#lines[@]}"
 }
 
 @test "$SUITE: list only test modules" {
   run "$TEST_GO_SCRIPT" modules '_*'
-  assert_success "${TEST_PLUGIN_MODULES[@]}" "${TEST_PROJECT_MODULES[@]}"
+  assert_success "${TEST_PROJECT_MODULES[@]}" "${TEST_PLUGIN_MODULES[@]}"
 }
 
 @test "$SUITE: list only test project modules" {

--- a/tests/modules/main.bats
+++ b/tests/modules/main.bats
@@ -66,17 +66,22 @@ get_first_and_last_core_module_summaries() {
 
 @test "$SUITE: --imported" {
   @go.create_test_go_script \
-    '. "$_GO_USE_MODULES" "complete" "_foo/_plugh" "_bar/_quux" "_frotz"' \
+    '. "$_GO_USE_MODULES" "complete" "_foo/_plugh"' \
+    '. "$_GO_USE_MODULES" "_bar/_quux"  "_foo/_plugh"' \
+    '. "$_GO_USE_MODULES" "_frotz"' \
     '@go "$@"'
 
   # The first will be an absolute path because the script's _GO_ROOTDIR doesn't
   # contain the framework sources.
   local expected=(
     "complete     $_GO_ROOTDIR/lib/complete"
+    "               go:3 main"
     "_foo/_plugh  scripts/plugins/_foo/lib/_plugh"
+    "               go:3 main"
     "_bar/_quux   scripts/plugins/_bar/lib/_quux"
+    "               go:4 main"
     "_frotz       scripts/lib/_frotz"
-  )
+    "               go:5 main")
 
   run "$TEST_GO_SCRIPT" modules --imported
   assert_success "${expected[@]}"

--- a/tests/strings/split.bats
+++ b/tests/strings/split.bats
@@ -3,8 +3,18 @@
 load ../environment
 load helpers
 
+setup() {
+  test_filter
+}
+
 teardown() {
   @go.remove_test_go_rootdir
+}
+
+create_split_test_script() {
+  create_strings_test_script 'declare result=()' \
+    "$1" \
+    '[[ "$?" -eq "0" ]] && printf "%s\n" "${result[@]}" "END"'
 }
 
 @test "$SUITE: error if result array name not a valid identifier" {
@@ -19,41 +29,47 @@ teardown() {
 }
 
 @test "$SUITE: empty string" {
-  create_strings_test_script 'declare result=()' \
-    '@go.split "," "" "result"' \
-    'echo "${result[@]}"'
+  create_split_test_script 'result+=('foo') && @go.split "," "" "result"'
   run "$TEST_GO_SCRIPT"
-  assert_success ''
+  assert_success 'END'
 }
 
 @test "$SUITE: single item" {
-  create_strings_test_script 'declare result=()' \
-    '@go.split "," "foo" "result"' \
-    'echo "${result[@]}"'
+  create_split_test_script '@go.split "," "foo" "result"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo'
+  assert_success 'foo' 'END'
 }
 
 @test "$SUITE: multiple items" {
-  create_strings_test_script 'declare result=()' \
-    '@go.split "," "foo,bar,baz" "result"' \
-    'echo "${result[@]}"'
+  create_split_test_script '@go.split "," "foo,bar,baz" "result"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo bar baz'
+  assert_success 'foo' 'bar' 'baz' 'END'
+}
+
+@test "$SUITE: empty delimiter returns original string without splitting" {
+  # This is due to the fact that `IFS=` disables Bash word splitting.
+  create_split_test_script '@go.split "" "foo,bar,baz" "result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo,bar,baz' 'END'
 }
 
 @test "$SUITE: multiple items using ASCII unit separator" {
-  create_strings_test_script 'declare result=()' \
-    "@go.split \$'\x1f' $'foo\x1fbar\x1fbaz' result" \
-    'echo "${result[@]}"'
+  create_split_test_script "@go.split \$'\x1f' $'foo\x1fbar\x1fbaz' result"
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo bar baz'
+  assert_success 'foo' 'bar' 'baz' 'END'
+}
+
+@test "$SUITE: multiple items containing newlines using ASCII unit separator" {
+  create_split_test_script \
+    "@go.split \$'\x1f' $'foo\nquux\x1fbar\nxyzzy\x1fbaz\nplugh' result"
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo' 'quux' 'bar' 'xyzzy' 'baz' 'plugh' 'END'
 }
 
 @test "$SUITE: split items into same variable" {
   create_strings_test_script 'declare items="foo,bar,baz"' \
     '@go.split "," "$items" "items"' \
-    'echo "${items[@]}"'
+    '[[ "$?" -eq "0" ]] && printf "%s\n" "${items[@]}" "END"'
   run "$TEST_GO_SCRIPT"
-  assert_success 'foo bar baz'
+  assert_success 'foo' 'bar' 'baz' 'END'
 }


### PR DESCRIPTION
Part of #150. This is the first step towards updating the output to match _GO_USE_MODULES behavior.

The first two commits are pure refactorings, using functions introduced in #120, updating the usage of `@go.pad_items` and `@go.zip_items`, and extracting a helper function for `./go modules --imported`.

The third commit fixes a latent bug in `@go.split` from the `strings` module wherein items that contained newlines would not split correctly, as the input string would get truncated at the first newline.

I discovered this `@go.split` bug while writing the fourth commit to add `_GO_IMPORTED_MODULE_CALLERS` info to `./go modules --imported`, which I included as a matter of convenience after extracting the helper function in the second commit.

The fifth commit is the actual first step towards #150, whereby the project's local modules are listed before plugin modules. The next step will be to produce separate sections for internal (`_GO_SCRIPTS_DIR/lib`) and public (`_GO_ROOTDIR/lib`) project modules.