### PR TITLE
Use optimized Bats from mbland/bats

### DIFF
--- a/lib/bats-main
+++ b/lib/bats-main
@@ -53,10 +53,10 @@ export _GO_BATS_DIR="${_GO_BATS_DIR:-$_GO_TEST_DIR/bats}"
 export _GO_BATS_PATH="$_GO_BATS_DIR/libexec/bats"
 
 # Version of Bats to fetch if `_GO_BATS_DIR` is missing
-export _GO_BATS_VERSION="${_GO_BATS_VERSION:-master}"
+export _GO_BATS_VERSION="${_GO_BATS_VERSION:-optimized-20170205}"
 
 # URL of the Bats git repository to clone to `_GO_BATS_DIR`
-export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/sstephenson/bats.git}"
+export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/mbland/bats.git}"
 
 # Set this to nonempty if you wish to collect coverage using kcov by default
 export _GO_COLLECT_BATS_COVERAGE="$_GO_COLLECT_BATS_COVERAGE"


### PR DESCRIPTION
For even greater details, see [the comment for the `optimized-20170215` tag from https://github.com/mbland/bats](https://github.com/mbland/bats/releases/tag/optimized-20170205).

With this commit, on a MacBook Pro with a 2.9GHz Intel Core i5 CPU and 8GB 1867MHz DDR3 RAM, using Bash 4.4.12(1)-release (the latest at the time of writing), the `./go test` suite now runs in:

```
  real    1m20.347s
  user    0m55.040s
  sys     0m18.208s
```

The impact is even more dramatic on Windows. On the same MacBook Pro, running Windows 10 under VMware Fusion 8.5.3 with 4GB RAM, the timing for `./go test` before the changes from #156 was in the O(50-60min) range for every version of Bash I have installed. Afterwards, it was down in the O(20+min range).

Using Bats with these changes included, running the MSYS2-based Bash 4.3.46(2)-release that ships with (what is probably a slightly outdated version of) Git for Windows, the suite now runs in:

```
  real    6m20.981s
  user    1m53.852s
  sys     3m16.015s
```

Running Bash 4.4.11(2)-release running under Cygwin:

```
  real    5m22.506s
  user    1m34.462s
  sys     2m41.568s
```

And running Bash 4.3.11(1)-release as part of the Windows Subsystem for
Linux (i.e. Ubuntu on Windows 10):

```
  real    3m40.502s
  user    0m36.531s
  sys     3m1.516s
```

In addition to the Bash versions mentioned above, I've also tested these changes using the following Bash versions:

- 3.2.57(1)-release: the default for macOS
- 4.2.25(1)-release: the version from the default Ubuntu 12.04.5/Precise
  image on Travis CI
- 4.3.42(1)-release: the latest on Alpine Linux
- 4.3.46(1)-release: the latest on Ubuntu 16.10
- 4.4.12(0)-release: the version from FreeBSD 10.3-RELEASE-p11
- 4.4.12(1)-release: the latest at the time of writing, on both Arch
  Linux and macOS via Homebrew

All of the go-script-bash tests passed on these other platforms in less than half the time from before.

I'll open a PR against https://github.com/sstephenson/bats shortly.

cc: @stroupaloop