### PR TITLE
lib/fileutil: Add @go.copy_files_safely

### DIFF
--- a/lib/fileutil
+++ b/lib/fileutil
@@ -8,8 +8,11 @@
 #
 #   @go.collect_file_paths
 #     Collects all the paths to regular files within a directory structure
+#
+#   @go.copy_files_safely
+#     Safely copy files into a target directory, preserving relative directories
 
-. "$_GO_USE_MODULES" 'log' 'path'
+. "$_GO_USE_MODULES" 'diff' 'log' 'path'
 
 # Creates a set of directories and any missing parents
 #
@@ -63,6 +66,94 @@
   @go.walk_file_system _@go.collect_file_paths_impl "$@"
 }
 
+# Safely copy files into a target directory, preserving relative directories
+#
+# Enables copying of selected files from one directory structure into another
+# with safety and feedback mechanisms. Useful for ensuring a target directory
+# stays in-sync with a source directory, while being alerted to differences.
+#
+# If `--src-dir` is specified and no source file paths are given, then the
+# contents of `--src-dir` will be copied, preserving the relative directory
+# structure of `--src-dir`.
+#
+# If source file paths are given, relative file paths will be preserved for all
+# files residing within `--src-dir`. Any absolute file paths and relative file
+# paths resolving to a directory outside `--src-dir` will be copied directly to
+# the top-level of `dest_dir` (i.e. no directory structure will be preserved).
+#
+# Options:
+#   --src-dir:    Parent directory of src files (default: `PWD`)
+#   --dir-mode:   Permissions to set for created directories
+#   --file-mode:  Permissions to set for copied files
+#   --edit:       Open _GO_DIFF_EDITOR to edit existing files that differ
+#   --verbose:    Emit source and destination file logs
+#
+# Arguments:
+#   src [src...]:  Paths to the files to copy
+#   dest_dir:      Destination directory for the copied file
+#
+# Returns:
+#   Zero if all files were copied, or if existing files had no differences
+#   Nonzero if any existing files had any differences
+#
+# Raises:
+#   `@go.log FATAL` on invalid or inaccessible file paths or failing file system
+#     operations
+@go.copy_files_safely() {
+  local __go_src_dir
+  local __go_dir_mode=()
+  local __go_file_mode
+  local __go_diff_files_args=()
+  local __go_verbose
+  local __go_src_files=()
+  local __go_dest_dir
+  local __go_source_file_errors=()
+  local src
+  local dest
+  local result='0'
+
+  _@go.parse_copy_files_safely_args "$@"
+
+  if ! _@go.set_source_files_for_copy_files_safely "${__go_src_files[@]}"; then
+    printf -v '__go_source_file_errors' '\n  %s' "${__go_source_file_errors[@]}"
+    @go.log FATAL "Source file list contains errors:$__go_source_file_errors"
+  elif [[ "${#__go_src_files[@]}" -eq '0' && -n "$__go_dest_dir" ]]; then
+    @go.log FATAL "No source files specified"
+  elif [[ "${#__go_src_files[@]}" -ne '0' && -z "$__go_dest_dir" ]]; then
+    @go.log FATAL "No destination directory specified"
+  fi
+
+  for src in "${__go_src_files[@]}"; do
+    if [[ "${src:0:1}" == '/' ]]; then
+      dest="$__go_dest_dir/${src##*/}"
+    else
+      dest="$__go_dest_dir/$src"
+      src="$__go_src_dir/$src"
+    fi
+
+    if [[ -n "$__go_verbose" ]]; then
+      @go.log INFO "Copying $src => $dest"
+    fi
+
+    if [[ -f "$dest" ]]; then
+      if ! @go.diff_files "${__go_diff_files_args[@]}" "$src" "$dest"; then
+        result='1'
+      fi
+    elif [[ -e "$dest" ]]; then
+      @go.log FATAL "$dest exists but isn't a regular file"
+    else
+      @go.create_dirs "${__go_dir_mode[@]}" "${dest%/*}"
+
+      if ! cp "$src" "$dest"; then
+        @go.log FATAL "Failed to copy $src to $dest"
+      elif [[ -n "$__go_file_mode" ]] && ! chmod "$__go_file_mode" "$dest"; then
+        @go.log FATAL "Failed to set permissions on $dest"
+      fi
+    fi
+  done
+  return "$result"
+}
+
 # --------------------------------
 # IMPLEMENTATION - HERE BE DRAGONS
 #
