### PR TITLE
Create public lib/existence module, fix `new --test`, update `demo-core prompt`

### DIFF
--- a/lib/existence
+++ b/lib/existence
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+#
+# Checks for the existence and accessibility of files and commands
+#
+# Many of the actual checks are Bash builtins, but these functions provide
+# standard error messages to make reporting missing or inaccessible files
+# easier. They eliminate a lot of boilerplate from scripts that check for
+# initial conditions before processing files and executing commands.
+#
+# Exports:
+#   @go.check_file_exists
+#     Checks whether a file exists and prints an error if not
+#
+#   @go.check_file_readable
+#     Checks whether a file exists and is readable, and prints an error if not
+#
+#   @go.pick_command
+#     Selects the first installed command from a list of possible commands/names
+#
+#   @go.check_command_installed
+#     Checks whether a required command is installed on the system
+
+# Checks whether a file exists and prints an error if not.
+#
+# Arguments:
+#   label:      Label describing the type of file
+#   file_path:  Path to the file to check
+@go.check_file_exists() {
+  if [[ ! -e "$2" ]]; then
+    @go.printf "%s doesn't exist: %s\n" "$1" "$2" >&2
+    return 1
+  fi
+}
+
+# Checks whether a file exists and is readable, and prints an error if not.
+#
+# Arguments:
+#   label:      Label describing the type of file
+#   file_path:  Path to the file to check
+@go.check_file_readable() {
+  if [[ ! -r "$2" ]]; then
+    @go.printf "%s doesn't exist or isn't readable: %s\n" "$1" "$2" >&2
+    return 1
+  fi
+}
+
+# Selects the first installed command from a list of possible commands/names.
+#
+# This may be used to select from a number of different commands, or to select
+# the correct name for a command whose name may differ from system to system.
+#
+# Arguments:
+#   result_var:  Name of the caller-defined variable for the resulting command
+#   ...:         List of commands from which to select the first available
+#
+# Returns:
+#   Zero if any of the commands are installed, nonzero otherwise
+@go.pick_command() {
+  local __go_pick_cmd
+  for __go_pick_cmd in "${@:2}"; do
+    if command -v "$__go_pick_cmd" >/dev/null; then
+      printf -v "$1" -- '%s' "$__go_pick_cmd"
+      return
+    fi
+  done
+  @go.printf 'None of the following commands were found on the system:\n' >&2
+  printf '  %s\n' "${@:2}" >&2
+  return 1
+}
+
+# Checks whether a required command is installed on the system.
+#
+# If the command isn't installed, prints an error message to standard error
+# instructing the user to install the required command.
+#
+# Arguments:
+#   cmd_name:  Name of the command that must be required on the system
+#   err_msg:   Name of the command or other info to use in the error message
+#
+# Returns:
+#   Zero if the command is installed, nonzero otherwise
+@go.check_command_installed() {
+  if ! command -v "$1" >/dev/null; then
+    @go.printf 'Please install %s on your system and try again.\n' \
+      "${2:-$1}" >&2
+    return 1
+  fi
+}

