### PR TITLE
Multiple small test optimizations based on `lib/bats/helper-function`

### DIFF
--- a/lib/bats/helper-function
+++ b/lib/bats/helper-function
@@ -52,14 +52,15 @@ restore_bats_shell_options() {
   local result="${1:-0}"
   local target_stack_item_pattern=" ${FUNCNAME[1]} ${BASH_SOURCE[1]}$"
 
-  # After removing our caller from BATS_CURRENT_STACK_TRACE and restoring the
-  # Bats shell options, the `return` call at the end of the function will fire
-  # `bats_debug_trap`, which sets BATS_CURRENT_STACK_TRACE to
-  # BATS_PREVIOUS_STACK_TRACE.
-  #
-  # If `result` is nonzero, `bats_error_trap` will fire and set
-  # BATS_ERROR_STACK_TRACE to BATS_PREVIOUS_STACK_TRACE and fail the test.
   if [[ "${BATS_CURRENT_STACK_TRACE[0]}" =~ $target_stack_item_pattern ]]; then
+    # After removing our caller from BATS_CURRENT_STACK_TRACE and restoring the
+    # Bats shell options, the `return` call at the end of the function will fire
+    # `bats_debug_trap`, which sets BATS_CURRENT_STACK_TRACE to
+    # BATS_PREVIOUS_STACK_TRACE.
+    #
+    # Then, if `result` is nonzero, `return` will fire `bats_error_trap`, which
+    # sets BATS_ERROR_STACK_TRACE to BATS_PREVIOUS_STACK_TRACE, and the error
+    # response will fail the test.
     unset 'BATS_CURRENT_STACK_TRACE[0]'
     set -eET
   fi

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -41,6 +41,8 @@
 # This is good practice even if you call `remove_bats_test_dirs` in your
 # `environment.bash` file.
 
+. "${BASH_SOURCE%/*}/helper-function"
+
 # A subdirectory of BATS_TMPDIR that contains a space.
 #
 # Using this path instead of BATS_TMPDIR directly helps ensure that shell
@@ -61,8 +63,9 @@ BATS_TEST_BINDIR="$BATS_TEST_ROOTDIR/bin"
 # Arguments:
 #   $1:  Path to the project's top-level test directory
 set_bats_test_suite_name() {
-  local test_rootdir="$(cd "$1" && echo "$PWD")"
-  local relative_filename="${BATS_TEST_FILENAME#$test_rootdir/}"
+  cd "$1"
+  local relative_filename="${BATS_TEST_FILENAME#$PWD/}"
+  cd - &>/dev/null
   readonly SUITE="${relative_filename%.bats}"
 }
 
@@ -74,18 +77,9 @@ set_bats_test_suite_name() {
 # Arguments:
 #   $@:  Paths of subdirectories relative to BATS_TEST_ROOTDIR
 create_bats_test_dirs() {
-  local dirs_to_create=()
-  local test_dir
-
-  for test_dir in "${@/#/$BATS_TEST_ROOTDIR/}"; do
-    if [[ ! -d "$test_dir" ]]; then
-      dirs_to_create+=("$test_dir")
-    fi
-  done
-
-  if [[ "${#dirs_to_create[@]}" -ne '0' ]]; then
-    mkdir -p "${dirs_to_create[@]}"
-  fi
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __create_bats_test_dirs "$@"
+  restore_bats_shell_options "$?"
 }
 
 # Creates a test script relative to BATS_TEST_ROOTDIR
@@ -100,26 +94,9 @@ create_bats_test_dirs() {
 #   $1:   Path of the script relative to BATS_TEST_ROOTDIR
 #   ...:  Lines comprising the script
 create_bats_test_script() {
-  local script="$1"
-  shift
-  local script_dir="${script%/*}"
-
-  if [[ -z "$script" ]]; then
-    echo "No test script specified" >&2
-    exit 1
-  elif [[ "$script_dir" == "$script" ]]; then
-    script_dir=''
-  fi
-
-  create_bats_test_dirs "$script_dir"
-  script="$BATS_TEST_ROOTDIR/$script"
-  rm -f "$script"
-
-  if [[ "${1:0:2}" != '#!' ]]; then
-    echo "#! /usr/bin/env bash" >"$script"
-  fi
-  printf '%s\n' "$@" >>"$script"
-  chmod 700 "$script"
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __create_bats_test_script "$@"
+  restore_bats_shell_options "$?"
 }
 
 # Recursively removes `BATS_TEST_ROOTDIR` and its subdirectories
@@ -183,18 +160,15 @@ skip_if_cannot_trigger_file_permission_failure() {
 # Arguments:
 #   ...:  System programs that must be present for the test case to proceed
 skip_if_system_missing() {
-  local missing=()
-  local program
+  local __missing=()
 
-  for program in "$@"; do
-    if ! command -v "$program" >/dev/null; then
-      missing+=("$program")
-    fi
-  done
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __search_for_missing_programs "$@"
+  restore_bats_shell_options "$?"
 
-  if [[ "${#missing[@]}" -ne '0' ]]; then
-    printf -v missing '%s, ' "${missing[@]}"
-    skip "${missing%, } not installed on the system"
+  if [[ "${#__missing[@]}" -ne '0' ]]; then
+    printf -v __missing '%s, ' "${__missing[@]}"
+    skip "${__missing%, } not installed on the system"
   fi
 }
 
@@ -311,12 +285,9 @@ test_filter() {
 # compare the exact lines of `output` using `assert_lines_equal` and other
 # `lines`-based assertions.
 split_bats_output_into_lines() {
-  local line
-  lines=()
-
-  while IFS= read -r line; do
-    lines+=("${line%$'\r'}")
-  done <<<"$output"
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __split_bats_output_into_lines
+  restore_bats_shell_options "$?"
 }
 
 # Creates a stub program in PATH for testing purposes
@@ -334,4 +305,81 @@ stub_program_in_path() {
     export PATH="$BATS_TEST_BINDIR:$PATH"
   fi
   create_bats_test_script "${BATS_TEST_BINDIR#$BATS_TEST_ROOTDIR/}/$1" "${@:2}"
+}
+
+# --------------------------------
+# IMPLEMENTATION - HERE BE DRAGONS
+#
+# None of the functions below this line are part of the public interface.
+# --------------------------------
+
+# Implementation for `create_bats_test_dirs`
+#
+# Arguments:
+#   $@:  Paths of subdirectories relative to BATS_TEST_ROOTDIR
+__create_bats_test_dirs() {
+  local dirs_to_create=()
+  local test_dir
+
+  for test_dir in "${@/#/$BATS_TEST_ROOTDIR/}"; do
+    if [[ ! -d "$test_dir" ]]; then
+      dirs_to_create+=("$test_dir")
+    fi
+  done
+
+  if [[ "${#dirs_to_create[@]}" -ne '0' ]]; then
+    mkdir -p "${dirs_to_create[@]}"
+  fi
+}
+
+# Implementation for `create_bats_test_script`
+#
+# Arguments:
+#   $1:   Path of the script relative to BATS_TEST_ROOTDIR
+#   ...:  Lines comprising the script
+__create_bats_test_script() {
+  local script="$1"
+  shift
+  local script_dir="${script%/*}"
+
+  if [[ -z "$script" ]]; then
+    echo "No test script specified" >&2
+    exit 1
+  elif [[ "$script_dir" == "$script" ]]; then
+    script_dir=''
+  fi
+
+  create_bats_test_dirs "$script_dir"
+  script="$BATS_TEST_ROOTDIR/$script"
+  rm -f "$script"
+
+  if [[ "${1:0:2}" != '#!' ]]; then
+    echo "#! /usr/bin/env bash" >"$script"
+  fi
+  printf '%s\n' "$@" >>"$script"
+  chmod 700 "$script"
+}
+
+# Enumerates programs not installed on the system for `skip_if_system_missing`
+#
+# Arguments:
+#   ...:  System programs that must be present for the test case to proceed
+__search_for_missing_programs() {
+  local program
+
+  for program in "$@"; do
+    if ! command -v "$program" >/dev/null; then
+      __missing+=("$program")
+    fi
+  done
+}
+
+# Implementation for `split_bats_output_into_lines`
+__split_bats_output_into_lines() {
+  local line
+  lines=()
+
+  while IFS= read -r line; do
+    lines+=("${line%$'\r'}")
+  done <<<"$output"
 }

--- a/lib/testing/environment
+++ b/lib/testing/environment
@@ -106,15 +106,7 @@ test-go() {
 #   ...:          Names of "child" command scripts
 @go.create_parent_and_subcommands() {
   set "$DISABLE_BATS_SHELL_OPTIONS"
-  local parent="$1"
-  shift
-  local subcommand
-
-  @go.create_test_command_script "$parent"
-
-  for subcommand in "$@"; do
-    @go.create_test_command_script "$parent.d/$subcommand"
-  done
+  __@go.create_parent_and_subcommands "$@"
   restore_bats_shell_options "$?"
 }
 
@@ -131,4 +123,27 @@ test-go() {
   . "$_GO_USE_MODULES" 'complete' 'strings'
   @go.split $'\n' "$(@go.compgen "${@:2}")" "$1"
   restore_bats_shell_options "$?"
+}
+
+# --------------------------------
+# IMPLEMENTATION - HERE BE DRAGONS
+#
+# None of the functions below this line are part of the public interface.
+# --------------------------------
+
+# Implementation for `@go.create_parent_and_subcommands`
+#
+# Arguments:
+#   parent_name:  Name of the "parent" command script
+#   ...:          Names of "child" command scripts
+__@go.create_parent_and_subcommands() {
+  local parent="$1"
+  shift
+  local subcommand
+
+  @go.create_test_command_script "$parent"
+
+  for subcommand in "$@"; do
+    @go.create_test_command_script "$parent.d/$subcommand"
+  done
 }

--- a/lib/testing/stubbing
+++ b/lib/testing/stubbing
@@ -11,6 +11,8 @@
 # You must import `_GO_CORE_DIR/lib/testing/environment` before importing this
 # script, and make sure to call `@go.remove_test_go_rootdir` from `teardown`.
 
+. "$_GO_CORE_DIR/lib/bats/helper-function"
+
 export _GO_INJECT_SEARCH_PATH="$TEST_GO_ROOTDIR/test-bin"
 export _GO_INJECT_MODULE_PATH="$TEST_GO_ROOTDIR/test-lib"
 
@@ -20,8 +22,10 @@ export _GO_INJECT_MODULE_PATH="$TEST_GO_ROOTDIR/test-lib"
 #   module_name:  Name of the command script to stub
 #   ...:          Lines comprising the stubbed command script implementation
 @go.create_command_script_test_stub() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   local script_path="$_GO_INJECT_SEARCH_PATH/$1"
   create_bats_test_script "${script_path#$BATS_TEST_ROOTDIR/}" "${@:2}"
+  restore_bats_shell_options "$?"
 }
 
 # Creates a stub module implementation in `_GO_INJECT_MODULE_PATH`
@@ -30,7 +34,9 @@ export _GO_INJECT_MODULE_PATH="$TEST_GO_ROOTDIR/test-lib"
 #   module_name:  Name of the module to stub
 #   ...:          Lines comprising the stubbed module implementation
 @go.create_module_test_stub() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   local module_path="$_GO_INJECT_MODULE_PATH/$1"
   create_bats_test_script "${module_path#$BATS_TEST_ROOTDIR/}" "${@:2}"
   chmod 600 "$module_path"
+  restore_bats_shell_options "$?"
 }

--- a/tests/assertion-test-helpers.bats
+++ b/tests/assertion-test-helpers.bats
@@ -24,6 +24,13 @@ emit_debug_info() {
 }
 
 run_assertion_test() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  setup_assertion_test "$@"
+  restore_bats_shell_options
+  run "$BATS_TEST_ROOTDIR/$EXPECT_ASSERTION_TEST_SCRIPT"
+}
+
+setup_assertion_test() {
   local expected_output=("${@:2}")
   local expected_output_line
 
@@ -43,11 +50,15 @@ run_assertion_test() {
     "@test \"$BATS_TEST_DESCRIPTION\" {" \
     "  $ASSERTION" \
     '}'
-  run "$BATS_TEST_ROOTDIR/$EXPECT_ASSERTION_TEST_SCRIPT"
 }
 
 check_failure_output() {
-  set +eET
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __check_failure_output "$@"
+  restore_bats_shell_options "$?"
+}
+
+__check_failure_output() {
   local test_script="$BATS_TEST_ROOTDIR/$EXPECT_ASSERTION_TEST_SCRIPT"
   local assertion_line="${ASSERTION%%$'\n'*}"
   local expected_output
@@ -69,7 +80,6 @@ check_failure_output() {
     result='1'
   fi
   unset 'BATS_CURRENT_STACK_TRACE[0]' 'BATS_PREVIOUS_STACK_TRACE[0]'
-  set -eET
   return "$result"
 }
 

--- a/tests/commands/helpers.bash
+++ b/tests/commands/helpers.bash
@@ -7,6 +7,12 @@ declare BUILTIN_SCRIPTS
 declare LONGEST_BUILTIN_NAME
 
 find_builtins() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __find_builtins
+  restore_bats_shell_options "$?"
+}
+
+__find_builtins() {
   local cmd_script
   local cmd_name
 
@@ -25,6 +31,12 @@ find_builtins() {
 }
 
 merge_scripts() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __merge_scripts "$@"
+  restore_bats_shell_options "$?"
+}
+
+__merge_scripts() {
   local args=("$@")
   local i=0
   local j=0
@@ -53,6 +65,12 @@ merge_scripts() {
 }
 
 add_scripts() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __add_scripts "$@"
+  restore_bats_shell_options "$?"
+}
+
+__add_scripts() {
   local script_names=("$@")
 
   merge_scripts "${script_names[@]/#/$TEST_GO_SCRIPTS_DIR/}"

--- a/tests/commands/main.bats
+++ b/tests/commands/main.bats
@@ -46,22 +46,18 @@ teardown() {
 }
 
 @test "$SUITE: tab complete subcommand" {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   @go.create_test_command_script 'foo'
-  mkdir "$TEST_GO_SCRIPTS_DIR/foo.d"
-
-  local expected=('bar' 'baz' 'quux')
-  local subcommand
-
-  for subcommand in "${expected[@]}"; do
-    @go.create_test_command_script "foo.d/$subcommand"
-  done
+  @go.create_test_command_script 'foo.d/bar'
+  @go.create_test_command_script 'foo.d/baz'
+  @go.create_test_command_script 'foo.d/quux'
+  restore_bats_shell_options "$?"
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo
-  assert_success "${expected[@]}"
+  assert_success 'bar' 'baz' 'quux'
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo b
-  expected=('bar' 'baz')
-  assert_success "${expected[@]}"
+  assert_success 'bar' 'baz'
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo g
   assert_failure
@@ -71,19 +67,15 @@ teardown() {
 }
 
 @test "$SUITE: only tab complete flags before other args" {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   @go.create_test_command_script 'foo'
-  mkdir "$TEST_GO_SCRIPTS_DIR/foo.d"
-
-  local subcommands=('bar' 'baz' 'quux')
-  local subcommand
-
-  for subcommand in "${subcommands[@]}"; do
-    @go.create_test_command_script "foo.d/$subcommand"
-  done
+  @go.create_test_command_script 'foo.d/bar'
+  @go.create_test_command_script 'foo.d/baz'
+  @go.create_test_command_script 'foo.d/quux'
+  restore_bats_shell_options "$?"
 
   run "$TEST_GO_SCRIPT" complete 1 commands '' foo
-  expected=('--paths' '--summaries')
-  assert_success "${expected[@]}"
+  assert_success '--paths' '--summaries'
 
   run "$TEST_GO_SCRIPT" complete 2 commands foo '' bar
   assert_failure
@@ -228,18 +220,16 @@ create_script_with_description() {
 }
 
 @test "$SUITE: command summaries" {
-  local user_commands=('bar' 'baz' 'foo')
-
-  for cmd_name in "${user_commands[@]}"; do
-    create_script_with_description "$cmd_name"
-  done
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  create_script_with_description 'foo'
+  create_script_with_description 'bar'
+  create_script_with_description 'baz'
+  restore_bats_shell_options "$?"
 
   run "$TEST_GO_SCRIPT" commands --summaries "$TEST_GO_SCRIPTS_DIR"
-  local expected=(
-    '  bar  Does bar stuff'
-    '  baz  Does baz stuff'
-    '  foo  Does foo stuff')
-  assert_success "${expected[@]}"
+  assert_success '  bar  Does bar stuff' \
+    '  baz  Does baz stuff' \
+    '  foo  Does foo stuff'
 }
 
 create_top_level_and_subcommand_scripts() {

--- a/tests/commands/main.bats
+++ b/tests/commands/main.bats
@@ -160,6 +160,12 @@ teardown() {
 }
 
 generate_expected_paths() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __generate_expected_paths
+  restore_bats_shell_options "$?"
+}
+
+__generate_expected_paths() {
   local script
   local cmd_name
   local longest_cmd_name_len
@@ -236,9 +242,7 @@ create_script_with_description() {
   assert_success "${expected[@]}"
 }
 
-@test "$SUITE: subcommand list, paths, and summaries" {
-  local top_level_commands=('bar' 'baz' 'foo')
-  local subcommands=('plugh' 'quux' 'xyzzy')
+create_top_level_and_subcommand_scripts() {
   local cmd_name
   local subcmd_dir
   local subcmd_name
@@ -252,6 +256,15 @@ create_script_with_description() {
       create_script_with_description "$cmd_name.d/$subcmd_name"
     done
   done
+}
+
+@test "$SUITE: subcommand list, paths, and summaries" {
+  local top_level_commands=('bar' 'baz' 'foo')
+  local subcommands=('plugh' 'quux' 'xyzzy')
+
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  create_top_level_and_subcommand_scripts
+  restore_bats_shell_options "$?"
 
   run "$TEST_GO_SCRIPT" commands 'foo'
   assert_success "${subcommands[@]}"

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -2,12 +2,12 @@
 
 load environment
 load commands/helpers
+. "$_GO_USE_MODULES" 'complete'
 
 setup() {
   test_filter
   @go.create_test_go_script '@go "$@"'
   find_builtins
-  . "$_GO_USE_MODULES" 'complete'
 }
 
 teardown() {

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -66,11 +66,8 @@ teardown() {
   assert_success 'scripts/'
 
   local expected=()
-  local item
-
-  while IFS= read -r item; do
-    expected+=("${item#$TEST_GO_ROOTDIR/}")
-  done < <(@go.compgen -d "$TEST_GO_SCRIPTS_DIR/")
+  @go.test_compgen expected -d "$TEST_GO_SCRIPTS_DIR/"
+  expected=("${expected[@]#$TEST_GO_ROOTDIR/}")
 
   run "$TEST_GO_SCRIPT" complete 1 cd 'scripts/'
   assert_success "${expected[@]}"

--- a/tests/complete/compgen.bats
+++ b/tests/complete/compgen.bats
@@ -58,17 +58,23 @@ teardown() {
   assert_success "${expected[@]/%//}"
 }
 
-@test "$SUITE: adds trailing slashes when called with -f" {
-  mkdir -p "${TEST_GO_ROOTDIR}"/{foo,bar,baz}
-  run "$TEST_GO_SCRIPT" -f -- ''
-
-  # Remember that `compgen` won't add trailing slashes by itself.
-  local expected=($(cd "$TEST_GO_ROOTDIR"; compgen -f -- ''))
+add_trailing_slashes() {
   local i
   for ((i=0; i != "${#expected[@]}"; ++i)); do
     if [[ -d "$TEST_GO_ROOTDIR/${expected[$i]}" ]]; then
       expected[$i]+='/'
     fi
   done
+}
+
+@test "$SUITE: adds trailing slashes when called with -f" {
+  mkdir -p "${TEST_GO_ROOTDIR}"/{foo,bar,baz}
+  run "$TEST_GO_SCRIPT" -f -- ''
+
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  # Remember that `compgen` won't add trailing slashes by itself.
+  local expected=($(cd "$TEST_GO_ROOTDIR"; compgen -f -- ''))
+  add_trailing_slashes
+  restore_bats_shell_options "$?"
   assert_success "${expected[@]}"
 }

--- a/tests/fullpath.bats
+++ b/tests/fullpath.bats
@@ -11,17 +11,16 @@ teardown() {
 }
 
 @test "$SUITE: tab completions" {
-  . "$_GO_USE_MODULES" 'complete'
-  local expected=('--existing')
-  expected+=($(@go.compgen -f))
+  local expected=()
+  @go.test_compgen expected -f
 
   run ./go complete 1 fullpath ''
-  assert_success "${expected[@]}"
+  assert_success '--existing' "${expected[@]}"
 
   run ./go complete 1 fullpath '-'
   assert_success '--existing '
 
-  expected=($(@go.compgen -f -- 'li'))
+  @go.test_compgen expected -f -- 'li'
   fail_if equal '0' "${#expected[@]}"
   run ./go complete 1 fullpath 'li'
   assert_success "${expected[@]}"

--- a/tests/glob/arg-completion.bats
+++ b/tests/glob/arg-completion.bats
@@ -1,13 +1,13 @@
 #! /usr/bin/env bats
 
 load ../environment
+. "$_GO_USE_MODULES" 'complete'
 
 TESTS_DIR="$TEST_GO_ROOTDIR/tests"
 
 setup() {
   test_filter
   mkdir -p "$TESTS_DIR"
-  . "$_GO_USE_MODULES" 'complete'
 }
 
 teardown() {

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -22,7 +22,16 @@ KCOV_ARGV_START=(
 
 setup() {
   test_filter
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  setup_fake_binaries
+  restore_bats_shell_options "$?"
+}
 
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+setup_fake_binaries() {
   local fake_binaries=(
     'apt-get'
     'cmake'
@@ -36,10 +45,6 @@ setup() {
     stub_program_in_path "$fake_binary" \
       'echo "$@" >"$0.out" 2>&1'
   done
-}
-
-teardown() {
-  @go.remove_test_go_rootdir
 }
 
 write_kcov_go_script() {

--- a/tests/modules/helpers.bash
+++ b/tests/modules/helpers.bash
@@ -20,6 +20,12 @@ TEST_PLUGIN_MODULES_PATHS=()
 TOTAL_NUM_MODULES=0
 
 setup_test_modules() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  __setup_test_modules
+  restore_bats_shell_options "$?"
+}
+
+__setup_test_modules() {
   local module
   local module_file
 

--- a/tests/path/list-available-commands.bats
+++ b/tests/path/list-available-commands.bats
@@ -12,25 +12,29 @@ teardown() {
   @go.remove_test_go_rootdir
 }
 
-@test "$SUITE: list available commands" {
-  # Since we aren't creating any new commands, and _@go.find_commands is already
-  # thoroughly tested in isolation, we only check that builtins are available.
+setup_list_available_commands() {
   local builtin_cmd
-  local expected=()
-
   for builtin_cmd in "$_GO_ROOTDIR"/libexec/*; do
     if [[ -f "$builtin_cmd" && -x "$builtin_cmd" ]]; then
       expected+=("${builtin_cmd[@]##*/}")
     fi
   done
+}
+
+@test "$SUITE: list available commands" {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  # Since we aren't creating any new commands, and _@go.find_commands is already
+  # thoroughly tested in isolation, we only check that builtins are available.
+  local expected=()
+  setup_list_available_commands
+  restore_bats_shell_options "$?"
 
   run "$TEST_GO_SCRIPT" "$_GO_ROOTDIR/libexec"
   assert_success
   assert_line_equals 0 'Available commands are:'
 
-  unset 'lines[0]'
-  local IFS=$'\n'
-  assert_equal "${expected[*]/#/  }" "${lines[*]}" 'available commands'
+  lines=("${lines[@]:1}")
+  assert_lines_equal "${expected[@]/#/  }"
 }
 
 @test "$SUITE: error if no commands available" {

--- a/tests/plugins.bats
+++ b/tests/plugins.bats
@@ -22,8 +22,7 @@ teardown() {
   @go.create_test_command_script 'plugins/foo/bin/foo'
 
   run "$TEST_GO_SCRIPT" complete 1 plugins ''
-  local expected=('--paths' '--summaries')
-  assert_success "${expected[@]}"
+  assert_success '--paths' '--summaries'
 
   run "$TEST_GO_SCRIPT" complete 1 plugins '--paths'
   assert_success '--paths '
@@ -39,7 +38,7 @@ teardown() {
   assert_failure ''
 }
 
-@test "$SUITE: show plugin info" {
+setup_show_plugin_info() {
   mkdir -p "$TEST_GO_PLUGINS_DIR/bar/bin" "$TEST_GO_PLUGINS_DIR/plugh/bin"
 
   local plugins=(
@@ -62,24 +61,24 @@ teardown() {
       longest_plugin_len="${#plugin}"
     fi
   done
+}
+
+@test "$SUITE: show plugin info" {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  setup_show_plugin_info
+  restore_bats_shell_options "$?"
 
   # Note that only `/bin` scripts from each plugin directory are included.
   run "$TEST_GO_SCRIPT" plugins
   assert_success 'bar' 'baz' 'plugh'
 
-  local paths=(
-    'bar    scripts/plugins/bar/bin/bar'
-    'baz    scripts/plugins/bar/bin/baz'
-    'plugh  scripts/plugins/plugh/bin/plugh')
-
   run "$TEST_GO_SCRIPT" plugins --paths
-  assert_success "${paths[@]}"
-
-  local summaries=(
-    '  bar    Does bar stuff'
-    '  baz    Does baz stuff'
-    '  plugh  Does plugh stuff')
+  assert_success 'bar    scripts/plugins/bar/bin/bar' \
+    'baz    scripts/plugins/bar/bin/baz' \
+    'plugh  scripts/plugins/plugh/bin/plugh'
 
   run "$TEST_GO_SCRIPT" plugins --summaries
-  assert_success "${summaries[@]}"
+  assert_success '  bar    Does bar stuff' \
+    '  baz    Does baz stuff' \
+    '  plugh  Does plugh stuff'
 }

--- a/tests/subcommands.bats
+++ b/tests/subcommands.bats
@@ -9,12 +9,14 @@ EXPECTED_SUBCOMMAND_LISTING=('Available subcommands of "foo" are:'
   '  quux  Do quux stuff')
 
 setup() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   @go.create_test_go_script '@go "$@"'
   @go.create_test_command_script 'foo' '. "$_GO_USE_MODULES" subcommands' \
     '@go.show_subcommands'
   @go.create_test_command_script 'foo.d/bar' '# Do bar stuff'
   @go.create_test_command_script 'foo.d/baz' '# Do baz stuff'
   @go.create_test_command_script 'foo.d/quux' '# Do quux stuff'
+  restore_bats_shell_options "$?"
 }
 
 teardown() {

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -27,6 +27,7 @@ quotify_expected() {
   run "$TEST_GO_SCRIPT" vars
   assert_success
 
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   local search_paths=("[0]=\"$_GO_CORE_DIR/libexec\""
     "[1]=\"$TEST_GO_SCRIPTS_DIR\"")
 
@@ -59,10 +60,12 @@ quotify_expected() {
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
+  restore_bats_shell_options "$?"
   assert_lines_equal "${expected[@]}"
 }
 
 @test "$SUITE: all _GO_* variables for Bash subcommand contain values" {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
   @go.create_test_command_script 'test-command.d/test-subcommand' \
     '. "$_GO_USE_MODULES" "module_0" "module_1"' \
     '@go vars'
@@ -131,6 +134,7 @@ quotify_expected() {
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
   quotify_expected
+  restore_bats_shell_options "$?"
   assert_lines_equal "${expected[@]}"
 }
 


### PR DESCRIPTION
Part of #156. At this point, the timing for `./go test` under Bash 3.2.57(1)-release on my MacBook Pro with a 2.9GHz Intel Core i5 CPU and 8GB 1867MHz DDR3 RAM went from the following for the merge commit for #161:

```
  784 tests, 0 failures, 2 skipped

  real    4m16.466s
  user    2m1.907s
  sys     2m2.015s
```

to:

```
  real    3m2.408s
  user    1m31.395s
  sys     1m21.114s
```