### PR TITLE
Small improvements, add `@go.test_compgen`, make `cmd-desc/from-file` test faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.*.swp
-.DS_Store
+# Are your editor's temp files, OS metadata files, etc. showing up in `git
+# status`? Try adding them to `$HOME/.config/git/ignore` instead.
 tests/bats/
 tests/coverage/
 tests/kcov/

--- a/go-core.bash
+++ b/go-core.bash
@@ -112,6 +112,9 @@ declare _GO_IMPORTED_MODULE_CALLERS=()
 # Path to the project's script directory
 declare _GO_SCRIPTS_DIR=
 
+# Directory containing Bats tests, relative to `_GO_ROOTDIR`
+declare -r -x _GO_TEST_DIR="${_GO_TEST_DIR:-tests}"
+
 # Path to the main ./go script in the project's root directory
 declare -r -x _GO_SCRIPT="$_GO_ROOTDIR/${0##*/}"
 

--- a/lib/bats-main
+++ b/lib/bats-main
@@ -40,9 +40,6 @@
 # make the Bats repository a submodule if so desired. The Bats version so cloned
 # may be set by overriding `_GO_BATS_VERSION`.
 
-# Directory containing Bats tests, relative to `_GO_ROOTDIR`
-export _GO_TEST_DIR="${_GO_TEST_DIR:-tests}"
-
 # Directory in which kcov will be built
 export _GO_KCOV_DIR="${_GO_KCOV_DIR:-$_GO_TEST_DIR/kcov}"
 

--- a/lib/complete
+++ b/lib/complete
@@ -15,7 +15,7 @@
 # `-f` or `-d` options to generate file or directory paths.
 #
 # Arguments:
