### PR TITLE
Add .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,14 @@
+version: 'v1.6.0.{build}'
+
+build: off
+
+# This presumes that Git bash is installed at `C:\Program Files\Git` and the
+# bash we're using is from that installation.
+#
+# If instead it finds the Windows Subsystem for Linux bash at
+# `C:\Windows\System32\bash.exe`, it will fail with a errors containing:
+#   syntax error near unexpected token `$'{\r''
+test_script:
+  - where bash
+  - bash --version
+  - bash ./go test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,4 +11,4 @@ build: off
 test_script:
   - where bash
   - bash --version
-  - bash ./go test
+  - bash -c './go test'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,4 +11,5 @@ build: off
 test_script:
   - where bash
   - bash --version
-  - bash -c './go test'
+  - bash -c 'echo PATH="$PATH"'
+  - bash -c 'PATH="/usr/bin:$PATH" ./go test'


### PR DESCRIPTION
This follows the example from https://www.appveyor.com/docs/lang/ruby/ except that it doesn't need `install` or `before_test` steps.

Inspired by bats-core/bats-core#8.