### PR TITLE
go-template: Fix test coverage, improve comments

### DIFF
--- a/go-template
+++ b/go-template
@@ -16,40 +16,44 @@
 # your project or check in a versioned copy of the sources. See the "How to use
 # this framework" section of `README.md` for details.
 #
-# Make sure the `_GO_STANDALONE`, `SCRIPTS_DIR`, and `GO_SCRIPT_BASH_VERSION`
-# variables within this script are configured as necessary for your program.
-# You can also add any other initialization or configuration logic between:
+# Make sure the variables within this script are configured as necessary for
+# your program. You can add any other initialization or configuration between:
 #
-#   . "$_GO_SCRIPT_BASH_CORE" "${SCRIPTS_DIR##*/}"`
+#   . "$_GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"`
 #   `@go "$@"`
 
-# Set `_GO_STANDALONE='true'` if your program isn't a project-specific script.
-readonly _GO_STANDALONE=
+# Set to 'true' if your script is a standalone program, i.e. not bound to
+# execute only from the directory in which it resides. See the "Standalone mode"
+# section in README.md.
+export _GO_STANDALONE=
 
-# Set SCRIPTS_DIR to the path where your command scripts reside.
+# The path where your command scripts reside
 #
 # For `_GO_STANDALONE` programs and plugins containing command scripts, you may
-# wish to set SCRIPTS_DIR to end with `bin` and have a separate `./go` script to
+# wish to set GO_SCRIPTS_DIR to `bin` and have a separate `./go` script to
 # manage project tasks that finds its command scripts in `scripts`.
-readonly SCRIPTS_DIR="${0%/*}/scripts"
+declare GO_SCRIPTS_DIR="${GO_SCRIPTS_DIR:-scripts}"
 
-# Set this to the `GO_SCRIPT_BASH_REPO_URL` tag or branch you wish to use.
-readonly GO_SCRIPT_BASH_VERSION='v1.3.0'
+# The `GO_SCRIPT_BASH_REPO_URL` tag or branch you wish to use
+declare GO_SCRIPT_BASH_VERSION="${GO_SCRIPT_BASH_VERSION:-v1.3.0}"
 
-readonly GO_SCRIPT_BASH_CORE="$SCRIPTS_DIR/go-script-bash/go-core.bash"
-readonly GO_SCRIPT_BASH_REPO_URL='https://github.com/mbland/go-script-bash.git'
+# The go-script-bash installation directory within your project
+declare GO_SCRIPT_BASH_CORE_DIR="${GO_SCRIPT_BASH_CORE_DIR:-${0%/*}/$GO_SCRIPTS_DIR/go-script-bash}"
 
-if [[ ! -e "$GO_SCRIPT_BASH_CORE" ]]; then
+# The URL of the go-script-bash framework sources
+declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/mbland/go-script-bash.git}"
+
+if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
   printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
   if ! git clone --depth 1 -c advice.detachedHead=false \
       -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
-      "${GO_SCRIPT_BASH_CORE%/*}"; then
+      "$GO_SCRIPT_BASH_CORE_DIR"; then
     printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
     exit 1
   fi
   printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
 fi
 
-. "$GO_SCRIPT_BASH_CORE" "${SCRIPTS_DIR##*/}"
+. "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"
 # Add any other configuration or initialization steps here.
 @go "$@"

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -24,38 +24,27 @@ GO_CORE_URL="${GO_CORE_URL:-$_GO_CORE_DIR}"
 
 setup() {
   test_filter
-  mkdir "$TEST_GO_ROOTDIR"
-
-  if [[ -e "$GO_CORE_URL/.git/shallow" ]]; then
-    skip "Can't clone shallow repositories"
-  fi
+  export GO_SCRIPT_BASH_VERSION="$_GO_CORE_VERSION"
+  export GO_SCRIPTS_DIR="$_GO_TEST_DIR/tmp/go-template-test-scripts"
+  export GO_SCRIPT_BASH_REPO_URL="$GO_CORE_URL"
 }
 
 teardown() {
-  @go.remove_test_go_rootdir
+  rm -rf "$_GO_ROOTDIR/$GO_SCRIPTS_DIR"
 }
 
-create_template_script() {
-  local repo_url="$1"
-  local version="$2"
-  local template="$(< "$_GO_CORE_DIR/go-template")"
-  local replacement
-
-  if [[ "$template" =~ GO_SCRIPT_BASH_REPO_URL=[^$'\n']+ ]]; then
-    replacement="GO_SCRIPT_BASH_REPO_URL='$repo_url'"
-    template="${template/${BASH_REMATCH[0]}/$replacement}"
-  fi
-  if [[ "$template" =~ GO_SCRIPT_BASH_VERSION=[^$'\n']+ ]]; then
-    replacement="GO_SCRIPT_BASH_VERSION='$version'"
-    template="${template/${BASH_REMATCH[0]}/$replacement}"
-  fi
-  printf '%s\n' "$template" > "$TEST_GO_ROOTDIR/go-template"
-  chmod 700 "$TEST_GO_ROOTDIR/go-template"
+@test "$SUITE: successfully run 'help' from its own directory" {
+  GO_SCRIPT_BASH_CORE_DIR="$_GO_CORE_DIR" GO_SCRIPTS_DIR='scripts' \
+    run "$_GO_CORE_DIR/go-template" 'help'
+  assert_success
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
 }
 
 @test "$SUITE: clone the go-script-bash repository from $GO_CORE_URL" {
-  create_template_script "$GO_CORE_URL" "$_GO_CORE_VERSION"
-  run "$TEST_GO_ROOTDIR/go-template"
+  if [[ -e "$GO_CORE_URL/.git/shallow" ]]; then
+    skip "Can't clone shallow repositories"
+  fi
+  run "$_GO_CORE_DIR/go-template"
 
   # Without a command argument, the script will print the top-level help and
   # return an error, but the core repo should exist as expected.
@@ -64,20 +53,20 @@ create_template_script() {
 
   # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
   # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
-  assert_output_matches "Cloning into '.*/scripts/go-script-bash'\.\.\."
+  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
   assert_output_matches "Clone of '$GO_CORE_URL' successful\."$'\n\n'
-  assert_output_matches "Usage: $TEST_GO_ROOTDIR/go-template <command>"
-  [[ -f "$TEST_GO_ROOTDIR/scripts/go-script-bash/go-core.bash" ]]
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
+  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
 
-  cd "$TEST_GO_ROOTDIR/scripts/go-script-bash"
+  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
   run git log --oneline -n 1
   assert_success
   assert_output_matches "go-script-bash $_GO_CORE_VERSION"
 }
 
 @test "$SUITE: fail to clone a nonexistent repo" {
-  create_template_script 'bogus-repo-that-does-not-exist'
-  run "$TEST_GO_ROOTDIR/go-template"
+  GO_SCRIPT_BASH_REPO_URL='bogus-repo-that-does-not-exist' \
+    run "$_GO_CORE_DIR/go-template"
   assert_failure "Cloning framework from 'bogus-repo-that-does-not-exist'..." \
     "fatal: repository 'bogus-repo-that-does-not-exist' does not exist" \
     "Failed to clone 'bogus-repo-that-does-not-exist'; aborting."


### PR DESCRIPTION
Not only does coverage collection work as advertised now, but the test is less hacky, and the changes to the `go-template` code make it more flexible/less fragile and more powerful in general.