### PR TITLE
Add @go.trim to lib/strings, add lib/prompt module

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -229,43 +229,6 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   return "$result"
 }
 
-# Prompts the user to select one item from a list of options.
-#
-# This is a thin wrapper around the `select` builtin command for
-# straightforward, single-option user prompts. If you need to do anything more
-# complex, use the `select` builtin command directly.
-#
-# This will prompt the user for a single input, returned in the caller-declared
-# variable identified by `result_var`. If the user enters an invalid option,
-# this will notify the user and prompt again. If the user terminates input (via
-# EOF, i.e. Ctrl-D), `result_var` will remain unchanged and the function will
-# return nonzero.
-#
-# Globals:
-#   PS3  environment variable defining the selection prompt
-#
-# Arguments:
-#   result_var:  Name of the caller-declared variable used to store the option
-#   ...:         Strings representing options available for the user to select
-#
-# Returns:
-#   zero if `result_var` contains the user's selection, nonzero otherwise
-@go.select_option() {
-  local __go_selected_option
-  select __go_selected_option in "${@:2}"; do
-    case "$__go_selected_option" in
-    '')
-      @go.printf '"%s" is not a valid option.\n' "$REPLY" >&2
-      ;;
-    *)
-      printf -v "$1" -- '%s' "$__go_selected_option"
-      break
-      ;;
-    esac
-  done
-  [[ -n "$__go_selected_option" ]]
-}
-
 # Searches through plugin directories using a helper function
 #
 # The search will begin in `_GO_SCRIPTS_DIR/plugins`. As long as `search_func`

--- a/lib/prompt
+++ b/lib/prompt
@@ -30,7 +30,7 @@
 # Returns:
 #   zero if `result_var` contains the user's selection, nonzero otherwise
 @go.select_option() {
-  @go.validate_identifier_or_die 'Result variable name' "$1"
+  @go.validate_identifier_or_die 'Input selection variable name' "$1"
 
   local __go_selected_option
   select __go_selected_option in "${@:2}"; do

--- a/lib/prompt
+++ b/lib/prompt
@@ -3,10 +3,60 @@
 # User input prompts
 #
 # Exports:
+#   @go.read_prompt_response
+#     Reads a line, trims leading/trailing space, and sets a default if empty
+#
+#   @go.prompt_for_input
+#     Prompts the user for a line of input
+#
 #   @go.select_option
 #     Prompts the user to select one item from a list of options
 
-. "$_GO_USE_MODULES" 'validation'
+. "$_GO_USE_MODULES" 'strings' 'validation'
+
+# Reads a line, trims leading/trailing space, and sets a default if empty
+#
+# Arguments:
+#   var_name:  Name of the caller's variable into which to read value
+#   default:   (Optional) Default value if the input line is empty
+@go.read_prompt_response() {
+  @go.validate_identifier_or_die 'Input prompt response variable name' "$1"
+  read -r "$1"
+  @go.trim "$1"
+  printf -v "$1" -- '%s' "${!1:-$2}"
+}
+
+# Prompts the user for a line of input
+#
+# If the prompt doesn't end with a whitespace character, a space will be added
+# between the prompt and the input cursor. Otherwise the existing character will
+# be preserved.
+#
+# If a default value is specified, a space will be added to the prompt, followed
+# by the default value in square brackets; the caller should not add the default
+# value to the prompt directly. If the prompt ends with a whitespace character,
+# it will be preserved and added after the default value.
+#
+# Arguments:
+#   result_var  Name of the caller-declared variable for the result
+#   prompt      Text prompt for user input
+#   default     (Optional) Default value if response is empty
+#   fail_msg    (Optional) Failure message if empty input isn't valid
+@go.prompt_for_input() {
+  @go.validate_identifier_or_die 'Input prompt response variable name' "$1"
+
+  if [[ "$2" =~ [[:space:]]$ ]]; then
+    @go.printf '%s%s%s' "${2%?}" "${3:+ [default: $3]}" "${BASH_REMATCH[0]}" >&2
+  else
+    @go.printf '%s %s' "$2" "${3:+[default: $3] }" >&2
+  fi
+  @go.read_prompt_response "$1" "$3"
+
+  if [[ -z "${!1}" && -n "$4" ]]; then
+    @go.printf '%s\n' "$4" >&2
+    return 1
+  fi
+}
 
 # Prompts the user to select one item from a list of options.
 #

--- a/lib/prompt
+++ b/lib/prompt
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+#
+# User input prompts
+#
+# Exports:
+#   @go.select_option
+#     Prompts the user to select one item from a list of options
+
+. "$_GO_USE_MODULES" 'validation'
+
+# Prompts the user to select one item from a list of options.
+#
+# This is a thin wrapper around the `select` builtin command for
+# straightforward, single-option user prompts. If you need to do anything more
+# complex, use the `select` builtin command directly.
+#
+# This will prompt the user for a single input, returned in the caller-declared
+# variable identified by `result_var`. If the user enters an invalid option,
+# this will notify the user and prompt again. If the user terminates input (via
+# EOF, i.e. Ctrl-D), `result_var` will remain unchanged and the function will
+# return nonzero.
+#
+# Globals:
+#   PS3  environment variable defining the selection prompt
+#
+# Arguments:
+#   result_var:  Name of the caller-declared variable used to store the option
+#   ...:         Strings representing options available for the user to select
+#
+# Returns:
+#   zero if `result_var` contains the user's selection, nonzero otherwise
+@go.select_option() {
+  @go.validate_identifier_or_die 'Result variable name' "$1"
+
+  local __go_selected_option
+  select __go_selected_option in "${@:2}"; do
+    case "$__go_selected_option" in
+    '')
+      @go.printf '"%s" is not a valid option.\n' "$REPLY" >&2
+      ;;
+    *)
+      printf -v "$1" -- '%s' "$__go_selected_option"
+      break
+      ;;
+    esac
+  done
+  [[ -n "$__go_selected_option" ]]
+}

