### PR TITLE
lib/portability: Add @go.native_file_path_or_url

### DIFF
--- a/lib/platform
+++ b/lib/platform
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # Sets the `_GO_PLATFORM_*` family of environment variables
 #

--- a/lib/portability
+++ b/lib/portability
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+#
+# Functions to manage platform differences
+#
+# Exports:
+#   @go.native_file_path_or_url
+#     Converts a file system path or 'file://' URL to a platform-native path
+
+. "$_GO_USE_MODULES" 'platform' 'validation'
+
+# Converts a file system path or 'file://' URL to a platform-native path
+#
+# This is useful when passing file paths or URLs to native programs on Git for
+# Windows, or validating the output of such programs, to ensure portability.
+# The resulting path will contain forward slashes.
+#
+# Prints both converted and unconverted paths and URLs to the specified result
+# variable.
+#
+# Arguments:
+#   result_var_name:  Name of caller's variable in which to store the result
+#   path:             File system path or 'file://' URL to convert
+@go.native_file_path_or_url() {
+  local _gnp_protocol="${2%%://*}"
+  @go.validate_identifier_or_die 'Result variable name' "$1"
+
+  if [[ "$_GO_PLATFORM_ID" != 'msys-git' ]] ||
+    [[ "$_gnp_protocol" != "$2" && "$_gnp_protocol" != 'file' ]]; then
+    printf -v "$1" '%s' "$2"
+  elif [[ "$_gnp_protocol" == 'file' ]]; then
+    printf -v "$1" 'file://%s' "$(cygpath -m "${2#file://}")"
+  else
+    printf -v "$1" '%s' "$(cygpath -m "$2")"
+  fi
+}

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -206,10 +206,8 @@ _@go.get_file() {
     if [[ "${url:0:1}" != '/' ]]; then
       url="${PWD}/${url}"
     fi
-    if [[ "$url" =~ ^/[^/]+ && -d "$BASH_REMATCH/Windows" ]]; then
-      url="${BASH_REMATCH}:/${url#$BASH_REMATCH/}"
-    fi
-    url="file://${url}"
+    . "$_GO_USE_MODULES" 'portability'
+    @go.native_file_path_or_url 'url' "file://${url}"
   fi
   _@go.get_file_impl "$download_dir" "$filename" "$url"
 }

--- a/tests/portability/native-file-path-or-url.bats
+++ b/tests/portability/native-file-path-or-url.bats
@@ -1,0 +1,32 @@
+#! /usr/bin/env bats
+
+load ../environment
+load "$_GO_CORE_DIR/lib/portability"
+
+@test "$SUITE: return unaltered path if _GO_PLATFORM_ID isn't msys-git" {
+  local result
+  _GO_PLATFORM_ID='foobar' @go.native_file_path_or_url 'result' '/foo/bar'
+  assert_equal '/foo/bar' "$result"
+}
+
+@test "$SUITE: return unaltered path if protocol isn't file://" {
+  local result
+  _GO_PLATFORM_ID='msys-git' \
+    @go.native_file_path_or_url 'result' 'https://mike-bland.com/'
+  assert_equal 'https://mike-bland.com/' "$result"
+}
+
+@test "$SUITE: return updated file system path" {
+  skip_if_system_missing 'cygpath'
+  local result
+  _GO_PLATFORM_ID='msys-git' @go.native_file_path_or_url 'result' '/foo/bar'
+  assert_equal "$(cygpath -m '/foo/bar')" "$result"
+}
+
+@test "$SUITE: return updated file:// URL" {
+  skip_if_system_missing 'cygpath'
+  local result
+  _GO_PLATFORM_ID='msys-git' \
+    @go.native_file_path_or_url 'result' 'file:///foo/bar'
+  assert_equal "file://$(cygpath -m '/foo/bar')" "$result"
+}


### PR DESCRIPTION
Closes #187. Part of #186. Replaces `git_for_windows_native_path` and updates the interface to print to a result variable rather than standard output, avoiding a subshell when no conversion takes place.