### PR TITLE
tests/template: Make fake tarball with BusyBox, and skip tests if programs are missing

### DIFF
--- a/go-template
+++ b/go-template
@@ -84,7 +84,7 @@ download_go_script_bash_tarball() {
   fi
   printf "Downloading framework from '%s'...\n" "$url"
 
-  if ! tar -xzf <("${download_cmd[@]}") || [[ ! -f "$unpacked_core" ]]; then
+  if ! tar -xzf - < <("${download_cmd[@]}") || [[ ! -f "$unpacked_core" ]]; then
     printf "Failed to download from '%s'.\n" "$url" >&2
     return 1
   elif [[ ! -d "$core_dir_parent" ]] && ! mkdir -p "$core_dir_parent" ; then

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -123,11 +123,11 @@ create_fake_tarball_if_not_using_real_url() {
   elif ! mkdir -p "$full_dir"; then
     printf 'Failed to create fake content dir %s\n' "$full_dir" >&2
     result='1'
-  elif ! tar xf <(tar cf - go-core.bash lib libexec) -C "$full_dir"; then
+  elif ! tar -xf - -C "$full_dir" < <(tar -cf - go-core.bash lib libexec); then
     printf 'Failed to mirror %s to fake tarball dir %s\n' \
       "$_GO_ROOTDIR" "$full_dir" >&2
     result='1'
-  elif ! tar cfz "$tarball" -C "$TEST_GO_ROOTDIR" "$dirname"; then
+  elif ! tar -czf "$tarball" -C "$TEST_GO_ROOTDIR" "$dirname"; then
     printf 'Failed to create fake tarball %s\n  from dir %s\n' \
       "$tarball" "$full_dir" >&2
     result='1'

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -311,7 +311,7 @@ run_with_download_program() {
   local repo='bogus-repo-that-does-not-exist'
 
   skip_if_none_present_on_system 'curl' 'fetch' 'wget'
-  skip_if_system_missing 'git'
+  skip_if_system_missing 'git' 'tar'
   GO_SCRIPT_BASH_DOWNLOAD_URL="$url" GO_SCRIPT_BASH_REPO_URL="$repo" \
     run "$TEST_GO_ROOTDIR/go-template"
   assert_failure
@@ -328,7 +328,7 @@ run_with_download_program() {
   local branch='vnonexistent'
 
   skip_if_none_present_on_system 'curl' 'fetch' 'wget'
-  skip_if_system_missing 'git'
+  skip_if_system_missing 'git' 'tar'
   GO_SCRIPT_BASH_VERSION="$branch" run "$TEST_GO_ROOTDIR/go-template"
   assert_failure
   assert_output_matches 'Using git clone as fallback'


### PR DESCRIPTION
### Making fake tarball with BusyBox

After thinking about it, I realized the `tar: lseek: Invalid seek` error produced by the BusyBox `tar` on Alpine Linux might be eliminated by having `tar` read from standard input rather than using `-f` to access directly the `/dev/fd` file created by the process substitution.

Also updated all the `tar` commands to make their invocations more consistent with one another.

### Skipping test cases

Most of the test cases will now be skipped if any of the required programs are missing, rather than failing and requiring the user to investigate.

Whereas `skip_if_system_missing` will skip a test case if any of the specified programs are missing, `skip_if_none_present_on_system` will skip a test case only if all of the programs are missing. I'll move it to `lib/bats/helpers` in a future commit.