--- a/lib/prompt
+++ b/lib/prompt
@@ -9,6 +9,9 @@
 #   @go.prompt_for_input
 #     Prompts the user for a line of input
 #
+#   @go.prompt_for_yes_or_no
+#     Prompts the user for a yes or no response
+#
 #   @go.select_option
 #     Prompts the user to select one item from a list of options
 
@@ -56,6 +59,53 @@
     @go.printf '%s\n' "$4" >&2
     return 1
   fi
+}
+
+# Prompts the user for a yes or no response
+#
+# Arguments:
+#   prompt   Text prompt for user input
+#   default  (Optional) Default response; must be 'yes' or 'no'
+#
+# Returns:
+#   Zero on 'y' or 'yes' (case- and space- insensitive), nonzero otherwise
+@go.prompt_for_yes_or_no() {
+  local prompt="$1"
+  local default="$2"
+  local response
+
+  case "$default" in
+  yes)
+    @go.printf '%s [Y/n] ' "$prompt" >&2
+    ;;
+  no)
+    @go.printf '%s [y/N] ' "$prompt" >&2
+    ;;
+  '')
+    @go.printf '%s [y/n] ' "$prompt" >&2
+    ;;
+  *)
+    @go.printf 'Invalid `default` parameter "%s" for %s at:\n' \
+      "$default" "$FUNCNAME" >&2
+    @go.print_stack_trace '1' >&2
+    exit 1
+    ;;
+  esac
+
+  while true; do
+    @go.read_prompt_response 'response' "$default"
+
+    if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+      return 0
+    elif [[ "$response" =~ ^[Nn]([Oo])?$ ]]; then
+      return 1
+    else
+      if [[ -n "$response" ]]; then
+        @go.printf '\n"%s" is an invalid response.\n' "$response" >&2
+      fi
+      @go.printf '\nPlease answer Y(es) or N(o): ' >&2
+    fi
+  done
 }
 
 # Prompts the user to select one item from a list of options.

--- a/lib/strings
+++ b/lib/strings
@@ -82,6 +82,23 @@ export __GO_STRINGS_VALIDATION_SKIP_CALLERS=2
   printf -v "$2" -- '%s' "${*:3}"
 }
 
+# Trims the leading and trailing whitespace from a string
+#
+# Arguments:
+#   var_name:  Name of the caller's variable containing the string to trim
+@go.trim() {
+  @go.validate_identifier_or_die 'Input/output variable name' "$1"
+  local __go_trim_input__="${!1}"
+
+  if [[ "$__go_trim_input__" =~ ^[[:space:]]+ ]]; then
+    __go_trim_input__="${__go_trim_input__#${BASH_REMATCH[0]}}"
+  fi
+  if [[ "$__go_trim_input__" =~ [[:space:]]+$ ]]; then
+    __go_trim_input__="${__go_trim_input__%${BASH_REMATCH[0]}}"
+  fi
+  printf -v "$1" -- '%s' "$__go_trim_input__"
+}
+
 # Determines the common prefix for a set of strings
 #
 # Will return the empty string for a single argument. This facilitates prefix

