### PR TITLE
Fix `lib/bats/assertion-test-helpers` tests failing under MSYS2

### DIFF
--- a/tests/assertion-test-helpers.bats
+++ b/tests/assertion-test-helpers.bats
@@ -31,7 +31,8 @@ create_failing_test_stub() {
   if [[ ! -d "$BATS_TMPDIR/bin" ]]; then
     mkdir -p "$BATS_TMPDIR/bin"
   fi
-  printf '%s\n' 'printf "ARG: \"%s\"\n" "$@"' 'exit 1' >"$cmd_path"
+  printf '%s\n' '#! /usr/bin/env bash' \
+    'printf "ARG: \"%s\"\n" "$@"' 'exit 1' >"$cmd_path"
   chmod 755 "$cmd_path"
   PATH="$BATS_TMPDIR/bin:$PATH"
   hash "$cmd_name"


### PR DESCRIPTION
The `#! /usr/bin/env bash` was missing from `create_failing_test_stub`, causing the two tests using it to fail under MSYS2, which uses the shebang to determine whether or not a script is executable in lieu of using `chmod` to set file permissions.