@@ -72,7 +163,7 @@
 # @go.walk_path_forwared helper to finds the first missing parent directory
 #
 # Arguments:
-#   path:  Path to examine whether 
+#   path:  Path to examine
 _@go.find_missing_parent_path() {
   __go_missing_parent="$1"
 
@@ -92,4 +183,108 @@ _@go.collect_file_paths_impl() {
   if [[ -f "$1" ]]; then
     __go_collected_file_paths+=("$1")
   fi
+}
+
+# Helper function to parse @go.copy_files_safely arguments
+#
+# Globals from @go.copy_files_safely set by this function:
+#   __go_src_dir:          Value of --src-dir
+#   __go_dir_mode:         Value of --dir-mode
+#   __go_file_mode:        Value of --file_mode
+#   __go_diff_files_args:  Value of --edit
+#   __go_verbose:          Value of --verbose
+#   __go_src_files:        Source files
+#   __go_dest_dir:         Destination directory
+#
+# Arguments:
+#   $@:  All arguments to @go.copy_files_safely
+_@go.parse_copy_files_safely_args() {
+  while [[ "$#" -ne '0' ]]; do
+    case "$1" in
+    --src-dir)
+      @go.add_parent_dir_if_relative_path '__go_src_dir' "$2"
+      @go.canonicalize_path '__go_src_dir' "$__go_src_dir"
+      shift 2
+      ;;
+    --dir-mode)
+      __go_dir_mode=('--mode' "$2")
+      shift 2
+      ;;
+    --file-mode)
+      __go_file_mode="$2"
+      shift 2
+      ;;
+    --edit)
+      __go_diff_files_args=('--edit')
+      shift
+      ;;
+    --verbose)
+      __go_verbose='true'
+      shift
+      ;;
+    *)
+      __go_src_files=("${@:1:$(($# - 1))}")
+      __go_dest_dir="${!#}"
+      @go.add_parent_dir_if_relative_path '__go_dest_dir' "$__go_dest_dir"
+      @go.canonicalize_path '__go_dest_dir' "$__go_dest_dir"
+      break
+      ;;
+    esac
+  done
+}
+
+# Helper for @go.copy_files_safely that ensures the source files are valid
+#
+# If `__go_src_dir` is set, it's assumed that it is a canonicalized absolute
+# path, thanks to `_@go.parse_copy_files_safely_args`.
+#
+# If no args are provided and `__go_src_dir` is set, `__go_src_files` will
+# contain the relative paths of all regular files from that directory.
+#
+# Otherwise, all args are validated as either valid absolute file paths or paths
+# relative to `__go_src_dir`. If `__go_src_dir` isn't set, it will be assigned
+# `PWD`.
+#
+# Globals from @go.copy_files_safely referenced or set by this function:
+#   __go_src_dir:          Common parent dir for relative source file paths
+#   __go_src_files:        Array in which valid source files will be stored
+#   __go_src_file_errors:  Array in which any file errors will be stored
+#
+# Arguments:
+#  $@:  Original list of file paths to validate
+_@go.set_source_files_for_copy_files_safely() {
+  local orig_src
+  local canonical_src
+  local absolute_src
+  local __go_collected_file_paths
+
+  if [[ -n "$__go_src_dir" && "$#" -eq '0' ]]; then
+    @go.collect_file_paths "$__go_src_dir"
+    __go_src_files=("${__go_collected_file_paths[@]#$__go_src_dir/}")
+    return
+  fi
+  __go_src_dir="${__go_src_dir:-$PWD}"
+  __go_src_files=()
+
+  for orig_src in "$@"; do
+    @go.add_parent_dir_if_relative_path --parent "$__go_src_dir" \
+      'absolute_src' "$orig_src"
+    @go.canonicalize_path 'absolute_src' "$absolute_src"
+    canonical_src="${absolute_src#$__go_src_dir/}"
+
+    if [[ -z "$orig_src" ]]; then
+      __go_source_file_errors+=("The empty string isn't a valid file name")
+    elif [[ "$canonical_src" == "$__go_src_dir" ]]; then
+      __go_source_file_errors+=("The --src-dir can't be a file path argument")
+    elif [[ ! -e "$absolute_src" ]]; then
+      __go_source_file_errors+=("File does not exist: $absolute_src")
+    elif [[ ! -f "$absolute_src" ]]; then
+      __go_source_file_errors+=("Path is not a regular file: $absolute_src")
+    elif [[ "${orig_src:0:1}" == '/' ]]; then
+      __go_src_files+=("$absolute_src")
+    else
+      __go_src_files+=("$canonical_src")
+    fi
+  done
+  return "${#__go_source_file_errors[@]}"
 }