--- a/libexec/demo-core.d/prompt
+++ b/libexec/demo-core.d/prompt
@@ -1,0 +1,37 @@
+#! /usr/bin/env bash
+#
+# Demonstration of `lib/prompt` capabilities
+#
+# Usage:
+#   {{go}} {{cmd}}
+#
+# Use this program to get a feel for the core `@go.prompt_for_input` and
+# `@go.prompt_for_yes_or_no` functions, and for examples of how to use them in
+# your own scripts.
+
+. "$_GO_USE_MODULES" 'prompt'
+
+_@go.prompt_demo() {
+  local name
+  local quest='To seek the grail!'
+
+  # No default value; returns error on no input.
+  if ! @go.prompt_for_input 'name' $'What is your name?\n' '' \
+    'Run away, Sir or Madam Not Appearing in this Film! Run away!'; then
+    return 1
+  fi
+  @go.printf 'Nice to meet you, %s!\n' "$name"
+
+  if @go.prompt_for_yes_or_no 'Do you have a quest?' 'yes'; then
+    # Default value applies if input is empty.
+    if ! @go.prompt_for_input 'quest' $'What is your quest?\n' "$quest"; then
+      return 1
+    fi
+  elif ! @go.prompt_for_yes_or_no "Might I suggest: $quest" 'yes'; then
+    @go.printf 'OK, no quest. Suit yourself!\n'
+    return 1
+  fi
+  @go.printf 'Your quest is: %s\n' "$quest"
+}
+
+_@go.prompt_demo "$@"

--- a/libexec/demo-core.d/select-option
+++ b/libexec/demo-core.d/select-option
@@ -17,33 +17,25 @@
 select_option_demo() {
   local options=("$@")
   local selected
-  local finish
 
   if [[ "${#options[@]}" -eq '0' ]]; then
     options=('Hello, World!' 'Goodbye, World!')
   fi
 
-  while [[ -z "$finish" ]]; do
+  while true; do
     @go.printf 'Please select one of the following options:\n'
 
-    if @go.select_option 'selected' "${options[@]}"; then
-      @go.printf 'You selected: "%s"\n\n' "$selected"
+    if ! @go.select_option 'selected' "${options[@]}"; then
+      @go.printf 'You declined to select an option. Exiting...\n\n'
+      return 1
     else
-      @go.printf 'You declined to select an option.\n\n'
+      @go.printf 'You selected: "%s"\n\n' "$selected"
     fi
 
-    @go.printf 'Would you like to select another option?\n'
-
-    if @go.select_option 'selected' 'Yes' 'No'; then
-      if  [[ "$selected" == 'No' ]]; then
-        @go.printf 'Exiting...\n'
-        finish='true'
-      else
-        printf '\n'
-      fi
-    else
-      @go.printf 'You declined to select an option. Exiting...\n'
-      finish='true'
+    if ! @go.prompt_for_yes_or_no 'Would you like to select another option?' \
+      'yes'; then
+      @go.printf 'Exiting...\n'
+      return 0
     fi
   done
 }

--- a/libexec/demo-core.d/select-option
+++ b/libexec/demo-core.d/select-option
@@ -12,6 +12,8 @@
 # Use this program to get a feel for the core `@go.select_option` function, and
 # for an example of how to use it in your own scripts.
 
