### PR TITLE
bats/helpers: Improve clarity, robustness, speed

### DIFF
--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -91,8 +91,8 @@ create_bats_test_dirs() {
 # teardown().
 #
 # Arguments:
-#   $1:   Path of the script relative to BATS_TEST_ROOTDIR
-#   ...:  Lines comprising the script
+#   script_path:  Path of the script relative to BATS_TEST_ROOTDIR
+#   ...:          Lines comprising the script
 create_bats_test_script() {
   set "$DISABLE_BATS_SHELL_OPTIONS"
   __create_bats_test_script "$@"
@@ -353,15 +353,22 @@ create_forwarding_script() {
 # Returns:
 #   Zero if the stub program exists and is removed, nonzero otherwise
 restore_program_in_path() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+
   local cmd_name="$1"
+  local result='0'
   export PATH="${PATH#$BATS_TEST_BINDIR:}"
 
-  if [[ -e "$BATS_TEST_BINDIR/$cmd_name" ]]; then
-    rm -f "$BATS_TEST_BINDIR/$cmd_name"
-  else
+  if [[ -z "$cmd_name" ]]; then
+    printf 'No command name provided.' >&2
+    result='1'
+  elif [[ ! -e "$BATS_TEST_BINDIR/$cmd_name" ]]; then
     printf "Bats test stub program doesn't exist: %s\n" "$cmd_name"
-    return 1
+    result='1'
+  else
+    rm -f "$BATS_TEST_BINDIR/$cmd_name"
   fi
+  restore_bats_shell_options "$result"
 }
 
 # --------------------------------
@@ -392,29 +399,29 @@ __create_bats_test_dirs() {
 # Implementation for `create_bats_test_script`
 #
 # Arguments:
-#   $1:   Path of the script relative to BATS_TEST_ROOTDIR
-#   ...:  Lines comprising the script
+#   script_path:  Path of the script relative to BATS_TEST_ROOTDIR
+#   ...:          Lines comprising the script
 __create_bats_test_script() {
-  local script="$1"
+  local script_path="$1"
   shift
-  local script_dir="${script%/*}"
+  local script_dir="${script_path%/*}"
 
-  if [[ -z "$script" ]]; then
-    echo "No test script specified" >&2
+  if [[ -z "$script_path" ]]; then
+    echo "No test script name or path specified" >&2
     exit 1
-  elif [[ "$script_dir" == "$script" ]]; then
+  elif [[ "$script_dir" == "$script_path" ]]; then
     script_dir=''
   fi
 
   create_bats_test_dirs "$script_dir"
-  script="$BATS_TEST_ROOTDIR/$script"
-  rm -f "$script"
+  script_path="$BATS_TEST_ROOTDIR/$script_path"
+  rm -f "$script_path"
 
   if [[ "${1:0:2}" != '#!' ]]; then
-    echo "#! /usr/bin/env bash" >"$script"
+    printf '%s\n' '#! /usr/bin/env bash' >"$script_path"
   fi
-  printf '%s\n' "$@" >>"$script"
-  chmod 700 "$script"
+  printf '%s\n' "$@" >>"$script_path"
+  chmod 700 "$script_path"
 }
 
 # Enumerates programs not installed on the system for `skip_if_system_missing`

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -78,7 +78,7 @@ __check_dirs_exist() {
 
 @test "$SUITE: create_bats_test_script errors if no args" {
   run create_bats_test_script
-  assert_failure 'No test script specified'
+  assert_failure 'No test script name or path specified'
 }
 
 @test "$SUITE: create_bats_test_script creates Bash script" {
@@ -151,7 +151,7 @@ __check_dirs_exist() {
 @test "$SUITE: skip if system missing" {
   create_bats_test_script 'test.bats' \
     '#! /usr/bin/env bats' \
-    "load '$_GO_CORE_DIR/lib/bats/helpers'" \
+    ". '$_GO_CORE_DIR/lib/bats/helpers'" \
     '@test "skip if missing" { skip_if_system_missing foo bar baz; }'
 
   stub_program_in_path 'foo'
@@ -164,7 +164,7 @@ __check_dirs_exist() {
     'ok 1 skip if missing'
 
   rm "$BATS_TEST_BINDIR"/*
-  run bats "$BATS_TEST_ROOTDIR/test.bats"
+  run "$BATS_TEST_ROOTDIR/test.bats"
   assert_success
   assert_lines_equal '1..1' \
     'ok 1 # skip (foo, bar, baz not installed on the system) skip if missing'
@@ -265,6 +265,11 @@ __check_dirs_exist() {
   assert_failure "Bats test stub program doesn't exist: foobar"
 }
 
+@test "$SUITE: restore_program_in_path fails when not provided an argument" {
+  run restore_program_in_path
+  assert_failure 'No command name provided.'
+}
+
 @test "$SUITE: create_forwarding_script does nothing if program doesn't exist" {
   create_forwarding_script 'some-noexistent-program-name'
   fail_if matches "^${BATS_TEST_BINDIR}:" "$PATH"
@@ -272,7 +277,7 @@ __check_dirs_exist() {
   assert_failure
 }
 
-@test "$SUITE: create_forwarding_script script with PATH=\$BATS_TEST_BINDIR" {
+@test "$SUITE: find forwarding script with PATH=\$BATS_TEST_BINDIR" {
   create_forwarding_script 'bash'
   PATH="$BATS_TEST_BINDIR" run command -v 'bash'
   assert_success "$BATS_TEST_BINDIR/bash"


### PR DESCRIPTION
`create_bats_test_script` makes it a little clearer that the first argument is a script name or path.

`restore_program_in_path` guards against empty program names and disables Bats shell options to improve speed.

This is in preparation for upcoming updates and additions to `bats-helpers` prior to following through on #181.