### PR TITLE
Add @go.create_gzipped_tarball and perform other small refactors

### DIFF
--- a/go-template
+++ b/go-template
@@ -19,7 +19,7 @@
 # Make sure the variables within this script are configured as necessary for
 # your program. You can add any other initialization or configuration between:
 #
-#   . "$_GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"`
+#   . "$GO_SCRIPT_BASH_CORE_DIR/go-core.bash" "$GO_SCRIPTS_DIR"`
 #   `@go "$@"`
 
 # Set to 'true' if your script is a standalone program, i.e. not bound to
@@ -50,7 +50,6 @@ declare GO_SCRIPT_BASH_DOWNLOAD_URL="${GO_SCRIPT_BASH_DOWNLOAD_URL:-${GO_SCRIPT_
 download_go_script_bash_tarball() {
   # GitHub removes the leading 'v' from the archive's output directory.
   local unpacked_dir="go-script-bash-${GO_SCRIPT_BASH_VERSION#v}"
-  local unpacked_core="$unpacked_dir/go-core.bash"
   local core_dir_parent="${GO_SCRIPT_BASH_CORE_DIR%/*}"
   local url="$GO_SCRIPT_BASH_DOWNLOAD_URL"
   local protocol="${url%%://*}"
@@ -84,7 +83,8 @@ download_go_script_bash_tarball() {
   fi
   printf "Downloading framework from '%s'...\n" "$url"
 
-  if ! tar -xzf - < <("${download_cmd[@]}") || [[ ! -f "$unpacked_core" ]]; then
+  if ! "${download_cmd[@]}" | tar -xzf - ||
+    [[ "${PIPESTATUS[0]}" -ne '0' ]]; then
     printf "Failed to download from '%s'.\n" "$url" >&2
     return 1
   elif [[ ! -d "$core_dir_parent" ]] && ! mkdir -p "$core_dir_parent" ; then

--- a/lib/archive
+++ b/lib/archive
@@ -1,0 +1,104 @@
+#! /usr/bin/env bash
+#
+# Archive file utilities
+#
+# Exports:
+#   @go.create_gzipped_tarball
+#     Creates a Gzipped Tar archive file (.tar.gz)
+
+. "$_GO_USE_MODULES" 'fileutil' 'log' 'path'
+
+# Creates a Gzipped Tar archive file (.tar.gz)
+#
+# By default, will create a tarball with the same basename as that of the source
+# directory plus '.tar.gz', e.g. a source directory of 'foo' will create
+# 'foo.tar.gz'. The resulting tarball will extract to a directory with that
+# basename.
+#
+# If `--name` is specified, a new directory of that name will be created as a
+# sibling of the source directory (if the directory or symlink doesn't yet
+# exist), the selected contents from the source directory will be mirrored into
+# it, and the tarball will be created from that sibling.This means the resulting
+# tarball's name will be based on `--name`, and will extract to the directory
+# specified by `--name`. This sibling directory will be deleted automatically
+# unless `--keep-mirror` is specified.
+#
+# Using a mirror instead of a symlink is portable on platforms without symlink
+# capability. However, this function correctly handles `source_dir` and tarball
+# `--name` symlinks.
+#
+# If no specific items are listed after the source directory, the entire
+# directory will be archived. These items should be relative paths within the
+# source directory.
+#
+# Options:
+#   --name:           Specifies an alternative name for the tarball
+#   --keep-mirror:    Keep the new directory created when `--name` is specified
+#   --remove-source:  Remove the source directory after the tarball is created
+#
+# Arguments:
+#   source_dir:  Directory containing files to archive
+#   ...:         If specified, selected items from `source_dir` to archive
+@go.create_gzipped_tarball() {
+  local source_dir
+  local tarball_dir
+  local real_source_dir
+  local real_tarball_dir
+  local tarball
+  local items
+  local keep_mirror
+  local remove_source
+  local varname
+
+  while [[ "$#" -ne '0' ]]; do
+    case "$1" in
+    --name)
+      tarball_dir="$2"
+      shift 2
+      ;;
+    --keep-mirror|--remove-source)
+      varname="${1#--}"
+      printf -v "${varname//-/_}" 'true'
+      shift
+      ;;
+    *)
+      break
+      ;;
+    esac
+  done
+
+  @go.canonicalize_path --pwd 'source_dir' "$1"
+  shift
+
+  if [[ -n "$tarball_dir" ]]; then
+    tarball_dir="${source_dir%/*}/${tarball_dir}"
+  else
+    tarball_dir="$source_dir"
+  fi
+  tarball="${tarball_dir}.tar.gz"
+
+  @go.realpath 'real_source_dir' "$source_dir"
+  @go.realpath 'real_tarball_dir' "$tarball_dir"
+
+  if [[ ! -d "$source_dir" ]]; then
+    @go.log FATAL "Source directory $source_dir doesn't exist"
+  elif [[ "$real_source_dir" != "$real_tarball_dir" ]]; then
+    @go.mirror_directory "$source_dir" "$tarball_dir" "$@"
+  else
+    keep_mirror='true'
+  fi
+
+  if [[ "$#" -eq '0' ]]; then
+    items=("${tarball_dir##*/}/.")
+  else
+    items=("${@/#/${tarball_dir##*/}/}")
+  fi
+
+  if ! tar -czf "$tarball" -C "${real_tarball_dir%/*}" "${items[@]}"; then
+    @go.log FATAL "Failed to create $tarball from $source_dir"
+  elif [[ -z "$keep_mirror" ]] && ! rm -rf "$tarball_dir"; then
+    @go.log FATAL "Failed to remove $tarball_dir after creating $tarball"
+  elif [[ -n "$remove_source" ]] && ! rm -rf "$source_dir"; then
+    @go.log FATAL "Failed to remove $source_dir after creating $tarball"
+  fi
+}