--- a/tests/fileutil/copy-files-safely.bats
+++ b/tests/fileutil/copy-files-safely.bats
@@ -1,0 +1,180 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+SRC_DIR=
+DEST_DIR=
+
+setup() {
+  test_filter
+  @go.create_test_go_script \
+    '. "$_GO_USE_MODULES" "fileutil"' \
+    '@go.copy_files_safely "$@"'
+
+  SRC_DIR="$TEST_GO_ROOTDIR/src"
+  DEST_DIR="$TEST_GO_ROOTDIR/dest"
+  mkdir -p "$SRC_DIR" "$DEST_DIR"
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: empty argument list does nothing" {
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: log FATAL on source file errors" {
+  run "$TEST_GO_SCRIPT" '' 'bogus'
+  assert_failure
+  assert_line_matches '0' 'FATAL.* Source file list contains errors:'
+  assert_line_equals  '1' "  The empty string isn't a valid file name"
+}
+
+@test "$SUITE: log FATAL on empty source file list when dest_dir specified" {
+  run "$TEST_GO_SCRIPT" 'bogus'
+  assert_failure
+  assert_line_matches '0' 'FATAL.* No source files specified'
+}
+
+@test "$SUITE: log FATAL on empty dest_dir when source files specified" {
+  printf '%s\n' 'foo' >"$SRC_DIR/foo"
+
+  run "$TEST_GO_SCRIPT" --src-dir "$SRC_DIR"
+  assert_failure
+  assert_line_matches '0' 'FATAL.* No destination directory specified'
+}
+
+@test "$SUITE: does nothing if a file already exists" {
+  printf 'foo\n' >"$SRC_DIR/foo"
+  printf 'foo\n' >"$DEST_DIR/foo"
+
+  run "$TEST_GO_SCRIPT" "$SRC_DIR/foo" "$DEST_DIR"
+  assert_success ''
+}
+
+@test "$SUITE: warns if a file already exists and is different" {
+  skip_if_system_missing diff
+  printf 'foo\n' >"$SRC_DIR/foo"
+  printf 'bar\n' >"$DEST_DIR/foo"
+
+  run "$TEST_GO_SCRIPT" "$SRC_DIR/foo" "$DEST_DIR"
+  assert_failure
+  assert_lines_match "^WARN.* $SRC_DIR/foo differs from $DEST_DIR/foo\$"
+}
+
+@test "$SUITE: --edit opens _GO_DIFF_EDITOR if an existing file is different" {
+  skip_if_system_missing diff
+  printf 'foo\n' >"$SRC_DIR/foo"
+  printf 'bar\n' >"$DEST_DIR/foo"
+  stub_program_in_path 'vimdiff' \
+    'printf "%s\n" "LHS: $1" "RHS: $2"'
+
+  _GO_DIFF_EDITOR='vimdiff' run "$TEST_GO_SCRIPT" --edit \
+    "$SRC_DIR/foo" "$DEST_DIR"
+  restore_program_in_path 'vimdiff'
+
+  assert_failure
+  assert_lines_match \
+    "^WARN.* $SRC_DIR/foo differs from $DEST_DIR/foo\$" \
+    "^INFO.* Editing $SRC_DIR/foo and $DEST_DIR/foo\$" \
+    "LHS: $SRC_DIR/foo" \
+    "RHS: $DEST_DIR/foo"
+}
+
+@test "$SUITE: logs FATAL if the destination exists and isn't a regular file" {
+  printf 'foo\n' >"$SRC_DIR/foo"
+  mkdir "$DEST_DIR/foo"
+
+  run "$TEST_GO_SCRIPT" "$SRC_DIR/foo" "$DEST_DIR"
+  assert_failure
+  assert_line_matches '0' \
+    "^FATAL.* $DEST_DIR/foo exists but isn't a regular file"
+}
+
+@test "$SUITE: creates a new file with verbose output" {
+  printf 'foo\n' >"$SRC_DIR/foo"
+
+  run "$TEST_GO_SCRIPT" --verbose "$SRC_DIR/foo" "$DEST_DIR"
+  assert_success
+  assert_lines_match "^INFO.* Copying $SRC_DIR/foo => $DEST_DIR/foo\$"
+}
+
+@test "$SUITE: sets permissions for new directories and destination file" {
+  skip_if_cannot_trigger_file_permission_failure
+  printf 'foo\n' >"$SRC_DIR/foo"
+  rmdir "$DEST_DIR"
+
+  run "$TEST_GO_SCRIPT" --dir-mode 723 --file-mode 200 \
+    "$SRC_DIR/foo" "$DEST_DIR"
+  assert_success ''
+
+  run ls -ld "$DEST_DIR/"{,foo}
+  assert_success
+  assert_lines_match \
+    "^drwx-w--wx .* $DEST_DIR/*$" \
+    "^--w------- .* $DEST_DIR/foo\$"
+}
+
+@test "$SUITE: logs FATAL if copy fails" {
+  printf 'foo\n' >"$SRC_DIR/foo"
+  stub_program_in_path 'cp' 'exit 1'
+
+  run "$TEST_GO_SCRIPT" "$SRC_DIR/foo" "$DEST_DIR"
+  restore_program_in_path 'cp'
+  assert_failure
+  assert_line_matches '0' "FATAL.* Failed to copy $SRC_DIR/foo to $DEST_DIR/foo"
+}
+
+@test "$SUITE: logs FATAL if setting file permissions fails" {
+  printf 'foo\n' >"$SRC_DIR/foo"
+  stub_program_in_path 'chmod' 'exit 1'
+
+  run "$TEST_GO_SCRIPT" --file-mode 600 "$SRC_DIR/foo" "$DEST_DIR"
+  restore_program_in_path 'chmod'
+  assert_failure
+  assert_line_matches '0' "FATAL.* Failed to set permissions on $DEST_DIR/foo"
+}
+
+@test "$SUITE: copies files directly into top-level when paths are absolute" {
+  mkdir -p "$SRC_DIR/"{bar,quux/xyzzy}
+  printf '0\n' >"$SRC_DIR/foo"
+  printf '1\n' >"$SRC_DIR/bar/baz"
+  printf '2\n' >"$SRC_DIR/quux/xyzzy/plugh"
+
+  run "$TEST_GO_SCRIPT" --src-dir "$SRC_DIR" --verbose \
+    "$SRC_DIR/foo" \
+    "$SRC_DIR/bar/baz" \
+    "$SRC_DIR/quux/xyzzy/plugh" \
+    "$DEST_DIR"
+
+  assert_success
+  assert_lines_match \
+    "INFO.* Copying $SRC_DIR/foo => $DEST_DIR/foo" \
+    "INFO.* Copying $SRC_DIR/bar/baz => $DEST_DIR/baz" \
+    "INFO.* Copying $SRC_DIR/quux/xyzzy/plugh => $DEST_DIR/plugh"
+  assert_file_equals "$DEST_DIR/foo" '0'
+  assert_file_equals "$DEST_DIR/baz" '1'
+  assert_file_equals "$DEST_DIR/plugh" '2'
+}
+
+@test "$SUITE: preserves relative directories when paths are relative" {
+  mkdir -p "$SRC_DIR/"{bar,quux/xyzzy}
+  printf '0\n' >"$SRC_DIR/foo"
+  printf '1\n' >"$SRC_DIR/bar/baz"
+  printf '2\n' >"$SRC_DIR/quux/xyzzy/plugh"
+
+  run "$TEST_GO_SCRIPT" --src-dir "$SRC_DIR" --verbose "$DEST_DIR"
+
+  assert_success
+  # Since we're relying on --src-dir without file arguments, the copies will
+  # happen in lexicographic order.
+  assert_lines_match \
+    "INFO.* Copying $SRC_DIR/bar/baz => $DEST_DIR/bar/baz" \
+    "INFO.* Copying $SRC_DIR/foo => $DEST_DIR/foo" \
+    "INFO.* Copying $SRC_DIR/quux/xyzzy/plugh => $DEST_DIR/quux/xyzzy/plugh"
+  assert_file_equals "$DEST_DIR/foo" '0'
+  assert_file_equals "$DEST_DIR/bar/baz" '1'
+  assert_file_equals "$DEST_DIR/quux/xyzzy/plugh" '2'
+}

