### PR TITLE
CONTRIBUTING: Add CLA link, pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+- [ ] I have reviewed the [contributor guidelines][contrib]
+- [ ] I have reviewed the [code of conduct][conduct]
+- [ ] I have reviewed and signed the [Contributor License Agreement][cla]
+
+[contrib]: CONTRIBUTING.md
+[conduct]: CODE_OF_CONDUCT.md
+[cla]:     https://github.com/mbland/cla
+
+Closes #.
+
+Replace this paragraph with a description of the change.
+
+cc: @mbland

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ file](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).
 
 ## Contributor License Agreement
 
-Please sign the [Contributor License Agreement][cla] by submitting the form at
-the end of the agreement prior to filing any pull requests.
+Please sign the [Contributor License Agreement][cla] by submitting the form
+linked from the top of the agreement prior to filing any pull requests.
 
 [cla]: https://github.com/mbland/cla
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ file](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).
 ## Table of contents
 
 - [Quick links](#quick-links)
+- [Contributor License Agreement](#contributor-license-agreement)
 - [Code of conduct](#code-of-conduct)
 - [Reporting issues](#reporting-issues)
 - [Updating documentation](#updating-documentation)
@@ -32,6 +33,13 @@ file](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).
 - [Issues](https://github.com/mbland/go-script-bash/issues)
 - [Pull requests](https://github.com/mbland/go-script-bash/pulls)
 - [Issues](https://github.com/mbland/go-script-bash/issues)
+
+## Contributor License Agreement
+
+Please sign the [Contributor License Agreement][cla] by submitting the form at
+the end of the agreement prior to filing any pull requests.
+
+[cla]: https://github.com/mbland/cla
 
 ## Code of conduct
 


### PR DESCRIPTION
Closes #214.

The Contributor License Agreement ensures that I retain the copyright to contributions to avoid complex licensing issues. See:

 - https://www.clahub.com/pages/why_cla

The new pull request template will ensure that contributors are aware of the contributor guidelines, the code of conduct, and the Contributor License Agreement.