--- a/lib/fileutil
+++ b/lib/fileutil
@@ -165,6 +165,10 @@
 # directory exists. Automatically creates the destination directory if it
 # doesn't exist.
 #
+# If specific path arguments aren't given after the `src_dir` and `dest_dir`
+# arguments, all of the items in `src_dir` will be included by default. If they
+# are given, only those items will be mirrored.
+#
 # Uses only `tar` features that are portable across platform variants. More
 # portable than `rsync`, which isn't installed by default on some systems; and
 # can be faster than `cp -a`.
@@ -172,15 +176,23 @@
 # Arguments:
 #   src_dir:   Original directory path
 #   dest_dir:  Mirrored directory path
-#   ...:       Paths relative to `src_dir` to include in the mirror
+#   ...:       Specific paths relative to `src_dir` to include in the mirror
 @go.mirror_directory() {
   local src_dir="$1"
   local dest_dir="$2"
+  local items=("${@:3}")
   local real_src
   local real_dest
 
+  @go.canonicalize_path --pwd 'src_dir' "$1"
+  @go.canonicalize_path --pwd 'dest_dir' "$2"
+
   @go.realpath 'real_src' "$src_dir"
   @go.realpath 'real_dest' "$dest_dir"
+
+  if [[ "${#items[@]}" -eq '0' ]]; then
+    items=('.')
+  fi
 
   if [[ "$real_src" == "$real_dest" ]]; then
     @go.log FATAL "Real source and destination dirs are the same:"$'\n'\
@@ -191,7 +203,7 @@
     @go.log FATAL "Source directory $src_dir doesn't exist"
   elif [[ ! -d "$dest_dir" ]] && ! mkdir -p "$dest_dir"; then
     @go.log FATAL "Failed to create destination directory $dest_dir"
-  elif ! tar -cf - -C "$src_dir" "${@:3}" | tar -xf - -C "$dest_dir" ||
+  elif ! tar -cf - -C "$src_dir" "${items[@]}" | tar -xf - -C "$dest_dir" ||
     [[ "${PIPESTATUS[0]}" != '0' ]]; then
     @go.log FATAL "Failed to mirror files from $src_dir to $dest_dir"
   fi

--- a/lib/fileutil
+++ b/lib/fileutil
@@ -245,8 +245,7 @@ _@go.parse_copy_files_safely_args() {
   while [[ "$#" -ne '0' ]]; do
     case "$1" in
     --src-dir)
-      @go.add_parent_dir_if_relative_path '__go_src_dir' "$2"
-      @go.canonicalize_path '__go_src_dir' "$__go_src_dir"
+      @go.canonicalize_path --pwd '__go_src_dir' "$2"
       shift 2
       ;;
     --dir-mode)
@@ -268,8 +267,7 @@ _@go.parse_copy_files_safely_args() {
     *)
       __go_src_files=("${@:1:$(($# - 1))}")
       __go_dest_dir="${!#}"