--- a/tests/fileutil/copy-files-safely/parse-args.bats
+++ b/tests/fileutil/copy-files-safely/parse-args.bats
@@ -1,0 +1,95 @@
+#! /usr/bin/env bats
+
+load ../../environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script \
+    '. "$_GO_USE_MODULES" "fileutil"' \
+    '_@go.parse_copy_files_safely_args "$@"' \
+    'for var_name in "${!__go_@}"; do' \
+    '  case "${var_name#__go_}" in' \
+    '  dir_mode|diff_files_args|src_files)' \
+    '    array_name="${var_name}[*]"' \
+    '    printf "%s: %s\n" "$var_name" "${!array_name}"' \
+    '    ;;' \
+    '  *)' \
+    '    printf "%s: %s\n" "$var_name" "${!var_name}"' \
+    '    ;;' \
+    '  esac' \
+    'done'
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: sets nothing when args empty" {
+  run "$TEST_GO_SCRIPT"
+  assert_success ''
+}
+
+@test "$SUITE: sets canonicalized real path of --src-dir relative to PWD" {
+  run "$TEST_GO_SCRIPT" '--src-dir' 'foo/bar/../baz'
+  assert_success "__go_src_dir: $TEST_GO_ROOTDIR/foo/baz"
+}
+
+@test "$SUITE: sets --dir-mode" {
+  run "$TEST_GO_SCRIPT" '--dir-mode' '755'
+  assert_success '__go_dir_mode: --mode 755'
+}
+
+@test "$SUITE: sets --file-mode" {
+  run "$TEST_GO_SCRIPT" '--file-mode' '644'
+  assert_success '__go_file_mode: 644'
+}
+
+@test "$SUITE: sets --edit" {
+  run "$TEST_GO_SCRIPT" '--edit'
+  assert_success '__go_diff_files_args: --edit'
+}
+
+@test "$SUITE: sets --verbose" {
+  run "$TEST_GO_SCRIPT" '--verbose'
+  assert_success '__go_verbose: true'
+}
+
+@test "$SUITE: sets dest dir only relative to PWD" {
+  run "$TEST_GO_SCRIPT" 'dest_dir'
+  assert_success \
+    "__go_dest_dir: $TEST_GO_ROOTDIR/dest_dir" \
+    '__go_src_files: '
+}
+
+@test "$SUITE: sets single src file and dest dir" {
+  run "$TEST_GO_SCRIPT" 'foo/bar' 'dest_dir'
+  assert_success \
+    "__go_dest_dir: $TEST_GO_ROOTDIR/dest_dir" \
+    '__go_src_files: foo/bar'
+}
+
+@test "$SUITE: sets multiple src files and dest dir" {
+  run "$TEST_GO_SCRIPT" 'foo/bar' 'baz/quux' 'xyzzy/plugh' 'dest_dir'
+  assert_success \
+    "__go_dest_dir: $TEST_GO_ROOTDIR/dest_dir" \
+    '__go_src_files: foo/bar baz/quux xyzzy/plugh'
+}
+
+@test "$SUITE: sets everything at once" {
+  run "$TEST_GO_SCRIPT" \
+    '--verbose' \
+    '--edit' \
+    '--file-mode' '644' \
+    '--dir-mode' '755' \
+    '--src-dir' 'foo/bar/../baz' \
+    'foo/bar' 'baz/quux' 'xyzzy/plugh' 'dest_dir'
+  assert_success
+  assert_lines_equal \
+    "__go_dest_dir: $TEST_GO_ROOTDIR/dest_dir" \
+    '__go_diff_files_args: --edit' \
+    '__go_dir_mode: --mode 755' \
+    '__go_file_mode: 644' \
+    "__go_src_dir: $TEST_GO_ROOTDIR/foo/baz" \
+    '__go_src_files: foo/bar baz/quux xyzzy/plugh' \
+    '__go_verbose: true'
+}

