### PR TITLE
bats-main: Use mbland/bats tag optimized-20170317

### DIFF
--- a/lib/bats-main
+++ b/lib/bats-main
@@ -53,7 +53,7 @@ export _GO_BATS_DIR="${_GO_BATS_DIR:-$_GO_TEST_DIR/bats}"
 export _GO_BATS_PATH="$_GO_BATS_DIR/libexec/bats"
 
 # Version of Bats to fetch if `_GO_BATS_DIR` is missing
-export _GO_BATS_VERSION="${_GO_BATS_VERSION:-optimized-20170205}"
+export _GO_BATS_VERSION="${_GO_BATS_VERSION:-optimized-20170317}"
 
 # URL of the Bats git repository to clone to `_GO_BATS_DIR`
 export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/mbland/bats.git}"


### PR DESCRIPTION
For greater details, see [the comment for `mbland/bats` tag `optimized-20170317`](https://github.com/mbland/bats/releases/tag/optimized-20170317).

Per that comment, while the performance improvements are not as dramatic as those from `optimized-20170205`, they are still significant.

All times were collected on a MacBook Pro with a 2.9GHz Intel Core i5 CPU and 8GB 1867MHz DDR3 RAM. The macOS times were collected on macOS 10.12.3. Times for other operating systems were collected on the same machine, running under VMmare Fusion 8.5.5.

Improvements are in the 7%-8% range across the board on most platforms, but as expected, are significantly greater on some Windows implementations, reaching up to 12%-13.5%.

macOS/Bash 3.2.57(1)-release before:
```
  789 tests, 0 failures, 2 skipped

  real    1m25.806s
  user    1m1.779s
  sys     0m18.484s
```
After (~7% faster):
```
  real    1m19.487s
  user    0m57.632s
  sys     0m15.909s
```

macOS/Bash 4.4.12(1)-release before:
```
  789 tests, 0 failures, 3 skipped

  real    1m20.796s
  user    0m55.405s
  sys     0m18.684s
```
After (~6% faster):
```
  real    1m14.554s
  user    0m51.306s
  sys     0m16.101s
```

Ubuntu Linux 16.10 (yakkety)/Bash 4.3.46(1)-release before:
```
  789 tests, 0 failures, 3 skipped

  real    1m9.426s
  user    0m31.220s
  sys     0m4.224s
```
After (~8% faster):
```
  real    1m3.911s
  user    0m29.856s
  sys     0m3.948s
```

Arch Linux/Bash 4.4.12(1)-release before:
```
  789 tests, 0 failures, 4 skipped

  real    0m46.714s
  user    0m30.503s
  sys     0m3.713s
```
After (~9% faster):
```
  real    0m42.468s
  user    0m28.643s
  sys     0m3.693s
```

Windows 10/Windows Subsystem for Linux/Bash 4.3.11(1)-release before:
```
  789 tests, 0 failures, 3 skipped

  real    3m37.525s
  user    0m36.969s
  sys     3m0.891s
```
After (~7.5% faster):
```
  real    3m21.062s
  user    0m34.078s
  sys     2m44.313s
```

Windows 10/Cygwin/Bash 4.4.12(3)-release before:
```
  789 tests, 0 failures, 3 skipped

  real    5m9.691s
  user    1m33.075s
  sys     2m44.395s
```
After (~12% faster):
```
  real    4m32.413s
  user    1m22.036s
  sys     2m22.253s
```

Windows 10/Git for Windows/Bash 4.3.46(2)-release run from the Windows
Command Prompt (not the Git for Windows MSYS2 terminal) before:
```
  789 tests, 0 failures, 14 skipped

  real    5m24.973s
  user    1m34.273s
  sys     2m47.360s
```
After (~13.5% faster):
```
  real    4m41.114s
  user    1m23.613s
  sys     2m21.771s
```