-      @go.add_parent_dir_if_relative_path '__go_dest_dir' "$__go_dest_dir"
-      @go.canonicalize_path '__go_dest_dir' "$__go_dest_dir"
+      @go.canonicalize_path --pwd '__go_dest_dir' "$__go_dest_dir"
       break
       ;;
     esac
@@ -310,9 +308,7 @@ _@go.set_source_files_for_copy_files_safely() {
   __go_src_files=()
 
   for orig_src in "$@"; do
-    @go.add_parent_dir_if_relative_path --parent "$__go_src_dir" \
-      'absolute_src' "$orig_src"
-    @go.canonicalize_path 'absolute_src' "$absolute_src"
+    @go.canonicalize_path  --parent "$__go_src_dir" 'absolute_src' "$orig_src"
     canonical_src="${absolute_src#$__go_src_dir/}"
 
     if [[ -z "$orig_src" ]]; then

--- a/lib/path
+++ b/lib/path
@@ -25,13 +25,34 @@
 # This will reduce any consecutive string of slashes to a single slash, and trim
 # a trailing slash if one remains.
 #
+# Options:
+#   --pwd:           Prepend `$PWD` to path before canonicalization if relative
+#   --parent <dir>:  Specifies parent dir prepended before canonicalization
+#
 # Arguments:
 #   result_var_name:   Name of the variable into which the result will be stored
 #   path:              Path to canonicalize
 @go.canonicalize_path() {
+  local add_pwd
+  local add_parent=()
+
+  case "$1" in
+  --pwd)
+    add_pwd='true'
+    shift
+    ;;
+  --parent)
+    add_parent=('--parent' "$2")
+    shift 2
+    ;;
+  esac
   @go.validate_identifier_or_die 'Canonicalized path result variable' "$1"
 
   printf -v "$1" '%s' "${2}${2:+/}"
