### PR TITLE
lib/platform: Add module for _GO_PLATFORM_* vars

### DIFF
--- a/lib/platform
+++ b/lib/platform
@@ -1,0 +1,63 @@
+#! /bin/bash
+#
+# Sets the `_GO_PLATFORM_*` family of environment variables
+#
+# This module doesn't export any functions, only the `_GO_PLATFORM_*`
+# environment variables if `/etc/os-release` if present, or just
+# `_GO_PLATFORM_ID` otherwise, which is set to:
+#
+#   - 'macos' if the Bash variable `OSTYPE` matches 'darwin'
+#   - 'msys-git' if `git --version` matches 'windows'
+#   - `$OSTYPE` in all other cases
+#
+# For information on `/etc/os-release`, see:
+#   https://www.freedesktop.org/software/systemd/man/os-release.html
+
+# This can be set for testing.
+export __GO_ETC_OS_RELEASE="${__GO_ETC_OS_RELEASE:-/etc/os-release}"
+
+_@go.platform_os_release() {
+  local line
+  local value
+
+  if [[ ! -f "$__GO_ETC_OS_RELEASE" ]]; then
+    return 1
+  fi
+
+  while read -r line; do
+    line="${line%$'\r'}"
+    if [[ "$line" =~ ^[^#]+= ]]; then
+      value="${line#*=}"
+      value="${value#\"}"
+      printf -v "_GO_PLATFORM_${line%%=*}" '%s' "${value%\"}"
+    fi
+  done <"$__GO_ETC_OS_RELEASE"
+}
+
+_@go.platform_ostype() {
+  case "$OSTYPE" in
+  darwin*)
+    _GO_PLATFORM_ID='macos' 
+    ;;
+  msys)
+    _GO_PLATFORM_ID='msys'
+    if command -v 'git' >/dev/null && [[ "$(git --version)" =~ windows ]]; then
+      _GO_PLATFORM_ID+='-git'
+    fi
+    ;;
+  *)
+    _GO_PLATFORM_ID="$OSTYPE"
+    ;;
+  esac
+}
+
+_@go.platform() {
+  if [[ -n "$_GO_PLATFORM_ID" ]]; then
+    return
+  elif ! _@go.platform_os_release; then
+    _@go.platform_ostype
+  fi
+  export "${!_GO_PLATFORM_@}"
+}
+
+_@go.platform

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -1,0 +1,62 @@
+#! /usr/bin/env bats
+
+load environment
+
+PLATFORM_TEST_SCRIPT=
+
+setup() {
+  unset "${!_GO_PLATFORM_@}"
+  @go.create_test_go_script \
+    '. "$_GO_USE_MODULES" "platform"' \
+    'for var in "${!_GO_PLATFORM_@}"; do' \
+    '  printf "%s=\"%s\"\n" "$var" "${!var}"' \
+    'done'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: leave _GO_PLATFORM_ID unchanged if already set" {
+  _GO_PLATFORM_ID='foobar' run "$TEST_GO_SCRIPT"
+  assert_success '_GO_PLATFORM_ID="foobar"'
+}
+
+@test "$SUITE: set _GO_PLATFORM_* variables from /etc/os-release" {
+  local os_release_path="$BATS_TEST_ROOTDIR/os-release"
+  local vars=('NAME="Foo Bar"'
+    'ID=foobar'
+    'VERSION_ID=666')
+
+  mkdir -p "$BATS_TEST_ROOTDIR"
+  printf '%s\n' "${vars[@]}" >"$os_release_path"
+
+  __GO_ETC_OS_RELEASE="$os_release_path" run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="foobar"' \
+    '_GO_PLATFORM_NAME="Foo Bar"' \
+    '_GO_PLATFORM_VERSION_ID="666"'
+}
+
+@test "$SUITE: set _GO_PLATFORM_ID from OSTYPE" {
+  OSTYPE='foobar' run "$TEST_GO_SCRIPT"
+  assert_success '_GO_PLATFORM_ID="foobar"'
+}
+
+@test "$SUITE: set _GO_PLATFORM_ID to macos from OSTYPE" {
+  OSTYPE='darwin16' run "$TEST_GO_SCRIPT"
+  assert_success '_GO_PLATFORM_ID="macos"'
+}
+
+@test "$SUITE: set _GO_PLATFORM_ID to msys from OSTYPE" {
+  stub_program_in_path 'git' 'printf "%s\n" "git version 2.13.0"'
+  OSTYPE='msys' run "$TEST_GO_SCRIPT"
+  assert_success '_GO_PLATFORM_ID="msys"'
+}
+
+@test "$SUITE: set _GO_PLATFORM_ID to msys-git from OSTYPE and git --version" {
+  stub_program_in_path 'git' 'printf "%s\n" "git version 2.13.0.windows.1"'
+  OSTYPE='msys' run "$TEST_GO_SCRIPT"
+  assert_success '_GO_PLATFORM_ID="msys-git"'
+}

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -11,6 +11,7 @@ setup() {
     'for var in "${!_GO_PLATFORM_@}"; do' \
     '  printf "%s=\"%s\"\n" "$var" "${!var}"' \
     'done'
+  export __GO_ETC_OS_RELEASE="$BATS_TEST_ROOTDIR/os-release"
 }
 
 teardown() {
@@ -23,15 +24,13 @@ teardown() {
 }
 
 @test "$SUITE: set _GO_PLATFORM_* variables from /etc/os-release" {
-  local os_release_path="$BATS_TEST_ROOTDIR/os-release"
-  local vars=('NAME="Foo Bar"'
-    'ID=foobar'
-    'VERSION_ID=666')
-
   mkdir -p "$BATS_TEST_ROOTDIR"
-  printf '%s\n' "${vars[@]}" >"$os_release_path"
+  printf '%s\n' \
+    'NAME="Foo Bar"' \
+    'ID=foobar' \
+    'VERSION_ID=666' >"$__GO_ETC_OS_RELEASE"
 
-  __GO_ETC_OS_RELEASE="$os_release_path" run "$TEST_GO_SCRIPT"
+  run "$TEST_GO_SCRIPT"
   assert_success
   assert_lines_equal \
     '_GO_PLATFORM_ID="foobar"' \


### PR DESCRIPTION
Part of #184. Exports variables prefixed with `_GO_PLATFORM_` instead of just `PLATFORM_`.