+. "$_GO_USE_MODULES" 'prompt'
+
 select_option_demo() {
   local options=("$@")
   local selected

--- a/tests/demo-core/prompt.bats
+++ b/tests/demo-core/prompt.bats
@@ -1,0 +1,72 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: use default quest option" {
+  run "$_GO_SCRIPT" demo-core prompt <<<$'Mike\n\n'
+  assert_success
+  split_bats_output_into_lines
+
+  local default_quest='Do you have a quest? [Y/n] '
+  default_quest+='What is your quest? [default: To seek the grail!]'
+
+  assert_lines_equal 'What is your name?' \
+    'Nice to meet you, Mike!' \
+    "${default_quest}" \
+    'Your quest is: To seek the grail!'
+}
+
+@test "$SUITE: return error if name not specified" {
+  run "$_GO_SCRIPT" demo-core prompt <<<''
+  assert_failure 'What is your name?' \
+    'Run away, Sir or Madam Not Appearing in this Film! Run away!'
+}
+
+@test "$SUITE: specify a different quest" {
+  run "$_GO_SCRIPT" demo-core prompt \
+    <<<$'Mike\nyes\nTo go back and face the peril!'
+  assert_success
+  split_bats_output_into_lines
+
+  local default_quest='Do you have a quest? [Y/n] '
+  default_quest+='What is your quest? [default: To seek the grail!]'
+
+  assert_lines_equal 'What is your name?' \
+    'Nice to meet you, Mike!' \
+    "${default_quest}" \
+    'Your quest is: To go back and face the peril!'
+}
+
+@test "$SUITE: decline a quest" {
+  run "$_GO_SCRIPT" demo-core prompt <<<$'Mike\nno\nno'
+  assert_failure
+  split_bats_output_into_lines
+
+  local default_quest='Do you have a quest? [Y/n] '
+  default_quest+='Might I suggest: To seek the grail! [Y/n]'
+
+  assert_lines_equal 'What is your name?' \
+    'Nice to meet you, Mike!' \
+    "${default_quest} OK, no quest. Suit yourself!"
+}
+
+@test "$SUITE: suggest a quest and accept it" {
+  run "$_GO_SCRIPT" demo-core prompt <<<$'Mike\nno\nyes'
+  assert_success
+  split_bats_output_into_lines
+
+  local default_quest='Do you have a quest? [Y/n] '
+  default_quest+='Might I suggest: To seek the grail! [Y/n]'
+
+  assert_lines_equal 'What is your name?' \
+    'Nice to meet you, Mike!' \
+    "${default_quest} Your quest is: To seek the grail!"
+}