-#   ...:  Arguments passed directly ot the builtin `compgen`
+#   ...:  Arguments passed directly to the builtin `compgen`
 @go.compgen() {
   local add_slashes
   local compreply=()

--- a/lib/testing/environment
+++ b/lib/testing/environment
@@ -108,3 +108,19 @@ test-go() {
     @go.create_test_command_script "$parent.d/$subcommand"
   done
 }
+
+# Assigns the results of `@go.compgen` to a caller-defined test data array
+#
+# While more compact than writing a `while` loop by hand, it's also faster
+# thanks to the fact that it disables the Bats function tracing mechanism.
+#
+# Arguments:
+#   result:  Name of the caller-declared output array
+#   ...:     Arguments passed directly to `@go.compgen`
+@go.test_compgen() {
+  . "$_GO_CORE_DIR/lib/bats/assertions"
+  set "$BATS_ASSERTION_DISABLE_SHELL_OPTIONS"
+  . "$_GO_USE_MODULES" 'complete' 'strings'
+  @go.split $'\n' "$(@go.compgen "${@:2}")" "$1"
+  return_from_bats_assertion
+}

--- a/lib/testing/stack-trace-item
+++ b/lib/testing/stack-trace-item
@@ -5,8 +5,6 @@
 # DO NOT USE THIS FILE DIRECTLY! Source `_GO_CORE_DIR/lib/testing/stack-trace`
 # and use the `stack_trace_item` function instead.
 
-. "$_GO_CORE_DIR/lib/bats/helpers"
-
 __@go.stack_trace_item() {
   local filepath="$1"
   local function_name="$2"

--- a/scripts/test
+++ b/scripts/test
@@ -26,7 +26,8 @@
 # Passes all arguments through to `@go.bats_main` from `lib/bats-main`.
 _test_main() {
   local _GO_BATS_COVERAGE_INCLUDE
-  _GO_BATS_COVERAGE_INCLUDE=('go' 'go-core.bash' 'lib/' 'libexec/' 'scripts/')
+  _GO_BATS_COVERAGE_INCLUDE=('go' 'go-core.bash' 'go-template'
+    'lib/' 'libexec/' 'scripts/')
   local _GO_COVERALLS_URL='https://coveralls.io/github/mbland/go-script-bash'
 
   . "$_GO_USE_MODULES" 'bats-main'

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -70,7 +70,7 @@ teardown() {
 
   while IFS= read -r item; do
     expected+=("${item#$TEST_GO_ROOTDIR/}")
-  done<<<"$(@go.compgen -d "$TEST_GO_SCRIPTS_DIR/")"
+  done < <(@go.compgen -d "$TEST_GO_SCRIPTS_DIR/")
 
   run "$TEST_GO_SCRIPT" complete 1 cd 'scripts/'
   assert_success "${expected[@]}"
@@ -85,16 +85,12 @@ teardown() {
   touch "${files[@]/#/$TEST_GO_SCRIPTS_DIR/}"
 
   local top_level=()
+  @go.test_compgen top_level -f "$TEST_GO_ROOTDIR/"
+  top_level=("${top_level[@]#$TEST_GO_ROOTDIR/}")
+
   local all_scripts_entries=()
-  local item
-
-  while IFS= read -r item; do
-    top_level+=("${item#$TEST_GO_ROOTDIR/}")
-  done <<<"$(@go.compgen -f "$TEST_GO_ROOTDIR/")"
-
-  while IFS= read -r item; do
-    all_scripts_entries+=("${item#$TEST_GO_ROOTDIR/}")
-  done <<<"$(@go.compgen -f "$TEST_GO_SCRIPTS_DIR/")"
+  @go.test_compgen all_scripts_entries -f "$TEST_GO_SCRIPTS_DIR/"
+  all_scripts_entries=("${all_scripts_entries[@]#$TEST_GO_ROOTDIR/}")
 
   run "$TEST_GO_SCRIPT" complete 1 edit ''
   assert_success "${top_level[@]}"

--- a/tests/get/file.bats
+++ b/tests/get/file.bats
@@ -26,12 +26,7 @@ teardown() {
   assert_success '-f'
 
   local expected=()
-  local item
-
-  . "$_GO_USE_MODULES" 'complete'
-  while IFS= read -r item; do
-    expected+=("$item")
-  done <<<"$(@go.compgen -f -- "$TEST_GO_ROOTDIR/")"
+  @go.test_compgen expected -f -- "$TEST_GO_ROOTDIR/"
 
   run "$TEST_GO_SCRIPT" get file --complete 1 -f
   assert_success "${expected[@]#$TEST_GO_ROOTDIR/}"

--- a/tests/get/git-repo.bats
+++ b/tests/get/git-repo.bats
@@ -24,10 +24,8 @@ teardown() {
   run "$TEST_GO_SCRIPT" get git-repo --complete 1
   assert_success ''
 
-  . "$_GO_USE_MODULES" 'complete'
-  while IFS= read -r item; do
-    expected+=("$item")
-  done <<<"$(@go.compgen -f -- "$TEST_GO_ROOTDIR/")"
+  local expected=()
+  @go.test_compgen expected -f -- "$TEST_GO_ROOTDIR/"
 
   run "$TEST_GO_SCRIPT" get git-repo --complete 2
   assert_success "${expected[@]#$TEST_GO_ROOTDIR/}"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -118,7 +118,7 @@ write_bats_dummy_stub_kcov_lib_and_copy_test_script() {
   local expected_kcov_args=(
     'tests/kcov'
     'tests/coverage'
-    'go,go-core.bash,lib/,libexec/,scripts/'
+    'go,go-core.bash,go-template,lib/,libexec/,scripts/'
     '/tmp/,tests/bats/'
     'https://coveralls.io/github/mbland/go-script-bash'
     "$TEST_GO_SCRIPT"

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -55,7 +55,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
-    "declare -x _GO_TEST_DIR=\"$_GO_TEST_DIR\""
+    "declare -rx _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
@@ -127,7 +127,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
-    "declare -x _GO_TEST_DIR=\"$_GO_TEST_DIR\""
+    "declare -rx _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected


### PR DESCRIPTION
This was all done during the course of preparing an implementation of `./go new` to address #142. Of particular note:

- a tweak to `.gitignore` encouraging the use of `$HOME/.config/git/ignore`
- the addition of `@go.test_compgen` to `lib/testing/environment`
- the spawning of issue #156 
- the vast improvement in performance of the `command-descriptions/from-file` test

See the commit messages for details and timing examples.