### PR TITLE
Download release file instead of cloning repo in go-template (continued from #179)

### DIFF
--- a/go-template
+++ b/go-template
@@ -63,7 +63,7 @@ download_go_script_bash_tarball() {
   fi
   printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
   if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") 2>/dev/null ||
-    [[ ! -d "$unpacked_dir" ]]; then
+    [[ ! -f "$unpacked_dir/go-core.bash" ]]; then
     printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
     return 1
   fi

--- a/go-template
+++ b/go-template
@@ -50,10 +50,6 @@ declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/m
 declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_BASH_REPO_URL%.git}/archive}/$GO_SCRIPT_BASH_VERSION.tar.gz"
 
 if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
-  declare PIPEFAIL_BACKUP=($(shopt -op | grep pipefail))
-  set -o pipefail
-  
-  # Using a function to allow for multiple return points
   curl_download(){
     local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
 
@@ -66,7 +62,8 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
       return 1
     fi
     printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-    if ! curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz 2>/dev/null ; then
+    if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") 2>/dev/null ||
+      [[ ! -d "$unpacked_dir" ]]; then
       printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" \
         >&2
       return 1
@@ -93,12 +90,10 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
         -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
         "$GO_SCRIPT_BASH_CORE_DIR"; then
       printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
-      "${PIPEFAIL_BACKUP[@]}"
       exit 1
     fi
     printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
   fi
-  "${PIPEFAIL_BACKUP[@]}"
 fi
 
 . "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"

--- a/go-template
+++ b/go-template
@@ -59,6 +59,8 @@ download_go_script_bash_tarball() {
     download_cmd=(curl -LfsS "$url")
   elif command -v fetch >/dev/null; then
     download_cmd=(fetch -o - "$url")
+  elif [[ "$url" =~ file:// ]] && command -v cat; then
+    download_cmd=(cat "${url#file://}")
   elif command -v wget >/dev/null; then
     download_cmd=(wget -O - "$url")
   else

--- a/go-template
+++ b/go-template
@@ -55,6 +55,8 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
   
   # Using a function to allow for multiple return points
   curl_download(){
+    local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
+
     if ! command curl -V >/dev/null; then
       printf "Failed to find cURL or tar\n"
       return 1
@@ -65,18 +67,19 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
     fi
     printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
     if ! curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz 2>/dev/null ; then
-      printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
+      printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" \
+        >&2
       return 1
     fi
     if ! mkdir -p "$GO_SCRIPTS_DIR" ; then
       printf "Failed to create scripts dir '%s'\n" "$GO_SCRIPTS_DIR" >&2
-      rm -rf "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
+      rm -rf "$unpacked_dir"
       return 1
     fi
-    if ! mv "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER" "$GO_SCRIPT_BASH_CORE_DIR"; then
+    if ! mv "$unpacked_dir" "$GO_SCRIPT_BASH_CORE_DIR"; then
       printf "Failed to install downloaded directory in '%s'\n" \
         "$GO_SCRIPT_BASH_CORE_DIR" >&2
-      rm -rf "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
+      rm -rf "$unpacked_dir"
       return 1
     fi
     printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"

--- a/go-template
+++ b/go-template
@@ -49,50 +49,55 @@ declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/m
 # URL with the release files
 declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_BASH_REPO_URL%.git}/archive}/$GO_SCRIPT_BASH_VERSION.tar.gz"
 
-if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
-  curl_download(){
-    local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
+# Downloads `GO_SCRIPT_BASH_VERSION` as a tar.gz file and unpacks it.
+download_go_script_bash_tarball() {
+  local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
 
-    if ! command curl -V >/dev/null; then
-      printf "Failed to find cURL or tar\n"
-      return 1
-    fi
-    if ! command tar --help >/dev/null; then
-      printf "Failed to find cURL or tar\n"
-      return 1
-    fi
-    printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-    if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") 2>/dev/null ||
-      [[ ! -d "$unpacked_dir" ]]; then
-      printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" \
-        >&2
-      return 1
-    fi
-    if ! mkdir -p "$GO_SCRIPTS_DIR" ; then
-      printf "Failed to create scripts dir '%s'\n" "$GO_SCRIPTS_DIR" >&2
-      rm -rf "$unpacked_dir"
-      return 1
-    fi
-    if ! mv "$unpacked_dir" "$GO_SCRIPT_BASH_CORE_DIR"; then
-      printf "Failed to install downloaded directory in '%s'\n" \
-        "$GO_SCRIPT_BASH_CORE_DIR" >&2
-      rm -rf "$unpacked_dir"
-      return 1
-    fi
-    printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-    return 0
-  }
-  
-  if ! curl_download; then
+  if ! command curl -V >/dev/null; then
+    printf "Failed to find cURL or tar\n"
+    return 1
+  fi
+  if ! command tar --help >/dev/null; then
+    printf "Failed to find cURL or tar\n"
+    return 1
+  fi
+  printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") 2>/dev/null ||
+    [[ ! -d "$unpacked_dir" ]]; then
+    printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
+    return 1
+  fi
+  if ! mkdir -p "$GO_SCRIPTS_DIR" ; then
+    printf "Failed to create scripts dir '%s'\n" "$GO_SCRIPTS_DIR" >&2
+    rm -rf "$unpacked_dir"
+    return 1
+  fi
+  if ! mv "$unpacked_dir" "$GO_SCRIPT_BASH_CORE_DIR"; then
+    printf "Failed to install downloaded directory in '%s'\n" \
+      "$GO_SCRIPT_BASH_CORE_DIR" >&2
+    rm -rf "$unpacked_dir"
+    return 1
+  fi
+  printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+}
+
+git_clone_go_script_bash() {
+  printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
+  if ! git clone --depth 1 -c advice.detachedHead=false \
+      -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
+      "$GO_SCRIPT_BASH_CORE_DIR"; then
+    printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
+    return 1
+  fi
+  printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
+}
+
+if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
+  if ! download_go_script_bash_tarball; then
     printf "Using git clone as fallback\n"
-    printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
-    if ! git clone --depth 1 -c advice.detachedHead=false \
-        -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
-        "$GO_SCRIPT_BASH_CORE_DIR"; then
-      printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
+    if ! git_clone_go_script_bash; then
       exit 1
     fi
-    printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
   fi
 fi
 

--- a/go-template
+++ b/go-template
@@ -6,9 +6,9 @@
 # description. You may remove any other comments from this template as well.
 #
 # This template automatically checks for the presence of the go-script-bash
-# sources and makes a shallow clone of the the go-script-bash repository if
-# necessary before dispatching commands. (If you prefer, you can change the
-# logic to create a regular clone instead.) This allows users to set up the
+# sources and downloads the go-script-bash repository contents if necessary
+# before dispatching commands. (If you prefer, you can change the logic to 
+# create a shallow or regular clone instead.) This allows users to set up the
 # framework without taking any extra steps when running the command for the
 # first time, without the need to commit the framework to your repository.
 #
@@ -37,21 +37,35 @@ declare GO_SCRIPTS_DIR="${GO_SCRIPTS_DIR:-scripts}"
 # The `GO_SCRIPT_BASH_REPO_URL` tag or branch you wish to use
 declare GO_SCRIPT_BASH_VERSION="${GO_SCRIPT_BASH_VERSION:-v1.5.0}"
 
+# The target version string, removing the leading 'v'
+declare _GO_SCRIPT_BASH_VERSION_NUMBER="${GO_SCRIPT_BASH_VERSION:1}"
+
 # The go-script-bash installation directory within your project
 declare GO_SCRIPT_BASH_CORE_DIR="${GO_SCRIPT_BASH_CORE_DIR:-${0%/*}/$GO_SCRIPTS_DIR/go-script-bash}"
 
 # The URL of the go-script-bash framework sources
 declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/mbland/go-script-bash.git}"
 
+# URL with the release files
+declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_BASH_REPO_URL%.git}/archive}/$GO_SCRIPT_BASH_VERSION.tar.gz"
+
+
 if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