--- a/tests/fileutil/copy-files-safely/set-source-files.bats
+++ b/tests/fileutil/copy-files-safely/set-source-files.bats
@@ -1,0 +1,182 @@
+#! /usr/bin/env bats
+
+load ../../environment
+
+SRC_DIR=
+
+setup() {
+  test_filter
+  @go.create_test_go_script \
+    '. "$_GO_USE_MODULES" "fileutil"' \
+    '_@go.set_source_files_for_copy_files_safely "$@"' \
+    'result="$?"' \
+    'for var_name in "${!__go_@}"; do' \
+    '  case "${var_name#__go_}" in' \
+    '  src_files|source_file_errors)' \
+    '    printf "%s:\n" "$var_name"' \
+    '    array_name="${var_name}[@]"' \
+    '    for item in "${!array_name}"; do' \
+    '      printf "  %s\n" "$item"' \
+    '    done' \
+    '    ;;' \
+    '  *)' \
+    '    printf "%s: %s\n" "$var_name" "${!var_name}"' \
+    '    ;;' \
+    '  esac' \
+    'done' \
+    'exit "$result"'
+
+  SRC_DIR="$TEST_GO_ROOTDIR/src"
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: sets __go_src_dir to PWD when not set" {
+  run "$TEST_GO_SCRIPT"
+  assert_success \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: sets no files when __go_src_dir doesn't exist" {
+  __go_src_dir="$SRC_DIR" run "$TEST_GO_SCRIPT"
+  assert_success "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: sets no files when __go_src_dir contains no files" {
+  mkdir -p "$SRC_DIR/"{foo,bar/baz,quux/xyzzy/plugh}
+
+  __go_src_dir="$SRC_DIR" run "$TEST_GO_SCRIPT"
+  assert_success "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: collects relative file paths from __go_src_dir when args empty" {
+  mkdir -p "$SRC_DIR/"{foo,bar,quux/xyzzy,frobozz}
+  printf '%s\n' 'baz' >"$SRC_DIR/bar/baz"
+  printf '%s\n' 'plugh' >"$SRC_DIR/quux/xyzzy/plugh"
+  printf '%s\n' 'frotz' >"$SRC_DIR/frobozz/frotz"
+
+  __go_src_dir="$SRC_DIR" run "$TEST_GO_SCRIPT"
+  assert_success \
+    "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:' \
+    '  bar/baz' \
+    '  frobozz/frotz' \
+    '  quux/xyzzy/plugh'
+}
+
+@test "$SUITE: validates relative file path args against __go_src_dir" {
+  mkdir -p "$SRC_DIR/"{foo,bar,quux/xyzzy,frobozz}
+  printf '%s\n' 'baz' >"$SRC_DIR/bar/baz"
+  printf '%s\n' 'plugh' >"$SRC_DIR/quux/xyzzy/plugh"
+  printf '%s\n' 'frotz' >"$SRC_DIR/frobozz/frotz"
+
+  # Note that it omits any args not provided as arguments.
+  __go_src_dir="$SRC_DIR" run "$TEST_GO_SCRIPT" 'bar/baz' 'quux/xyzzy/plugh'
+  assert_success \
+    "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:' \
+    '  bar/baz' \
+    '  quux/xyzzy/plugh'
+}
+
+@test "$SUITE: passes through absolute paths into __go_src_dir" {
+  mkdir -p "$SRC_DIR/"{foo,bar,quux/xyzzy,frobozz}
+  printf '%s\n' 'baz' >"$SRC_DIR/bar/baz"
+  printf '%s\n' 'plugh' >"$SRC_DIR/quux/xyzzy/plugh"
+  printf '%s\n' 'frotz' >"$SRC_DIR/frobozz/frotz"
+
+  # Note that it omits any args not provided as arguments.
+  __go_src_dir="$SRC_DIR" run \
+    "$TEST_GO_SCRIPT" "$SRC_DIR/bar/baz" "$SRC_DIR/quux/xyzzy/plugh"
+
+  assert_success \
+    "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:' \
+    "  $SRC_DIR/bar/baz" \
+    "  $SRC_DIR/quux/xyzzy/plugh"
+}
+
+@test "$SUITE: passes through absolute paths not in __go_src_dir" {
+  mkdir -p "$SRC_DIR/"{foo,bar,quux/xyzzy,frobozz}
+  printf '%s\n' 'baz' >"$SRC_DIR/bar/baz"
+  printf '%s\n' 'plugh' >"$SRC_DIR/quux/xyzzy/plugh"
+  printf '%s\n' 'frotz' >"$SRC_DIR/frobozz/frotz"
+
+  __go_src_dir="$SRC_DIR/quux" run "$TEST_GO_SCRIPT" \
+    "$SRC_DIR/bar/baz" "$SRC_DIR/quux/xyzzy/plugh" "$SRC_DIR/frobozz/frotz"
+
+  assert_success \
+    "__go_src_dir: $SRC_DIR/quux" \
+    '__go_src_files:' \
+    "  $SRC_DIR/bar/baz" \
+    "  $SRC_DIR/quux/xyzzy/plugh" \
+    "  $SRC_DIR/frobozz/frotz"
+}
+
+@test "$SUITE: canonicalizes paths containing . and .." {
+  mkdir -p "$TEST_GO_ROOTDIR"
+  printf '%s\n' 'foo' >"$TEST_GO_ROOTDIR/foo"
+
+  run "$TEST_GO_SCRIPT" 'bar/./../foo/.'
+  assert_success \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:' \
+    "  foo"
+}
+
+@test "$SUITE: a source path matching __go_src_dir causes an error" {
+  run "$TEST_GO_SCRIPT" "$TEST_GO_ROOTDIR"
+  assert_failure \
+    '__go_source_file_errors:' \
+    "  The --src-dir can't be a file path argument" \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: an empty file path causes an error" {
+  run "$TEST_GO_SCRIPT" ''
+  assert_failure \
+    '__go_source_file_errors:' \
+    "  The empty string isn't a valid file name" \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: file paths producing parents of __go_src_dir become absolute" {
+  mkdir -p "$SRC_DIR" "$TEST_GO_ROOTDIR/baz"
+  printf '%s\n' 'bar' >"$TEST_GO_ROOTDIR/bar"
+  printf '%s\n' 'quux' >"$TEST_GO_ROOTDIR/baz/quux"
+
+  __go_src_dir="$SRC_DIR" run "$TEST_GO_SCRIPT" 'foo/../../bar' '../baz/quux'
+  assert_success \
+    "__go_src_dir: $SRC_DIR" \
+    '__go_src_files:' \
+    "  $TEST_GO_ROOTDIR/bar" \
+    "  $TEST_GO_ROOTDIR/baz/quux"
+}
+
+@test "$SUITE: nonexistent file path causes an error" {
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_failure \
+    '__go_source_file_errors:' \
+    "  File does not exist: $TEST_GO_ROOTDIR/foo" \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:'
+}
+
+@test "$SUITE: a file path that isn't a regular file causes an error" {
+  local dir_path="$TEST_GO_ROOTDIR/foo"
+  mkdir -p "$dir_path"
+
+  run "$TEST_GO_SCRIPT" 'foo'
+  assert_failure \
+    '__go_source_file_errors:' \
+    "  Path is not a regular file: $dir_path" \
+    "__go_src_dir: $TEST_GO_ROOTDIR" \
+    '__go_src_files:'
+}


### PR DESCRIPTION
Closes #184. Originally based on `copy_files_safely` from the `scripts/lib/copy` module of mbland/dev-setup.