--- a/tests/demo-core/select-option.bats
+++ b/tests/demo-core/select-option.bats
@@ -12,31 +12,28 @@ teardown() {
 }
 
 @test "$SUITE: use default selection options" {
-  run "$_GO_SCRIPT" demo-core select-option <<<$'1\n1\n2\n2\n'
+  run "$_GO_SCRIPT" demo-core select-option <<<$'1\nYes\n2\nNo'
   assert_success
   split_bats_output_into_lines
+
+  local select_affirmative='Would you like to select another option? [Y/n] '
+  select_affirmative+='Please select one of the following options:'
+
   assert_lines_equal 'Please select one of the following options:' \
     '1) Hello, World!' \
     '2) Goodbye, World!' \
     "${PS3}You selected: \"Hello, World!\"" \
     '' \
-    'Would you like to select another option?' \
-    '1) Yes' \
-    '2) No' \
-    "${PS3}" \
-    'Please select one of the following options:' \
+    "${select_affirmative}" \
     '1) Hello, World!' \
     '2) Goodbye, World!' \
     "${PS3}You selected: \"Goodbye, World!\"" \
     '' \
-    'Would you like to select another option?' \
-    '1) Yes' \
-    '2) No' \
-    "${PS3}Exiting..."
+    'Would you like to select another option? [Y/n] Exiting...'
 }
 
 @test "$SUITE: use user-provided selection options" {
-  run "$_GO_SCRIPT" demo-core select-option foo bar baz <<<$'2\n2\n'
+  run "$_GO_SCRIPT" demo-core select-option foo bar baz <<<$'2\nNo'
   assert_success
   split_bats_output_into_lines
   assert_lines_equal 'Please select one of the following options:' \
@@ -45,30 +42,21 @@ teardown() {
     '3) baz' \
     "${PS3}You selected: \"bar\"" \
     '' \
-    'Would you like to select another option?' \
-    '1) Yes' \
-    '2) No' \
-    "${PS3}Exiting..."
+    'Would you like to select another option? [Y/n] Exiting...'
 }
 
-@test "$SUITE: exit both prompts on empty input" {
+@test "$SUITE: exit prompt and program on empty input terminated by EOF" {
   mkdir "$TEST_GO_ROOTDIR"
   printf '' >"$TEST_GO_ROOTDIR/input.txt"
   run "$_GO_SCRIPT" demo-core select-option foo bar baz \
     <"$TEST_GO_ROOTDIR/input.txt"
 
-  assert_success
+  assert_failure
   split_bats_output_into_lines
   assert_lines_equal 'Please select one of the following options:' \
     '1) foo' \
     '2) bar' \
     '3) baz' \
-    "${PS3}" \
-    'You declined to select an option.' \
-    '' \
-    'Would you like to select another option?' \
-    '1) Yes' \
-    '2) No' \
     "${PS3}" \
     'You declined to select an option. Exiting...'
 }

--- a/tests/prompt/prompt-for-input.bats
+++ b/tests/prompt/prompt-for-input.bats
@@ -1,0 +1,64 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    'declare prompt="$1"' \
+    'declare default="$2"' \
+    'declare fail_msg="$3"' \
+    'declare response="initial value"' \
+    'declare result' \
+    '@go.prompt_for_input "response" "$prompt" "$default" "$fail_msg"' \
+    'result="$?"' \
+    'printf -- "%s\n" "$response"' \
+    'exit "$result"'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: error if variable not a valid identifier" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    '@go.prompt_for_input "invalid;"'
+
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='Input prompt response variable name "invalid;" for '
+  err_msg+='@go.prompt_for_input contains invalid identifier characters at:'
+
+  assert_lines_match "^${err_msg}\$" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: reads and trims value" {
+  run "$TEST_GO_SCRIPT" $'What is your quest?\n' <<<'  To seek the grail!   '
+  assert_success 'What is your quest?' \
+    'To seek the grail!'
+}
+
+@test "$SUITE: with default preserves prompt space" {
+  run "$TEST_GO_SCRIPT" $'What is your quest?\n' 'To seek the grail!' <<<''
+  assert_success 'What is your quest? [default: To seek the grail!]' \
+    'To seek the grail!'
+}
+
+@test "$SUITE: with default adds prompt space if missing" {
+  run "$TEST_GO_SCRIPT" 'What is your quest?' 'To seek the grail!' <<<''
+  assert_success \
+    'What is your quest? [default: To seek the grail!] To seek the grail!'
+}
+
+@test "$SUITE: reads empty input if no error message" {
+  run "$TEST_GO_SCRIPT" $'What is your quest?\n' <<<''
+  assert_success 'What is your quest?'
+}
+
+@test "$SUITE: fails with error message on empty input" {
+  run "$TEST_GO_SCRIPT" $'What is your quest?\n' '' 'Auuuuuuuugh!' <<<''
+  assert_failure 'What is your quest?' \
+    'Auuuuuuuugh!'
+}

--- a/tests/prompt/prompt-for-yes-or-no.bats
+++ b/tests/prompt/prompt-for-yes-or-no.bats
@@ -1,0 +1,106 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    'declare default="$1"' \
+    'if @go.prompt_for_yes_or_no "To be or not to be?" "$default"; then' \
+    "  printf \"\n'Tis nobler to suffer the slings and arrows of fortune!\n\"" \
+    'else' \
+    "  printf \"\n'Tis nobler to take up arms against a sea of troubles!\n\"" \
+    'fi'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: error if default value invalid" {
+  run "$TEST_GO_SCRIPT" 'foobar'
+  assert_failure
+  assert_lines_match \
+    '^Invalid `default` parameter "foobar" for @go.prompt_for_yes_or_no at:' \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: default to yes" {
+  run "$TEST_GO_SCRIPT" 'yes' <<<''
+  assert_success 'To be or not to be? [Y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+
+  run "$TEST_GO_SCRIPT" 'yes' <<<'no'
+  assert_success 'To be or not to be? [Y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+}
+
+@test "$SUITE: default to no" {
+  run "$TEST_GO_SCRIPT" 'no' <<<''
+  assert_success 'To be or not to be? [y/N] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+
+  run "$TEST_GO_SCRIPT" 'no' <<<'yes'
+  assert_success 'To be or not to be? [y/N] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+}
+
+@test "$SUITE: default to neither, prompt for an answer if first is empty" {
+  run "$TEST_GO_SCRIPT" <<<'yes'
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+}
+
+@test "$SUITE: prompt repeatedly until valid answer given" {
+  run "$TEST_GO_SCRIPT" <<<$'\nfoobar\nyes'
+  assert_success 'To be or not to be? [y/n] ' \
+    'Please answer Y(es) or N(o): '  \
+    '"foobar" is an invalid response.' \
+    '' \
+    'Please answer Y(es) or N(o): '  \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+}
+
+@test "$SUITE: match 'yes' patterns, trim input" {
+  run "$TEST_GO_SCRIPT" <<<'   yes   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+
+  run "$TEST_GO_SCRIPT" <<<'   Yes   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+
+  run "$TEST_GO_SCRIPT" <<<'   YES   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+
+  run "$TEST_GO_SCRIPT" <<<'   y   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+
+  run "$TEST_GO_SCRIPT" <<<'   Y   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to suffer the slings and arrows of fortune!"
+}
+
+@test "$SUITE: match 'no' patterns, trim input" {
+  run "$TEST_GO_SCRIPT" <<<'   no   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+
+  run "$TEST_GO_SCRIPT" <<<'   No   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+
+  run "$TEST_GO_SCRIPT" <<<'   NO   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+
+  run "$TEST_GO_SCRIPT" <<<'   n   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+
+  run "$TEST_GO_SCRIPT" <<<'   N   '
+  assert_success 'To be or not to be? [y/n] ' \
+    "'Tis nobler to take up arms against a sea of troubles!"
+}

--- a/tests/prompt/read-prompt-response.bats
+++ b/tests/prompt/read-prompt-response.bats
@@ -1,0 +1,35 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+setup() {
+  test_filter
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: error if response variable not a valid identifier" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    '@go.read_prompt_response "invalid;"'
+
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='Input prompt response variable name "invalid;" for '
+  err_msg+='@go.read_prompt_response contains invalid identifier characters at:'
+
+  assert_lines_match "^${err_msg}\$" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: reads and trims variable value, backslashes aren't special" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    'declare response="initial value"' \
+    '@go.read_prompt_response "response"' \
+    'printf -- "%s\n" "$response"'
+
+  run "$TEST_GO_SCRIPT" <<<"   Hello, World! \ Goodbye, World!  "
+  assert_success 'Hello, World! \ Goodbye, World!'
+}

--- a/tests/prompt/select-option.bats
+++ b/tests/prompt/select-option.bats
@@ -4,7 +4,8 @@ load ../environment
 
 setup() {
   test_filter
-  @go.create_test_go_script 'declare selection' \
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    'declare selection' \
     'if @go.select_option "selection" "$@"; then' \
     '  printf "\nSelection: \"%s\"\n" "$selection"' \
     'else' \

--- a/tests/prompt/select-option.bats
+++ b/tests/prompt/select-option.bats
@@ -18,6 +18,20 @@ teardown() {
   @go.remove_test_go_rootdir
 }
 
+@test "$SUITE: error if selection variable not a valid identifier" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "prompt"' \
+    '@go.select_option "invalid;"'
+
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='Input selection variable name "invalid;" for '
+  err_msg+='@go.select_option contains invalid identifier characters at:'
+
+  assert_lines_match "^${err_msg}\$" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
 @test "$SUITE: no options exits instantly" {
   run "$TEST_GO_SCRIPT"
   assert_failure ''

--- a/tests/strings/trim.bats
+++ b/tests/strings/trim.bats
@@ -1,0 +1,64 @@
+#! /usr/bin/env bats
+
+load ../environment
+load helpers
+
+setup() {
+  test_filter
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: error if result variable name not a valid identifier" {
+  create_strings_test_script '@go.trim "invalid;"'
+  run "$TEST_GO_SCRIPT"
+  assert_failure
+
+  local err_msg='^Input/output variable name "invalid;" for @go.trim '
+  err_msg+='contains invalid identifier characters at:$'
+
+  assert_lines_match "$err_msg" \
+    "^  $TEST_GO_SCRIPT:[0-9] main$"
+}
+
+@test "$SUITE: empty string" {
+  create_strings_test_script 'declare result' \
+    '@go.trim "result"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: no leading or trailing space" {
+  create_strings_test_script 'declare result="foo bar"' \
+    '@go.trim "result"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar'
+}
+
+@test "$SUITE: trim leading space" {
+  create_strings_test_script 'declare result="  foo bar"' \
+    '@go.trim "result"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar'
+}
+
+@test "$SUITE: trim trailing space" {
+  create_strings_test_script 'declare result="foo bar  "' \
+    '@go.trim "result"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar'
+}
+
+@test "$SUITE: trim leading and trailing space" {
+  create_strings_test_script 'declare result="  foo bar  "' \
+    '@go.trim "result"' \
+    'echo "$result"'
+  run "$TEST_GO_SCRIPT"
+  assert_success 'foo bar'
+}


### PR DESCRIPTION
Another part of #148. Also moves `@go.select_option` from `go-core.bash` to `lib/prompt`.

After this, only the file and command check functions remain to be imported from https://github.com/mbland/certbot-webroot-setup.