--- a/libexec/demo-core.d/prompt
+++ b/libexec/demo-core.d/prompt
@@ -23,10 +23,9 @@ _@go.prompt_demo() {
   @go.printf 'Nice to meet you, %s!\n' "$name"
 
   if @go.prompt_for_yes_or_no 'Do you have a quest?' 'yes'; then
-    # Default value applies if input is empty.
-    if ! @go.prompt_for_input 'quest' $'What is your quest?\n' "$quest"; then
-      return 1
-    fi
+    # Default value applies if input is empty. Since there is a default, this
+    # won't return an error on no input.
+    @go.prompt_for_input 'quest' $'What is your quest?\n' "$quest"
   elif ! @go.prompt_for_yes_or_no "Might I suggest: $quest" 'yes'; then
     @go.printf 'OK, no quest. Suit yourself!\n'
     return 1

--- a/libexec/new
+++ b/libexec/new
@@ -226,7 +226,9 @@ _@go.new_test() {
   local parent_dir="${test_relpath%/*}"
   local impl
 
-  if [[ -n "$parent_dir" ]]; then
+  if [[ "$parent_dir" == "${test_path##*/}" ]]; then
+    parent_dir=''
+  else
     parent_dir="${parent_dir//[^\/]}/"
   fi
 

--- a/tests/existence.bats
+++ b/tests/existence.bats
@@ -1,0 +1,87 @@
+#! /usr/bin/env bats
+
+load environment
+
+setup() {
+  test_filter
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: check_file_exists" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
+    '@go.check_file_exists "$@"'
+  run "$TEST_GO_SCRIPT" 'Foo config' "$TEST_GO_ROOTDIR/foo"
+  assert_failure "Foo config doesn't exist: $TEST_GO_ROOTDIR/foo"
+
+  printf '' >"$TEST_GO_ROOTDIR/foo"
+  run "$TEST_GO_SCRIPT" 'Foo config' "$TEST_GO_ROOTDIR/foo"
+  assert_success ''
+}
+
+@test "$SUITE: check_file_readable" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
+    '@go.check_file_readable "$@"'
+  run "$TEST_GO_SCRIPT" 'Foo config' "$TEST_GO_ROOTDIR/foo"
+  assert_failure \
+    "Foo config doesn't exist or isn't readable: $TEST_GO_ROOTDIR/foo"
+
+  printf '' >"$TEST_GO_ROOTDIR/foo"
+  run "$TEST_GO_SCRIPT" 'Foo config' "$TEST_GO_ROOTDIR/foo"
+  assert_success ''
+}
+
+@test "$SUITE: check_file_readable fails if no read permission" {
+  skip_if_cannot_trigger_file_permission_failure
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
+    '@go.check_file_readable "$@"'
+  printf '' >"$TEST_GO_ROOTDIR/foo"
+  chmod ugo-r "$TEST_GO_ROOTDIR/foo"
+
+  run "$TEST_GO_SCRIPT" 'Foo config' "$TEST_GO_ROOTDIR/foo"
+  assert_failure \
+    "Foo config doesn't exist or isn't readable: $TEST_GO_ROOTDIR/foo"
+}
+
+@test "$SUITE: pick_command" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
+    'declare selected_cmd' \
+    'if @go.pick_command "selected_cmd" "$@"; then' \
+    '  printf "%s\n" "$selected_cmd"' \
+    'else' \
+    '  exit 1' \
+    'fi'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  assert_failure "None of the following commands were found on the system:" \
+    '  foo' \
+    '  bar' \
+    '  baz'
+
+  stub_program_in_path 'baz'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  assert_success 'baz'
+
+  stub_program_in_path 'bar'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  assert_success 'bar'
+
+  stub_program_in_path 'foo'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  assert_success 'foo'
+}
+
+@test "$SUITE: check_command_installed" {
+  @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
+    '@go.check_command_installed "$@"'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar'
+  assert_failure 'Please install foobar on your system and try again.'
+
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
+  assert_failure 'Please install Foo Bar on your system and try again.'
+
+  stub_program_in_path 'foobar'
+  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
+  assert_success ''
+}

--- a/tests/existence.bats
+++ b/tests/existence.bats
@@ -53,35 +53,35 @@ teardown() {
     'else' \
     '  exit 1' \
     'fi'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
   assert_failure "None of the following commands were found on the system:" \
     '  foo' \
     '  bar' \
     '  baz'
 
   stub_program_in_path 'baz'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
   assert_success 'baz'
 
   stub_program_in_path 'bar'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
   assert_success 'bar'
 
   stub_program_in_path 'foo'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
+  run "$TEST_GO_SCRIPT" 'foo' 'bar' 'baz'
   assert_success 'foo'
 }
 
 @test "$SUITE: check_command_installed" {
   @go.create_test_go_script '. "$_GO_USE_MODULES" "existence"' \
     '@go.check_command_installed "$@"'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar'
+  run "$TEST_GO_SCRIPT" 'foobar'
   assert_failure 'Please install foobar on your system and try again.'
 
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
+  run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
   assert_failure 'Please install Foo Bar on your system and try again.'
 
   stub_program_in_path 'foobar'
-  PATH="$BATS_TEST_BINDIR:/bin" run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
+  run "$TEST_GO_SCRIPT" 'foobar' 'Foo Bar'
   assert_success ''
 }

--- a/tests/new.bats
+++ b/tests/new.bats
@@ -431,7 +431,14 @@ assert_command_script_is_executable() {
     $'\n@test "\$SUITE: short description of your first test case" \{\n'
 }
 
-@test "$SUITE: --test fails if public module already exists" {
+@test "$SUITE: no '../' in environment load path for top-level test" {
+  run "$TEST_GO_SCRIPT" new --test foo
+  assert_success "EDITING: $TEST_GO_ROOTDIR/$_GO_TEST_DIR/foo.bats"
+  assert_file_matches "$TEST_GO_ROOTDIR/$_GO_TEST_DIR/foo.bats" \
+    $'\nload environment\n'
+}
+
+@test "$SUITE: --test fails if test already exists" {
   run "$TEST_GO_SCRIPT" new --test foo/bar/baz
   assert_success "EDITING: $TEST_GO_ROOTDIR/$_GO_TEST_DIR/foo/bar/baz.bats"
   run "$TEST_GO_SCRIPT" new --test foo/bar/baz


### PR DESCRIPTION
Closes #148. This is the last bit of functionality migrated from https://github.com/mbland/certbot-webroot-setup, providing a standard means of checking for file and command existence and reporting errors.

Also removes and documents an unreachable failure case in `demo-core prompt`, fixes the `load environment` line for `new --test` for tests created at the top level of `_GO_TEST_DIR`, and updates a misnamed test case in `tests/new.bats`.