### PR TITLE
bats/helpers: Reset executable hash after stubbing

### DIFF
--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -311,6 +311,7 @@ stub_program_in_path() {
   if [[ ! "$PATH" =~ $bindir_pattern ]]; then
     export PATH="$BATS_TEST_BINDIR:$PATH"
   fi
+  hash "$cmd_name"
 }
 
 # Creates a forwarding wrapper in `BATS_TEST_BINDIR` for an existing command
@@ -357,6 +358,8 @@ restore_program_in_path() {
 
   local cmd_name="$1"
   local result='0'
+
+  # Updating `PATH` clears the executable hash table, so no need to call `hash`.
   export PATH="${PATH#$BATS_TEST_BINDIR:}"
 
   if [[ -z "$cmd_name" ]]; then


### PR DESCRIPTION
`stub_program_in_path` now calls `hash` on the new stub to ensure it is discovered instead of the implementation it's intended to replace. Previously, if `stub_program_in_path` was invoked for a program that had already been executed by the test, the original program would still get invoked rather than the stub (unless `hash` was called or `PATH` was updated elsewhere).

Per the comments from the 'bats-helpers: {stub,restore}_program_in_path trigger Bash command rehash' test case:

`restore_program_in_path` unconditionally updates `PATH`, which resets Bash's executable path hash table. I didn't realize this until calling `stub_program_in_path` on `rm` and finding that the `rm` stub was only found when it was the first in a series of programs to be stubbed. After some trial and error, I realized this was because the `create_bats_test_script` call invokes `rm` and `stub_program_in_path` only modifies `PATH` on the first call.

This isn't documented in the Bash man page, but once I figured out what was happening, my hypothesis was confirmed by: https://superuser.com/a/1000317