-  printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
-  if ! git clone --depth 1 -c advice.detachedHead=false \
-      -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
-      "$GO_SCRIPT_BASH_CORE_DIR"; then
-    printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
+  printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz
+  if [[ ${PIPESTATUS[0]} -ne 0 ]] || [[ ${PIPESTATUS[1]:1} -ne 0 ]] ; then
+    printf "Failed to download from '%s'; aborting.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
     exit 1
   fi
-  printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
+  if ! mkdir -p $GO_SCRIPTS_DIR; then
+    printf "Faild to create scripts dir '%s'" $GO_SCRIPTS_DIR >&2
+    exit 2
+  fi
+  if ! mv go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER $GO_SCRIPT_BASH_CORE_DIR; then
+    printf "Failed to install downloaded directory in '%s'\n" $GO_SCRIPT_BASH_CORE_DIR >&2
+    exit 3
+  fi
+  printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
 fi
 
 . "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"

--- a/go-template
+++ b/go-template
@@ -54,11 +54,11 @@ download_go_script_bash_tarball() {
   local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
 
   if ! command -v curl >/dev/null; then
-    printf "Failed to find cURL or tar\n"
+    printf "Failed to find cURL\n" >&2
     return 1
   fi
   if ! command -v tar >/dev/null; then
-    printf "Failed to find cURL or tar\n"
+    printf "Failed to find tar\n" >&2
     return 1
   fi
   printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"

--- a/go-template
+++ b/go-template
@@ -53,13 +53,23 @@ download_go_script_bash_tarball() {
   local unpacked_core="$unpacked_dir/go-core.bash"
   local core_dir_parent="${GO_SCRIPT_BASH_CORE_DIR%/*}"
   local url="$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  local protocol="${url%%://*}"
   local download_cmd=()
+
+  if [[ "$protocol" == "$url" ]]; then
+    printf 'GO_SCRIPT_BASH_DOWNLOAD_URL has no protocol: %s\n' "$url" >&2
+    return 1
+  elif command -v cygpath >/dev/null && [[ "$protocol" == 'file' ]]; then
+    url="file://$(cygpath -m "${url#file://}")"
+  fi
 
   if command -v curl >/dev/null; then
     download_cmd=(curl -LfsS "$url")
   elif command -v fetch >/dev/null; then
     download_cmd=(fetch -o - "$url")
-  elif [[ "$url" =~ file:// ]] && command -v cat; then
+  elif [[ "$protocol" == 'file' ]] && command -v cat; then
+    # `wget` can't handle 'file://' urls. Though input redirection would work
+    # below, this method is consistent with the process substitution logic.
     download_cmd=(cat "${url#file://}")
   elif command -v wget >/dev/null; then
     download_cmd=(wget -O - "$url")

--- a/go-template
+++ b/go-template
@@ -65,7 +65,7 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
       return 1
     fi
     printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-    if ! curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz ; then
+    if ! curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz 2>/dev/null ; then
       printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
       return 1
     fi

--- a/go-template
+++ b/go-template
@@ -49,23 +49,53 @@ declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/m
 # URL with the release files
 declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_BASH_REPO_URL%.git}/archive}/$GO_SCRIPT_BASH_VERSION.tar.gz"
 
-
 if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
-  printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-  curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz
-  if [[ ${PIPESTATUS[0]} -ne 0 ]] || [[ ${PIPESTATUS[1]:1} -ne 0 ]] ; then
-    printf "Failed to download from '%s'; aborting.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
-    exit 1
+  declare PIPEFAIL_BACKUP
+  PIPEFAIL_BACKUP=$(shopt -op | grep pipefail)
+  set -o pipefail
+  
+  # Using a function to allow for multiple return points
+  curl_download(){
+    if ! command curl -V >/dev/null; then
+      printf "Failed to find cURL or tar\n"
+      return 1
+    fi
+    if ! command tar -h >/dev/null; then
+      printf "Failed to find cURL or tar\n"
+      return 1
+    fi
+    printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+    if ! curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL" | tar -xz ; then
+      printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
+      return 1
+    fi
+    if ! mkdir -p $GO_SCRIPTS_DIR ; then
+      printf "Failed to create scripts dir '%s'" $GO_SCRIPTS_DIR >&2
+      rm -rf go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER
+      return 1
+    fi
+    if ! mv go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER $GO_SCRIPT_BASH_CORE_DIR; then
+      printf "Failed to install downloaded directory in '%s'\n" $GO_SCRIPT_BASH_CORE_DIR >&2
+      rm -rf go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER
+      return 1
+    fi
+    printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+    return 0
+  }
+  
+  if ! curl_download; then
+    printf "Using git clone as fallback\n"
+    printf "Cloning framework from '%s'...\n" "$GO_SCRIPT_BASH_REPO_URL"
+    if ! git clone --depth 1 -c advice.detachedHead=false \
+        -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
+        "$GO_SCRIPT_BASH_CORE_DIR"; then
+      printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
+      $PIPEFAIL_BACKUP
+      exit 1
+    fi
+    printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
   fi
-  if ! mkdir -p $GO_SCRIPTS_DIR; then
-    printf "Faild to create scripts dir '%s'" $GO_SCRIPTS_DIR >&2
-    exit 2
-  fi
-  if ! mv go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER $GO_SCRIPT_BASH_CORE_DIR; then
-    printf "Failed to install downloaded directory in '%s'\n" $GO_SCRIPT_BASH_CORE_DIR >&2
-    exit 3
-  fi
-  printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  $PIPEFAIL_BACKUP
 fi
 
 . "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"

--- a/go-template
+++ b/go-template
@@ -50,15 +50,17 @@ declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_
 download_go_script_bash_tarball() {
   # GitHub removes the leading 'v' from the archive's output directory.
   local unpacked_dir="go-script-bash-${GO_SCRIPT_BASH_VERSION#v}"
+  local unpacked_core="$unpacked_dir/go-core.bash"
   local core_dir_parent="${GO_SCRIPT_BASH_CORE_DIR%/*}"
+  local url="$GO_SCRIPT_BASH_DOWNLOAD_URL"
   local download_cmd=()
 
   if command -v curl >/dev/null; then
-    download_cmd=(curl -LfsS)
-  elif command -v wget >/dev/null; then
-    download_cmd=(wget -O -)
+    download_cmd=(curl -LfsS "$url")
   elif command -v fetch >/dev/null; then
-    download_cmd=(fetch -o -)
+    download_cmd=(fetch -o - "$url")
+  elif command -v wget >/dev/null; then
+    download_cmd=(wget -O - "$url")
   else
     printf "Failed to find cURL, wget, or fetch\n" >&2
     return 1
@@ -68,11 +70,10 @@ download_go_script_bash_tarball() {
     printf "Failed to find tar\n" >&2
     return 1
   fi
-  printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  printf "Downloading framework from '%s'...\n" "$url"
 
-  if ! tar -xzf <("${download_cmd[@]}" "$GO_SCRIPT_BASH_DOWNLOAD_URL") ||
-    [[ ! -f "$unpacked_dir/go-core.bash" ]]; then
-    printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
+  if ! tar -xzf <("${download_cmd[@]}") || [[ ! -f "$unpacked_core" ]]; then
+    printf "Failed to download from '%s'.\n" "$url" >&2
     return 1
   elif [[ ! -d "$core_dir_parent" ]] && ! mkdir -p "$core_dir_parent" ; then
     printf "Failed to create scripts dir '%s'\n" "$core_dir_parent" >&2
@@ -84,7 +85,7 @@ download_go_script_bash_tarball() {
     rm -rf "$unpacked_dir"
     return 1
   fi
-  printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
+  printf "Download of '%s' successful.\n\n" "$url"
 }
 
 git_clone_go_script_bash() {

--- a/go-template
+++ b/go-template
@@ -37,9 +37,6 @@ declare GO_SCRIPTS_DIR="${GO_SCRIPTS_DIR:-scripts}"
 # The `GO_SCRIPT_BASH_REPO_URL` tag or branch you wish to use
 declare GO_SCRIPT_BASH_VERSION="${GO_SCRIPT_BASH_VERSION:-v1.5.0}"
 
-# The target version string, removing the leading 'v'
-declare _GO_SCRIPT_BASH_VERSION_NUMBER="${GO_SCRIPT_BASH_VERSION:1}"
-
 # The go-script-bash installation directory within your project
 declare GO_SCRIPT_BASH_CORE_DIR="${GO_SCRIPT_BASH_CORE_DIR:-${0%/*}/$GO_SCRIPTS_DIR/go-script-bash}"
 
@@ -51,7 +48,9 @@ declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_
 
 # Downloads `GO_SCRIPT_BASH_VERSION` as a tar.gz file and unpacks it.
 download_go_script_bash_tarball() {
-  local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
+  # GitHub removes the leading 'v' from the archive's output directory.
+  local unpacked_dir="go-script-bash-${GO_SCRIPT_BASH_VERSION#v}"
+  local core_dir_parent="${GO_SCRIPT_BASH_CORE_DIR%/*}"
 
   if ! command -v curl >/dev/null; then
     printf "Failed to find cURL\n" >&2
@@ -62,17 +61,16 @@ download_go_script_bash_tarball() {
     return 1
   fi
   printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
-  if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") 2>/dev/null ||
+
+  if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") ||
     [[ ! -f "$unpacked_dir/go-core.bash" ]]; then
     printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
     return 1
-  fi
-  if ! mkdir -p "$GO_SCRIPTS_DIR" ; then
-    printf "Failed to create scripts dir '%s'\n" "$GO_SCRIPTS_DIR" >&2
+  elif [[ ! -d "$core_dir_parent" ]] && ! mkdir -p "$core_dir_parent" ; then
+    printf "Failed to create scripts dir '%s'\n" "$core_dir_parent" >&2
     rm -rf "$unpacked_dir"
     return 1
-  fi
-  if ! mv "$unpacked_dir" "$GO_SCRIPT_BASH_CORE_DIR"; then
+  elif ! mv "$unpacked_dir" "$GO_SCRIPT_BASH_CORE_DIR"; then
     printf "Failed to install downloaded directory in '%s'\n" \
       "$GO_SCRIPT_BASH_CORE_DIR" >&2
     rm -rf "$unpacked_dir"

--- a/go-template
+++ b/go-template
@@ -59,7 +59,7 @@ download_go_script_bash_tarball() {
   if [[ "$protocol" == "$url" ]]; then
     printf 'GO_SCRIPT_BASH_DOWNLOAD_URL has no protocol: %s\n' "$url" >&2
     return 1
-  elif [[ "$EXEPATH" =~ \\Git$ && "$protocol" == 'file' ]]; then
+  elif [[ "$(git --version)" =~ windows && "$protocol" == 'file' ]]; then
     url="file://$(cygpath -m "${url#file://}")"
   fi
 

--- a/go-template
+++ b/go-template
@@ -60,7 +60,7 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
       printf "Failed to find cURL or tar\n"
       return 1
     fi
-    if ! command tar -h >/dev/null; then
+    if ! command tar --help >/dev/null; then
       printf "Failed to find cURL or tar\n"
       return 1
     fi
@@ -70,7 +70,7 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
       return 1
     fi
     if ! mkdir -p $GO_SCRIPTS_DIR ; then
-      printf "Failed to create scripts dir '%s'" $GO_SCRIPTS_DIR >&2
+      printf "Failed to create scripts dir '%s'\n" $GO_SCRIPTS_DIR >&2
       rm -rf go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER
       return 1
     fi

--- a/go-template
+++ b/go-template
@@ -50,8 +50,7 @@ declare GO_SCRIPT_BASH_REPO_URL="${GO_SCRIPT_BASH_REPO_URL:-https://github.com/m
 declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_BASH_REPO_URL%.git}/archive}/$GO_SCRIPT_BASH_VERSION.tar.gz"
 
 if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
-  declare PIPEFAIL_BACKUP
-  PIPEFAIL_BACKUP=$(shopt -op | grep pipefail)
+  declare PIPEFAIL_BACKUP=($(shopt -op | grep pipefail))
   set -o pipefail
   
   # Using a function to allow for multiple return points
@@ -90,12 +89,12 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
         -b "$GO_SCRIPT_BASH_VERSION" "$GO_SCRIPT_BASH_REPO_URL" \
         "$GO_SCRIPT_BASH_CORE_DIR"; then
       printf "Failed to clone '%s'; aborting.\n" "$GO_SCRIPT_BASH_REPO_URL" >&2
-      $PIPEFAIL_BACKUP
+      "${PIPEFAIL_BACKUP[@]}"
       exit 1
     fi
     printf "Clone of '%s' successful.\n\n" "$GO_SCRIPT_BASH_REPO_URL"
   fi
-  $PIPEFAIL_BACKUP
+  "${PIPEFAIL_BACKUP[@]}"
 fi
 
 . "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"

--- a/go-template
+++ b/go-template
@@ -59,7 +59,7 @@ download_go_script_bash_tarball() {
   if [[ "$protocol" == "$url" ]]; then
     printf 'GO_SCRIPT_BASH_DOWNLOAD_URL has no protocol: %s\n' "$url" >&2
     return 1
-  elif command -v cygpath >/dev/null && [[ "$protocol" == 'file' ]]; then
+  elif [[ "$EXEPATH" =~ \\Git$ && "$protocol" == 'file' ]]; then
     url="file://$(cygpath -m "${url#file://}")"
   fi
 

--- a/go-template
+++ b/go-template
@@ -68,14 +68,15 @@ if [[ ! -e "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" ]]; then
       printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
       return 1
     fi
-    if ! mkdir -p $GO_SCRIPTS_DIR ; then
-      printf "Failed to create scripts dir '%s'\n" $GO_SCRIPTS_DIR >&2
-      rm -rf go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER
+    if ! mkdir -p "$GO_SCRIPTS_DIR" ; then
+      printf "Failed to create scripts dir '%s'\n" "$GO_SCRIPTS_DIR" >&2
+      rm -rf "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
       return 1
     fi
-    if ! mv go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER $GO_SCRIPT_BASH_CORE_DIR; then
-      printf "Failed to install downloaded directory in '%s'\n" $GO_SCRIPT_BASH_CORE_DIR >&2
-      rm -rf go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER
+    if ! mv "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER" "$GO_SCRIPT_BASH_CORE_DIR"; then
+      printf "Failed to install downloaded directory in '%s'\n" \
+        "$GO_SCRIPT_BASH_CORE_DIR" >&2
+      rm -rf "go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
       return 1
     fi
     printf "Download of '%s' successful.\n\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"

--- a/go-template
+++ b/go-template
@@ -53,11 +53,11 @@ declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_
 download_go_script_bash_tarball() {
   local unpacked_dir="go-script-bash-$_GO_SCRIPT_BASH_VERSION_NUMBER"
 
-  if ! command curl -V >/dev/null; then
+  if ! command -v curl >/dev/null; then
     printf "Failed to find cURL or tar\n"
     return 1
   fi
-  if ! command tar --help >/dev/null; then
+  if ! command -v tar >/dev/null; then
     printf "Failed to find cURL or tar\n"
     return 1
   fi

--- a/go-template
+++ b/go-template
@@ -51,18 +51,26 @@ download_go_script_bash_tarball() {
   # GitHub removes the leading 'v' from the archive's output directory.
   local unpacked_dir="go-script-bash-${GO_SCRIPT_BASH_VERSION#v}"
   local core_dir_parent="${GO_SCRIPT_BASH_CORE_DIR%/*}"
+  local download_cmd=()
 
-  if ! command -v curl >/dev/null; then
-    printf "Failed to find cURL\n" >&2
+  if command -v curl >/dev/null; then
+    download_cmd=(curl -LfsS)
+  elif command -v wget >/dev/null; then
+    download_cmd=(wget -O -)
+  elif command -v fetch >/dev/null; then
+    download_cmd=(fetch -o -)
+  else
+    printf "Failed to find cURL, wget, or fetch\n" >&2
     return 1
   fi
+
   if ! command -v tar >/dev/null; then
     printf "Failed to find tar\n" >&2
     return 1
   fi
   printf "Downloading framework from '%s'...\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL"
 
-  if ! tar -xzf <(curl -LfsS "$GO_SCRIPT_BASH_DOWNLOAD_URL") ||
+  if ! tar -xzf <("${download_cmd[@]}" "$GO_SCRIPT_BASH_DOWNLOAD_URL") ||
     [[ ! -f "$unpacked_dir/go-core.bash" ]]; then
     printf "Failed to download from '%s'.\n" "$GO_SCRIPT_BASH_DOWNLOAD_URL" >&2
     return 1

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -108,13 +108,13 @@ create_fake_tarball_if_not_using_real_url() {
 create_forwarding_script() {
   set "$DISABLE_BATS_SHELL_OPTIONS"
   local real_program="$(command -v "$1")"
-  local forwarding_script="$BATS_TEST_BINDIR/$1"
+  local script="$BATS_TEST_BINDIR/$1"
 
   if [[ ! -d "$BATS_TEST_BINDIR" ]]; then
     mkdir "$BATS_TEST_BINDIR"
   fi
-  printf '%s\n' "#! $BASH" "\"$real_program\" \"\$@\"" >"$forwarding_script"
-  chmod 700 "$forwarding_script"
+  printf '%s\n' "#! $BASH" "PATH='$PATH' \"$real_program\" \"\$@\"" >"$script"
+  chmod 700 "$script"
   restore_bats_shell_options
 }
 

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -2,31 +2,15 @@
 
 load environment
 
-# By default, the test will try to clone its own repo to avoid flakiness due to
-# an external dependency. However, doing so causes a failure on Travis, since it
-# uses shallow clones to produce test runs, resulting in the error:
-#
-#   fatal: attempt to fetch/clone from a shallow repository
-#
 # However, since Travis already depends on having a good connection to GitHub,
 # we'll use the real URL. Alternatively, `git` could be stubbed out via
 # `stub_program_in_path` from `_GO_CORE_DIR/lib/bats/helpers`, but the potential
 # for neither flakiness nor complexity seems that great, and this approach
-# provides extra confidence that the mechanism works as advertised.
-#
-# A developer can also run the test locally against the real URL by setting
-# `TEST_USE_REAL_URL` on the command line. The value of `GO_CORE_URL` is
-# subsequently displayed in the name of the test case to validate which repo is
-# being used during the test run.
-TEST_USE_REAL_URL="${TEST_USE_REAL_URL:-$TRAVIS}"
-GO_CORE_URL="${TEST_USE_REAL_URL:+$_GO_CORE_URL}"
-GO_CORE_URL="${GO_CORE_URL:-$_GO_CORE_DIR}"
 
 setup() {
   test_filter
   export GO_SCRIPT_BASH_VERSION="$_GO_CORE_VERSION"
   export GO_SCRIPTS_DIR="$_GO_TEST_DIR/tmp/go-template-test-scripts"
-  export GO_SCRIPT_BASH_REPO_URL="$GO_CORE_URL"
 }
 
 teardown() {
@@ -40,34 +24,34 @@ teardown() {
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
 }
 
-@test "$SUITE: clone the go-script-bash repository from $GO_CORE_URL" {
-  if [[ -e "$GO_CORE_URL/.git/shallow" ]]; then
-    skip "Can't clone shallow repositories"
-  fi
+@test "$SUITE: download the go-script-bash release from $GO_CORE_URL" {
   run "$_GO_CORE_DIR/go-template"
 
   # Without a command argument, the script will print the top-level help and
   # return an error, but the core repo should exist as expected.
   assert_failure
-  assert_output_matches "Cloning framework from '$GO_CORE_URL'\.\.\."
+  assert_output_matches "Downloading framework from '${GO_SCRIPT_BASH_REPO_URL%.git}.*.tar.gz'\.\.\."
 
   # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
   # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
-  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
-  assert_output_matches "Clone of '$GO_CORE_URL' successful\."$'\n\n'
+  assert_output_matches "Download of '${GO_SCRIPT_BASH_REPO_URL%.git}.*.tar.gz' successful."
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
   [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
 
-  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
-  run git log --oneline -n 1
-  assert_success
-  assert_output_matches "go-script-bash $_GO_CORE_VERSION"
 }
 
-@test "$SUITE: fail to clone a nonexistent repo" {
+@test "$SUITE: fail to download a nonexistent repo" {
   GO_SCRIPT_BASH_REPO_URL='bogus-repo-that-does-not-exist' \
     run "$_GO_CORE_DIR/go-template"
-  assert_failure "Cloning framework from 'bogus-repo-that-does-not-exist'..." \
-    "fatal: repository 'bogus-repo-that-does-not-exist' does not exist" \
-    "Failed to clone 'bogus-repo-that-does-not-exist'; aborting."
+  assert_failure "Downloading framework from 'bogus-repo-that-does-not-exist/archive/$GO_SCRIPT_BASH_VERSION.tar.gz'..." \
+    "curl: (6) Could not resolve host: bogus-repo-that-does-not-exist" \
+    "Failed to download from 'bogus-repo-that-does-not-exist/archive/$GO_SCRIPT_BASH_VERSION.tar.gz'; aborting." 
+}
+
+@test "$SUITE: fail to download a nonexistent version" {
+  GO_SCRIPT_BASH_VERSION='vnonexistent' \
+    run "$_GO_CORE_DIR/go-template"
+  assert_failure "Downloading framework from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'..." \
+    "curl: (22) The requested URL returned error: 404 Not Found" \
+    "Failed to download from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'; aborting." 
 }

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -223,13 +223,13 @@ run_with_download_program() {
   local repo='bogus-repo-that-does-not-exist'
   GO_SCRIPT_BASH_DOWNLOAD_URL="$url" GO_SCRIPT_BASH_REPO_URL="$repo" \
     run "$TEST_GO_ROOTDIR/go-template"
-  assert_failure "Downloading framework from '$url/$RELEASE_TARBALL'..." \
-    "curl: (6) Could not resolve host: $url" \
-    "Failed to download from '$url/$RELEASE_TARBALL'." \
-    'Using git clone as fallback' \
-    "Cloning framework from '$repo'..." \
-    "fatal: repository '$repo' does not exist" \
-    "Failed to clone '$repo'; aborting."
+  assert_failure
+  assert_output_matches "Downloading framework from '$url/$RELEASE_TARBALL'"
+  assert_output_matches "Failed to download from '$url/$RELEASE_TARBALL'"
+  assert_output_matches 'Using git clone as fallback'
+  assert_output_matches "Cloning framework from '$repo'"
+  assert_output_matches "fatal: repository '$repo' does not exist"
+  assert_output_matches "Failed to clone '$repo'; aborting."
 }
 
 @test "$SUITE: fail to download a nonexistent version" {

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -88,8 +88,8 @@ git_for_windows_native_path() {
   local path="$1"
   local protocol="${path%%://*}"
 
-  if [[ ! "$EXEPATH" =~ \\Git$ && "$protocol" != "$path" &&
-    "$protocol" != 'file' ]]; then
+  if [[ ! "$EXEPATH" =~ \\Git$ ]] ||
+    [[ "$protocol" != "$path" && "$protocol" != 'file' ]]; then
     printf '%s' "$path"
   elif [[ "$protocol" == 'file' ]]; then
     printf 'file://'

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -92,7 +92,6 @@ create_fake_tarball_if_not_using_real_url() {
       "$tarball" "$full_dir" >&2
     result='1'
   fi
-  printf 'MAKING TARBALL %s\n' "$tarball" >&2
   restore_bats_shell_options "$result"
 }
 

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -125,7 +125,7 @@ create_forwarding_script() {
 
   # Without a command argument, the script will print the top-level help and
   # return an error, but the core repo should exist as expected.
-  assert_output_matches "Failed to find cURL or tar"
+  assert_output_matches "Failed to find cURL"
   assert_output_matches "Using git clone as fallback"
   assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'"
   assert_output_matches "Cloning into '$TEST_GO_SCRIPTS_DIR/go-script-bash'"
@@ -146,7 +146,7 @@ create_forwarding_script() {
 
   # Without a command argument, the script will print the top-level help and
   # return an error, but the core repo should exist as expected.
-  assert_output_matches "Failed to find cURL or tar"
+  assert_output_matches "Failed to find tar"
   assert_output_matches "Using git clone as fallback"
   assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'"
   assert_output_matches "Cloning into '$TEST_GO_SCRIPTS_DIR/go-script-bash'"

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -11,6 +11,8 @@ setup() {
   test_filter
   export GO_SCRIPT_BASH_VERSION="$_GO_CORE_VERSION"
   export GO_SCRIPTS_DIR="$_GO_TEST_DIR/tmp/go-template-test-scripts"
+  export GO_SCRIPT_BASH_REPO_URL="https://github.com/mbland/go-script-bash.git"
+  export GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_REPO_URL%.git}/archive"
 }
 
 teardown() {
@@ -24,7 +26,7 @@ teardown() {
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
 }
 
-@test "$SUITE: download the go-script-bash release from $GO_CORE_URL" {
+@test "$SUITE: download the go-script-bash release from $GO_SCRIPT_BASH_REPO_URL" {
   run "$_GO_CORE_DIR/go-template"
 
   # Without a command argument, the script will print the top-level help and
@@ -42,10 +44,15 @@ teardown() {
 
 @test "$SUITE: fail to download a nonexistent repo" {
   GO_SCRIPT_BASH_REPO_URL='bogus-repo-that-does-not-exist' \
+    GO_SCRIPT_BASH_DOWNLOAD_URL='bogus-url-that-does-not-exist' \
     run "$_GO_CORE_DIR/go-template"
-  assert_failure "Downloading framework from 'bogus-repo-that-does-not-exist/archive/$GO_SCRIPT_BASH_VERSION.tar.gz'..." \
-    "curl: (6) Could not resolve host: bogus-repo-that-does-not-exist" \
-    "Failed to download from 'bogus-repo-that-does-not-exist/archive/$GO_SCRIPT_BASH_VERSION.tar.gz'; aborting." 
+  assert_failure "Downloading framework from 'bogus-url-that-does-not-exist/$GO_SCRIPT_BASH_VERSION.tar.gz'..." \
+    "curl: (6) Could not resolve host: bogus-url-that-does-not-exist" \
+    "Failed to download from 'bogus-url-that-does-not-exist/$GO_SCRIPT_BASH_VERSION.tar.gz'." \
+    "Using git clone as fallback" \
+    "Cloning framework from 'bogus-repo-that-does-not-exist'..." \
+    "fatal: repository 'bogus-repo-that-does-not-exist' does not exist" \
+    "Failed to clone 'bogus-repo-that-does-not-exist'; aborting."
 }
 
 @test "$SUITE: fail to download a nonexistent version" {
@@ -53,5 +60,61 @@ teardown() {
     run "$_GO_CORE_DIR/go-template"
   assert_failure "Downloading framework from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'..." \
     "curl: (22) The requested URL returned error: 404 Not Found" \
-    "Failed to download from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'; aborting." 
+    "Failed to download from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'." \
+    "Using git clone as fallback" \
+    "Cloning framework from 'https://github.com/mbland/go-script-bash.git'..." \
+    "Cloning into '/Users/paquete/octobot/repos/go-script-bash/tests/tmp/go-template-test-scripts/go-script-bash'..." \
+    "warning: Could not find remote branch vnonexistent to clone." \
+    "fatal: Remote branch vnonexistent not found in upstream origin" \
+    "Failed to clone 'https://github.com/mbland/go-script-bash.git'; aborting."
+}
+
+@test "$SUITE: fail to find curl uses git clone" {
+  PATH="$BATS_TEST_BINDIR:$PATH" 
+  stub_program_in_path curl "exit 1"
+  run "$_GO_CORE_DIR/go-template"
+  restore_program_in_path curl
+
+  # Without a command argument, the script will print the top-level help and
+  # return an error, but the core repo should exist as expected.
+  assert_output_matches "Failed to find cURL or tar"
+  assert_output_matches "Using git clone as fallback"
+  assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'\.\.\."
+
+  # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
+  # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
+  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
+  assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
+  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+
+  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
+  run git log --oneline -n 1
+  assert_success
+  assert_output_matches "go-script-bash $_GO_CORE_VERSION"
+}
+
+@test "$SUITE: fail to find tar uses git clone" {
+  PATH="$BATS_TEST_BINDIR:$PATH" 
+  stub_program_in_path tar "exit 1"
+  run "$_GO_CORE_DIR/go-template"
+  restore_program_in_path tar
+
+  # Without a command argument, the script will print the top-level help and
+  # return an error, but the core repo should exist as expected.
+  assert_output_matches "Failed to find cURL or tar"
+  assert_output_matches "Using git clone as fallback"
+  assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'\.\.\."
+
+  # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
+  # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
+  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
+  assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
+  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+
+  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
+  run git log --oneline -n 1
+  assert_success
+  assert_output_matches "go-script-bash $_GO_CORE_VERSION"
 }

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -135,6 +135,7 @@ run_with_download_program() {
 
   create_forwarding_script 'bash'
   create_forwarding_script 'tar'
+  create_forwarding_script 'gzip'
   create_forwarding_script 'mkdir'
   create_forwarding_script 'mv'
 

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -2,10 +2,25 @@
 
 load environment
 
+# By default, the test will try to clone its own repo to avoid flakiness due to
+# an external dependency. However, doing so causes a failure on Travis, since it
+# uses shallow clones to produce test runs, resulting in the error:
+#
+#   fatal: attempt to fetch/clone from a shallow repository
+#
 # However, since Travis already depends on having a good connection to GitHub,
 # we'll use the real URL. Alternatively, `git` could be stubbed out via
 # `stub_program_in_path` from `_GO_CORE_DIR/lib/bats/helpers`, but the potential
 # for neither flakiness nor complexity seems that great, and this approach
+# provides extra confidence that the mechanism works as advertised.
+#
+# A developer can also run the test locally against the real URL by setting
+# `TEST_USE_REAL_URL` on the command line. The value of `GO_CORE_URL` is
+# subsequently displayed in the name of the test case to validate which repo is
+# being used during the test run.
+TEST_USE_REAL_URL="${TEST_USE_REAL_URL:-$TRAVIS}"
+GO_CORE_URL="${TEST_USE_REAL_URL:+$_GO_CORE_URL}"
+GO_CORE_URL="${GO_CORE_URL:-$_GO_CORE_DIR}"
 
 setup() {
   test_filter

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -21,12 +21,13 @@ load environment
 TEST_USE_REAL_URL="${TEST_USE_REAL_URL:-$TRAVIS}"
 GO_CORE_URL="${TEST_USE_REAL_URL:+$_GO_CORE_URL}"
 GO_CORE_URL="${GO_CORE_URL:-$_GO_CORE_DIR}"
+GO_SCRIPT_BASH_VERSION="$_GO_CORE_VERSION"
+GO_SCRIPT_BASH_REPO_URL="https://github.com/mbland/go-script-bash.git"
+GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_REPO_URL%.git}/archive"
 
 setup() {
   test_filter
-  export GO_SCRIPT_BASH_VERSION="$_GO_CORE_VERSION"
-  export GO_SCRIPT_BASH_REPO_URL="https://github.com/mbland/go-script-bash.git"
-  export GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_REPO_URL%.git}/archive"
+  export GO_SCRIPT_BASH_{VERSION,REPO_URL,DOWNLOAD_URL}
 
   # Set up the template to run from `TEST_GO_ROOTDIR`. Add a dummy script to
   # ensure it doesn't return nonzero due to no scripts being present. This will

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -42,8 +42,9 @@ CLONE_DIR=
 setup() {
   test_filter
   export GO_SCRIPT_BASH_{VERSION,REPO_URL,DOWNLOAD_URL}
-  NATIVE_LOCAL_URL="$(windows_native_path "$LOCAL_DOWNLOAD_URL")"
-  CLONE_DIR="$(windows_native_path "$TEST_GO_SCRIPTS_DIR")/go-script-bash"
+  NATIVE_LOCAL_URL="$(git_for_windows_native_path "$LOCAL_DOWNLOAD_URL")"
+  CLONE_DIR="$(git_for_windows_native_path "$TEST_GO_SCRIPTS_DIR")"
+  CLONE_DIR+='/go-script-bash'
   EXPECTED_URL="$FULL_DOWNLOAD_URL"
 
   if [[ -z "$TEST_USE_REAL_URL" ]]; then
@@ -73,22 +74,22 @@ assert_go_core_unpacked() {
   restore_bats_shell_options "$result"
 }
 
-# Converts a Unix path or 'file://' URL to a Windows native path.
+# Converts a Unix path or 'file://' URL to a Git for Windows native path.
 #
-# This is useful when passing file paths or URLs to native programs on MSYS2
-# or Cygwin, or validating the output of such programs, to ensure portability.
+# This is useful when passing file paths or URLs to native programs on Git for
+# Windows, or validating the output of such programs, to ensure portability.
 # The resulting path will contain forward slashes.
 #
 # Prints both converted and unconverted paths and URLs to standard output.
 #
 # Arguments:
 #   path:  Path or 'file://' URL to convert
-windows_native_path() {
+git_for_windows_native_path() {
   local path="$1"
   local protocol="${path%%://*}"
 
-  if ! command -v cygpath >/dev/null ||
-    [[ "$protocol" != "$path" && "$protocol" != 'file' ]]; then
+  if [[ ! "$EXEPATH" =~ \\Git$ && "$protocol" != "$path" &&
+    "$protocol" != 'file' ]]; then
     printf '%s' "$path"
   elif [[ "$protocol" == 'file' ]]; then
     printf 'file://'

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -34,6 +34,18 @@ teardown() {
   rm -rf "$_GO_ROOTDIR/$GO_SCRIPTS_DIR"
 }
 
+assert_go_core_unpacked() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  local go_core="$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash"
+  local result='0'
+
+  if [[ ! -f "$go_core" ]]; then
+    printf "Download did not unpack go-core.bash to: $go_core" >&2
+    result='1'
+  fi
+  restore_bats_shell_options "$result"
+}
+
 @test "$SUITE: successfully run 'help' from its own directory" {
   GO_SCRIPT_BASH_CORE_DIR="$_GO_CORE_DIR" GO_SCRIPTS_DIR='scripts' \
     run "$_GO_CORE_DIR/go-template" 'help'
@@ -53,8 +65,7 @@ teardown() {
   # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
   assert_output_matches "Download of '${GO_SCRIPT_BASH_REPO_URL%.git}.*.tar.gz' successful."
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
-  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
-
+  assert_go_core_unpacked
 }
 
 @test "$SUITE: fail to download a nonexistent repo" {
@@ -101,7 +112,7 @@ teardown() {
   assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
   assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
-  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+  assert_go_core_unpacked
 
   cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
   run git log --oneline -n 1
@@ -126,7 +137,7 @@ teardown() {
   assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
   assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
-  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+  assert_go_core_unpacked
 
   cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
   run git log --oneline -n 1
@@ -152,7 +163,7 @@ teardown() {
   assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
   assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
-  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+  assert_go_core_unpacked
 
   cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
   run git log --oneline -n 1
@@ -178,7 +189,7 @@ teardown() {
   assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
   assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
   assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
-  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+  assert_go_core_unpacked
 
   cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
   run git log --oneline -n 1

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -177,15 +177,26 @@ run_with_download_program() {
   assert_go_core_unpacked
 }
 
-@test "$SUITE: download locally using wget" {
-  run_with_download_program 'wget'
+@test "$SUITE: download locally using fetch" {
+  run_with_download_program 'fetch'
   assert_output_matches "Downloading framework from '$LOCAL_DOWNLOAD_URL'\.\.\."
   assert_output_matches "Usage: $TEST_GO_ROOTDIR/go-template <command>"
   assert_go_core_unpacked
 }
 
-@test "$SUITE: download locally using fetch" {
-  run_with_download_program 'fetch'
+@test "$SUITE: download locally using cat" {
+  # We'll actually use `cat` with `file://` URLs, since `wget` only supports
+  # HTTP, HTTPS, and FTP.
+  run_with_download_program 'cat'
+  assert_output_matches "Downloading framework from '$LOCAL_DOWNLOAD_URL'\.\.\."
+  assert_output_matches "Usage: $TEST_GO_ROOTDIR/go-template <command>"
+  assert_go_core_unpacked
+}
+
+@test "$SUITE: download locally using wget" {
+  # As mentioned in the above test case, we'll actually use `cat` with `file://`
+  # URLs, but we're simulating `wget` by pretending `cat` doesn't exist.
+  run_with_download_program 'wget'
   assert_output_matches "Downloading framework from '$LOCAL_DOWNLOAD_URL'\.\.\."
   assert_output_matches "Usage: $TEST_GO_ROOTDIR/go-template <command>"
   assert_go_core_unpacked

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -335,7 +335,10 @@ run_with_download_program() {
 }
 
 @test "$SUITE: fail to find tar uses git clone" {
+  # If none of these are installed on the system, the test will fail.
   create_forwarding_script 'curl'
+  create_forwarding_script 'wget'
+  create_forwarding_script 'fetch'
   PATH="$BATS_TEST_BINDIR" run "$BASH" "$TEST_GO_ROOTDIR/go-template"
 
   assert_output_matches "Failed to find tar"

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -118,3 +118,55 @@ teardown() {
   assert_success
   assert_output_matches "go-script-bash $_GO_CORE_VERSION"
 }
+
+@test "$SUITE: fail to create directory uses git clone" {
+  PATH="$BATS_TEST_BINDIR:$PATH" 
+  stub_program_in_path mkdir "exit 1"
+  run "$_GO_CORE_DIR/go-template"
+  restore_program_in_path mkdir
+
+  # Without a command argument, the script will print the top-level help and
+  # return an error, but the core repo should exist as expected.
+  assert_output_matches "Downloading framework from '${GO_SCRIPT_BASH_REPO_URL%.git}.*.tar.gz'\.\.\."
+  assert_output_matches "Failed to create scripts dir '$GO_SCRIPTS_DIR'"
+  assert_output_matches "Using git clone as fallback"
+  assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'\.\.\."
+
+  # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
+  # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
+  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
+  assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
+  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+
+  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
+  run git log --oneline -n 1
+  assert_success
+  assert_output_matches "go-script-bash $_GO_CORE_VERSION"
+}
+
+@test "$SUITE: fail to move extracted directory uses git clone" {
+  PATH="$BATS_TEST_BINDIR:$PATH" 
+  stub_program_in_path mv "exit 1"
+  run "$_GO_CORE_DIR/go-template"
+  restore_program_in_path mv
+
+  # Without a command argument, the script will print the top-level help and
+  # return an error, but the core repo should exist as expected.
+  assert_output_matches "Downloading framework from '${GO_SCRIPT_BASH_REPO_URL%.git}.*.tar.gz'\.\.\."
+  assert_output_matches "Failed to install downloaded directory in '.*/$GO_SCRIPTS_DIR/go-script-bash'"
+  assert_output_matches "Using git clone as fallback"
+  assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'\.\.\."
+
+  # Use `.*/scripts/go-script-bash` to account for the fact that `git clone` on
+  # MSYS2 will output `C:/Users/<user>/AppData/Local/Temp/` in place of `/tmp`.
+  assert_output_matches "Cloning into '.*/$GO_SCRIPTS_DIR/go-script-bash'\.\.\."
+  assert_output_matches "Clone of '$GO_SCRIPT_BASH_REPO_URL' successful\."$'\n\n'
+  assert_output_matches "Usage: $_GO_CORE_DIR/go-template <command>"
+  [[ -f "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash/go-core.bash" ]]
+
+  cd "$_GO_ROOTDIR/$GO_SCRIPTS_DIR/go-script-bash"
+  run git log --oneline -n 1
+  assert_success
+  assert_output_matches "go-script-bash $_GO_CORE_VERSION"
+}

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -63,7 +63,7 @@ teardown() {
     "Failed to download from 'https://github.com/mbland/go-script-bash/archive/vnonexistent.tar.gz'." \
     "Using git clone as fallback" \
     "Cloning framework from 'https://github.com/mbland/go-script-bash.git'..." \
-    "Cloning into '/Users/paquete/octobot/repos/go-script-bash/tests/tmp/go-template-test-scripts/go-script-bash'..." \
+    "Cloning into '$PWD/$GO_SCRIPTS_DIR/go-script-bash'..." \
     "warning: Could not find remote branch vnonexistent to clone." \
     "fatal: Remote branch vnonexistent not found in upstream origin" \
     "Failed to clone 'https://github.com/mbland/go-script-bash.git'; aborting."

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -51,8 +51,9 @@ setup() {
     EXPECTED_URL="$NATIVE_LOCAL_URL"
   fi
 
-  # Ensure `cygpath` is always available if we need it.
+  # Ensure `cygpath` and `git` are always available if we need them.
   create_forwarding_script 'cygpath'
+  create_forwarding_script 'git'
 
   mkdir -p "$TEST_GO_ROOTDIR"
   cp "$_GO_CORE_DIR/go-template" "$TEST_GO_ROOTDIR"
@@ -88,7 +89,7 @@ git_for_windows_native_path() {
   local path="$1"
   local protocol="${path%%://*}"
 
-  if [[ ! "$EXEPATH" =~ \\Git$ ]] ||
+  if [[ ! "$(git --version)" =~ windows ]] ||
     [[ "$protocol" != "$path" && "$protocol" != 'file' ]]; then
     printf '%s' "$path"
   elif [[ "$protocol" == 'file' ]]; then
@@ -324,7 +325,6 @@ run_with_download_program() {
 }
 
 @test "$SUITE: fail to find download program uses git clone" {
-  create_forwarding_script 'git'
   PATH="$BATS_TEST_BINDIR" run "$BASH" "$TEST_GO_ROOTDIR/go-template"
 
   assert_output_matches "Failed to find cURL, wget, or fetch"
@@ -336,7 +336,6 @@ run_with_download_program() {
 
 @test "$SUITE: fail to find tar uses git clone" {
   create_forwarding_script 'curl'
-  create_forwarding_script 'git'
   PATH="$BATS_TEST_BINDIR" run "$BASH" "$TEST_GO_ROOTDIR/go-template"
 
   assert_output_matches "Failed to find tar"

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -99,7 +99,6 @@ assert_go_core_unpacked() {
 }
 
 @test "$SUITE: fail to find curl uses git clone" {
-  PATH="$BATS_TEST_BINDIR:$PATH" 
   stub_program_in_path curl "exit 1"
   run "$TEST_GO_ROOTDIR/go-template"
   restore_program_in_path curl
@@ -121,7 +120,6 @@ assert_go_core_unpacked() {
 }
 
 @test "$SUITE: fail to find tar uses git clone" {
-  PATH="$BATS_TEST_BINDIR:$PATH" 
   stub_program_in_path tar "exit 1"
   run "$TEST_GO_ROOTDIR/go-template"
   restore_program_in_path tar


### PR DESCRIPTION
Closes #179.

I've taken @elpaquete's fine work from #179 and refactored it a bit to:
* rebase on `master` (after I remembered to push the v1.5.0 commit just today—d'oh!)
* fix a few bugs
* add a few tests
* clean up the formatting
* restore the ability to test it without a network connection
* add the capability to use `wget` and `fetch` as well.

I still need to test this on all the platforms (I think I might need to add tweaks for MSYS2), but I hope to have it in by tomorrow and cut v1.6.0 right away.

@elpaquete Note that I found a way to get rid of `curl | tar` and `set -o pipefail`, namely by using a command substitution and checking that the expected output is present.