### PR TITLE
Add null command

### DIFF
--- a/libexec/null
+++ b/libexec/null
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+#
+# Returns a successful exit value if the framework is properly installed
+#
+# If it fails, it should generate output indicating what's wrong with the
+# framework installation and exit with an error value.
+#
+# Useful for tests that only need to verify that the framework is installed
+# correctly, or for `_GO_STANDALONE` scripts that run a separate `./go` script
+# to install the framework.
+#
+# For maximum performance, avoid spawning a process to set `COLUMNS` like so:
+#
+#   COLUMNS=80 {{go}} {{cmd}}

--- a/tests/null.bats
+++ b/tests/null.bats
@@ -1,0 +1,23 @@
+#! /usr/bin/env bats
+
+load environment
+
+setup() {
+  @go.create_test_go_script
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: returns a successful value" {
+  COLUMNS=80 run "$TEST_GO_SCRIPT" null
+  assert_success ''
+}
+
+@test "$SUITE: a bad installation returns a successful value" {
+  rmdir "$TEST_GO_SCRIPTS_DIR"
+  COLUMNS=80 run "$TEST_GO_SCRIPT" null
+  assert_failure \
+    "ERROR: command script directory $TEST_GO_SCRIPTS_DIR does not exist"
+}

--- a/tests/null.bats
+++ b/tests/null.bats
@@ -10,12 +10,12 @@ teardown() {
   @go.remove_test_go_rootdir
 }
 
-@test "$SUITE: returns a successful value" {
+@test "$SUITE: a good installation emits nothing and exits successfully" {
   COLUMNS=80 run "$TEST_GO_SCRIPT" null
   assert_success ''
 }
 
-@test "$SUITE: a bad installation returns a successful value" {
+@test "$SUITE: a bad installation emits errors and exits unsuccessfully" {
   rmdir "$TEST_GO_SCRIPTS_DIR"
   COLUMNS=80 run "$TEST_GO_SCRIPT" null
   assert_failure \


### PR DESCRIPTION
Closes #189. This command is useful for tests and other cases where the proper installation of the framework must be verified.

Decided on 'null' instead of 'ok' since it's conceivable a user might want to define an application-specific 'ok' command.