+
+  if [[ -n "${!1}" && (-n "$add_pwd" || "${#add_parent[@]}" -ne '0') ]]; then
+    @go.add_parent_dir_if_relative_path "${add_parent[@]}" "$1" "${!1}"
+  fi
 
   while [[ "${!1}" =~ //+ ]]; do
     printf -v "$1" '%s' "${!1/"${BASH_REMATCH[0]}"//}"

--- a/tests/archive/create-gzipped-tarball.bats
+++ b/tests/archive/create-gzipped-tarball.bats
@@ -1,0 +1,277 @@
+#! /usr/bin/env bats
+
+load ../environment
+
+SRC_DIR="$TEST_GO_ROOTDIR/foo"
+ITEMS=
+
+setup() {
+  test_filter
+  @go.create_test_go_script \
+    '. "$_GO_USE_MODULES" "archive"' \
+    '@go.create_gzipped_tarball "$@"'
+
+  mkdir -p "$SRC_DIR"{/baz,/xyzzy/plugh}
+  ITEMS=('bar' 'baz/quux' 'xyzzy/plugh/frobozz' 'xyzzy/plugh/frotz')
+
+  local item
+  for item in "${ITEMS[@]}"; do
+    printf '%s\n' "$item" >"${SRC_DIR}/${item}"
+  done
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+validate_dirs() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  _validate_dirs "$@"
+  restore_bats_shell_options "$?"
+}
+
+_validate_dirs() {
+  local result='0'
+  local mirror_dir
+
+  while [[ "$#" -ne '0' ]]; do
+    case "$1" in
+    --source-kept)
+      if [[ ! -d "$SRC_DIR" ]]; then
+        printf "Source directory %s should not've been removed\n" "$SRC_DIR" >&2
+        result='1'
+      fi
+      ;;
+    --source-removed)
+      if [[ -d "$SRC_DIR" ]]; then
+        printf "Source directory %s should've been removed\n" "$SRC_DIR" >&2
+        result='1'
+      fi
+      ;;
+    --mirror-*)
+      if [[ ! "${1#--mirror-}" =~ ^(kept|removed)$ ]]; then
+        printf 'Unknown flag: %s\n' "$1" >&2
+        result='1'
+      elif [[ -z "$2" ]]; then
+        printf '%s argument empty\n' "$1" >&2
+        result='1'
+      fi
+      mirror_dir="$TEST_GO_ROOTDIR/$2"
+
+      if [[ "$1" == '--mirror-kept' && ! -d "$mirror_dir" ]]; then
+        printf "Mirror directory %s should not've been removed\n" \
+          "$mirror_dir" >&2
+        result='1'
+      elif [[ "$1" == '--mirror-removed' && -d "$mirror_dir" ]]; then
+        printf "Mirror directory %s should've been removed\n" "$mirror_dir" >&2
+        result='1'
+      fi
+      shift
+      ;;
+    *)
+      printf 'Unknown flag: %s\n' "$1" >&2
+      result='1'
+      ;;
+    esac
+    shift
+  done
+
+  rm -rf "$SRC_DIR"
+  if [[ -n "$mirror_dir" ]]; then
+    rm -rf "$mirror_dir"
+  fi
+  return "$result"
+}
+
+validate_tarball() {
+  set "$DISABLE_BATS_SHELL_OPTIONS"
+  _validate_tarball "$@"
+  restore_bats_shell_options "$?"
+}
+
+_validate_tarball() {
+  local expected_tarball="$1"
+  local expected_items=("${@:2}")
+  local __go_collected_file_paths=()
+  local unexpected_items=()
+  local tarball_name="${expected_tarball##*/}"
+  local tarball_dir="${TEST_GO_ROOTDIR}/${tarball_name%.tar.gz}"
+  local expected_item
+  local actual_item
+  local result='0'
+
+  if [[ ! -f "$expected_tarball" ]]; then
+    printf 'Did not create expected tarball %s\n' "$expected_tarball" >&2
+    result='1'
+  elif ! tar -xvzf "$expected_tarball" -C "$TEST_GO_ROOTDIR" >&2; then
+    printf 'Failed to extract %s\n' "$expected_tarball" >&2
+    result='1'
+  else
+    for expected_item in "${expected_items[@]}"; do
+      if [[ ! -f "$tarball_dir/$expected_item" ]]; then
+        printf 'Failed to extract: %s\n' "$expected_item" >&2
+        result='1'
+      fi
+    done
+
+    . "$_GO_USE_MODULES" 'fileutil'
+    @go.collect_file_paths "$tarball_dir"
+    __go_collected_file_paths=("${__go_collected_file_paths[@]#$tarball_dir/}")
+
+    for actual_item in "${__go_collected_file_paths[@]}"; do
+      for expected_item in "${expected_items[@]}"; do
+        if [[ "$actual_item" == "$expected_item" ]]; then
+          continue 2
+        fi
+      done
+      unexpected_items+=("$actual_item")
+    done
+
+    if [[ "${#unexpected_items[@]}" -ne '0' ]]; then
+      printf 'Unexpected items included in tarball:\n' >&2
+      printf '  %s\n' "${unexpected_items[@]}" >&2
+      result='1'
+    fi
+  fi
+  return "$result"
+}
+
+@test "$SUITE: successfully create a tarball" {
+  skip_if_system_missing 'tar'
+  run "$TEST_GO_SCRIPT" "$SRC_DIR"
+  assert_success ''
+  validate_dirs --source-kept
+  validate_tarball "$TEST_GO_ROOTDIR/foo.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: successfully create a tarball relative to PWD" {
+  skip_if_system_missing 'tar'
+
+  # _GO_STANDALONE prevents PWD from always being _GO_ROOTDIR.
+  cd "$SRC_DIR/xyzzy/plugh"
+  _GO_STANDALONE='true' run "$TEST_GO_SCRIPT" '../..'
+  cd - >/dev/null
+
+  assert_success ''
+  validate_dirs --source-kept
+  validate_tarball "$TEST_GO_ROOTDIR/foo.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: successfully create a tarball with a different name" {
+  skip_if_system_missing 'tar'
+  run "$TEST_GO_SCRIPT" '--name' 'foo-0.1.0' "$SRC_DIR"
+  assert_success ''
+  validate_dirs --source-kept --mirror-removed 'foo-0.1.0'
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: successfully create a tarball from a symlink" {
+  skip_if_system_missing 'tar' 'ln'
+  if [[ "$OSTYPE" == 'msys' ]]; then
+    skip "ln doesn't work like it normally does on MSYS2"
+  fi
+
+  ln -s "$SRC_DIR" "${SRC_DIR}-0.1.0"
+  run "$TEST_GO_SCRIPT" '--remove-source' "${SRC_DIR}-0.1.0"
+  assert_success ''
+
+  # Remember that `--source-kept` checks `$SRC_DIR`; recursively removing
+  # 'foo-0.1.0' should only remove the symlink, but leave `$SRC_DIR` intact.
+  validate_dirs --source-kept --mirror-removed 'foo-0.1.0'
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: create a tarball with only certain files" {
+  skip_if_system_missing 'tar'
+  unset 'ITEMS[0]' 'ITEMS[2]'
+  run "$TEST_GO_SCRIPT" '--name' 'foo-0.1.0' "$SRC_DIR" "${ITEMS[@]}"
+  assert_success ''
+  validate_dirs --source-kept --mirror-removed 'foo-0.1.0'
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: create a tarball from a symlink with only certain files" {
+  skip_if_system_missing 'tar' 'ln'
+  if [[ "$OSTYPE" == 'msys' ]]; then
+    skip "ln doesn't work like it normally does on MSYS2"
+  fi
+
+  ln -s "$SRC_DIR" "${SRC_DIR}-0.1.0"
+  unset 'ITEMS[0]' 'ITEMS[2]'
+  run "$TEST_GO_SCRIPT" "${SRC_DIR}-0.1.0" "${ITEMS[@]}"
+  assert_success ''
+  validate_dirs --source-kept --mirror-kept 'foo-0.1.0'
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: remove the source directory after creating the tarball" {
+  skip_if_system_missing 'tar'
+  run "$TEST_GO_SCRIPT" '--name' 'foo-0.1.0' '--remove-source' "$SRC_DIR"
+  assert_success ''
+  validate_dirs --source-removed
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: keep the mirror directory after creating the tarball" {
+  skip_if_system_missing 'tar'
+  run "$TEST_GO_SCRIPT" '--name' 'foo-0.1.0' '--keep-mirror' "$SRC_DIR"
+  assert_success ''
+  validate_dirs --source-kept --mirror-kept 'foo-0.1.0'
+  validate_tarball "$TEST_GO_ROOTDIR/foo-0.1.0.tar.gz" "${ITEMS[@]}"
+}
+
+@test "$SUITE: logs FATAL when the source directory doesn't exist" {
+  run "$TEST_GO_SCRIPT" "$TEST_GO_ROOTDIR/nonexistent"
+  assert_failure
+  assert_line_matches '0' \
+    "FATAL.* Source directory $TEST_GO_ROOTDIR/nonexistent doesn't exist"
+}
+
+@test "$SUITE: logs FATAL when tar fails" {
+  skip_if_system_missing 'tar'
+  stub_program_in_path 'tar' \
+    'if [[ "$1" == '-czf' ]]; then' \
+    '  exit 1' \
+    'fi' \
+    "$(command -v 'tar') \"\$@\""
+
+  run "$TEST_GO_SCRIPT" "$SRC_DIR"
+  restore_program_in_path 'tar'
+  assert_failure
+  assert_line_matches '0' \
+    "FATAL.* Failed to create $SRC_DIR.tar.gz from $SRC_DIR"
+}
+
+@test "$SUITE: logs fatal when removing the mirror dir fails" {
+  skip_if_system_missing 'tar'
+
+  local tarball_dir="${SRC_DIR}-0.1.0"
+
+  stub_program_in_path 'rm' \
+    "if [[ \"\$2\" ==  \"$tarball_dir\" ]]; then" \
+    '  exit 1' \
+    'fi' \
+    "$(command -v 'rm') \"\$@\""
+
+  run "$TEST_GO_SCRIPT" '--name' 'foo-0.1.0' "$SRC_DIR"
+  restore_program_in_path 'rm'
+  assert_failure
+  assert_line_matches '0' \
+    "FATAL.* Failed to remove $tarball_dir after creating ${tarball_dir}.tar.gz"
+}
+
+@test "$SUITE: logs fatal when removing the source dir fails" {
+  skip_if_system_missing 'tar'
+
+  stub_program_in_path 'rm' \
+    "if [[ \"\$2\" ==  \"${SRC_DIR}\" ]]; then" \
+    '  exit 1' \
+    'fi' \
+    "$(command -v 'rm') \"\$@\""
+
+  run "$TEST_GO_SCRIPT" '--remove-source' "$SRC_DIR"
+  restore_program_in_path 'rm'
+  assert_failure
+  assert_line_matches '0' \
+    "FATAL.* Failed to remove $SRC_DIR after creating ${SRC_DIR}.tar.gz"
+}

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -206,9 +206,11 @@ run_with_download_program() {
 
   skip_if_none_present_on_system 'curl' 'fetch' 'wget'
   skip_if_system_missing 'git' 'tar'
+
   GO_SCRIPT_BASH_DOWNLOAD_URL="$url" GO_SCRIPT_BASH_REPO_URL="$repo" \
     run "$TEST_GO_ROOTDIR/go-template"
 
+  @go.native_file_path_or_url 'url' "$url"
   assert_output_matches "Downloading framework from '$url/$RELEASE_TARBALL'"
   assert_output_matches "Failed to download from '$url/$RELEASE_TARBALL'"
   assert_output_matches 'Using git clone as fallback'
@@ -225,6 +227,7 @@ run_with_download_program() {
   skip_if_system_missing 'git' 'tar'
   GO_SCRIPT_BASH_VERSION="$branch" run "$TEST_GO_ROOTDIR/go-template"
 
+  @go.native_file_path_or_url 'url' "$url"
   assert_output_matches "Downloading framework from '$url/${branch}.tar.gz'"
   assert_output_matches "Failed to download from '$url/${branch}.tar.gz'"
   assert_output_matches 'Using git clone as fallback'

--- a/tests/template.bats
+++ b/tests/template.bats
@@ -291,8 +291,8 @@ run_with_download_program() {
     run "$BASH" "$TEST_GO_ROOTDIR/go-template"
   restore_program_in_path 'tar'
 
-  assert_output_matches "Downloading framework from '$EXPECTED_URL'\.\.\."
-  assert_output_matches "Failed to download from '$LOCAL_DOWNLOAD_URL'"
+  assert_output_matches "Downloading framework from '$NATIVE_LOCAL_URL'\.\.\."
+  assert_output_matches "Failed to download from '$NATIVE_LOCAL_URL'"
   assert_output_matches "Using git clone as fallback"
   assert_output_matches "Cloning framework from '$GO_SCRIPT_BASH_REPO_URL'"
   assert_output_matches "Cloning into '$CLONE_DIR'"


### PR DESCRIPTION
Closes #186. Normally I would split these into separate PRs, but in the interest of putting #186 to bed and moving on, I'm eliding them here.

`@go.canonicalize_path` now accepts `--pwd` and `--parent <dir>` options for convenience, rather than forcing the caller to use `@go.add_parent_dir_if_relative_path` directly.

`@go.mirror_directory` now mirrors the entire source directory by default.

`@go.create_gzipped_tarball` throws in tons of sanity checks and provides maximum portability, when a handful of direct commands just won't do. (The same could be said for `@go.mirror_directory`.)

`create_fake_tarball_if_not_using_real_url` now uses `@go.mirror_directory`, but not `@go.create_gzipped_tarball`, since the latter follows the convention that the extracted directory matches the basename of the tarball. With GitHub releases, the name of the extracted directory does _not_ match the basename of the tarball, e.g. `v1.6.0.tar.gz` extracts to `go-script-bash-v1.6.0`. So in this case, it was easier to use `@go.mirror_directory`, then use `tar` directly, despite the fact that `create_fake_tarball_if_not_using_real_url` inspired `@go.create_gzipped_tarball`, which then inspired `@go.mirror_directory`.

(If `@go.create_gzipped_tarball` doesn't prove useful in the long run, I can remove it in v2.0.0.)

Finally, after digging deeper into process substitution vs. pipes during the implementation of `@go.mirror_directory` from `lib/fileutil`, I realized a few things:

* The same number of processes are spawned.
* There's little benefit to a process substitution for straightforward pipes when the output isn't consumed by the shell process.
* It's not straightforward to get the status from a process substitution, and neither '$!' nor `wait` help.
* The 'PIPESTATUS' variable is available to check the status of each process in the pipe, without the need for `set -o pipefail`.

Hence, `go-template` now uses a `{curl,fetch,cat,wget} | tar` pipe with a `[[ ${PIPESTATUS[0]} -ne '0' ]]` check. There's a new test case for `tar` failure, and the 'fail to download ...' test cases required a little tweaking to ensure they properly cover the cases where `${download_cmd[@]}` fails.

(Yeah, really shoulda been separate PRs.)