### PR TITLE
Add GitHub ISSUE_TEMPLATE and CODEOWNERS files, and `./go goinfo` command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This enables automatic code review requests per:
+# - https://help.github.com/articles/about-codeowners/
+# - https://help.github.com/articles/enabling-required-reviews-for-pull-requests/
+* @mbland

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Due diligence
+
+- [ ] I am familiar with the ["Reporting issues" section of
+  CONTRIBUTING.md][reporting]
+- [ ] I have searched the [existing issues][issues] and haven't found one
+  that matches what I'm reporting or requesting now.
+- [ ] If this is a bug report, I have searched the [Bash changelog][changes]
+  for information that may explain or provide clues to the behavior I'm
+  observing and reference it in the body of the report.
+
+[reporting]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md#reporting-issues
+[issues]:    https://github.com/mbland/go-script-bash/issues
+[changes]:   https://tiswww.case.edu/php/chet/bash/CHANGES
+
+## Framework, Bash, and operating system version information
+
+```
+If this is a bug report, replace this preformatted section with the output from:
+
+$ ./go goinfo
+
+Otherwise remove this section altogether.
+```
+
+## Description
+
+Replace this text with a description of your bug report or feature request.
+
+If this is a bug report, include any relevant command line steps, code snippets,
+or test cases to reproduce the issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ been filed.
 
 If you do find one...
 
-[issues]: https://github.com/mbland/custom-links/issues
+[issues]: https://github.com/mbland/go-script-bash/issues
 
 ### Do not add a +1 comment!
 
@@ -84,10 +84,11 @@ matching issue...
 Try to be as specific as possible about your environment and the problem you're
 observing. At a minimum, include:
 
-- The version of bash you're using, from either `bash --version` or `echo
-  $BASH_VERSION`
-- The version of the go-script-bash library you're using
+- The output from `./go goinfo`
 - Command line steps or code snippets that reproduce the issue
+- Any apparently relevant information from the [Bash changelog][bash-changes]
+
+[bash-changes]: https://tiswww.case.edu/php/chet/bash/CHANGES
 
 Also consider using:
 

--- a/lib/platform
+++ b/lib/platform
@@ -42,6 +42,7 @@ _@go.platform_ostype() {
   case "$OSTYPE" in
   darwin*)
     _GO_PLATFORM_ID='macos'
+    _GO_PLATFORM_VERSION_ID="$(sw_vers -productVersion)"
     ;;
   freebsd*)
     _GO_PLATFORM_ID='freebsd'
@@ -57,7 +58,7 @@ _@go.platform_ostype() {
     ;;
   esac
 
-  if command -v 'uname' >/dev/null; then
+  if [[ -z "$_GO_PLATFORM_VERSION_ID" ]] && command -v 'uname' >/dev/null; then
     _GO_PLATFORM_VERSION_ID="$(uname -r)"
   fi
 }

--- a/lib/platform
+++ b/lib/platform
@@ -56,6 +56,10 @@ _@go.platform_ostype() {
     _GO_PLATFORM_ID="$OSTYPE"
     ;;
   esac
+
+  if command -v 'uname' >/dev/null; then
+    _GO_PLATFORM_VERSION_ID="$(uname -r)"
+  fi
 }
 
 _@go.platform() {

--- a/libexec/goinfo
+++ b/libexec/goinfo
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+#
+# Prints go-script-bash, Bash, and operating system version information
+#
+# Useful for diagnosing problems and filing bug reports.
+#
+# More information may be gleaned from `uname`, as well as `sw_vers` on macOS,
+# but this includes the most often relevant information.
+
+. "$_GO_USE_MODULES" 'format' 'platform'
+
+_@go.gocore() {
+  local varnames=('_GO_CORE_VERSION'
+    'BASH_VERSION'
+    'OSTYPE'
+    '_GO_PLATFORM_ID'
+    '_GO_PLATFORM_VERSION_ID')
+  local values=()
+  local varname
+  local result=()
+
+  for varname in "${varnames[@]}"; do
+    values+=("${!varname}")
+  done
+
+  @go.pad_items 'varnames' "${varnames[@]/%/:}"
+  @go.zip_items 'varnames' 'values' '  ' result
+  printf '%s\n' "${result[@]}"
+}
+
+_@go.gocore "$@"

--- a/libexec/goinfo
+++ b/libexec/goinfo
@@ -9,7 +9,7 @@
 
 . "$_GO_USE_MODULES" 'format' 'platform'
 
-_@go.gocore() {
+_@go.goinfo() {
   local varnames=('_GO_CORE_VERSION'
     'BASH_VERSION'
     'OSTYPE'
@@ -28,4 +28,4 @@ _@go.gocore() {
   printf '%s\n' "${result[@]}"
 }
 
-_@go.gocore "$@"
+_@go.goinfo "$@"

--- a/tests/goinfo.bats
+++ b/tests/goinfo.bats
@@ -1,0 +1,30 @@
+#! /usr/bin/env bats
+
+load environment
+
+setup() {
+  test_filter
+  @go.create_test_go_script '@go "$@"'
+  export __GO_ETC_OS_RELEASE="$BATS_TEST_ROOTDIR/os-release"
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: emit version information about framework, Bash, and OS" {
+  # Use simulated /etc/os-release to prevent computation via uname or sw_vers.
+  mkdir -p "$BATS_TEST_ROOTDIR"
+  printf '%s\n' \
+    'ID=foobar' \
+    'VERSION_ID=666' >"$__GO_ETC_OS_RELEASE"
+
+  run "$TEST_GO_SCRIPT" 'goinfo'
+  assert_success
+  assert_lines_equal \
+    "_GO_CORE_VERSION:         $_GO_CORE_VERSION" \
+    "BASH_VERSION:             $BASH_VERSION" \
+    "OSTYPE:                   $OSTYPE" \
+    '_GO_PLATFORM_ID:          foobar' \
+    '_GO_PLATFORM_VERSION_ID:  666'
+}

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -12,9 +12,20 @@ setup() {
     '  printf "%s=\"%s\"\n" "$var" "${!var}"' \
     'done'
   export __GO_ETC_OS_RELEASE="$BATS_TEST_ROOTDIR/os-release"
+
+  stub_program_in_path 'uname' \
+    'if [[ "$*" == "-r" ]]; then' \
+    '  printf "$TEST_UNAME_VERSION\n"' \
+    'fi'
+
+  stub_program_in_path 'git' \
+    'if [[ "$*" == "--version" ]]; then' \
+    '  printf "git version %s\n" "$TEST_GIT_VERSION"' \
+    'fi'
 }
 
 teardown() {
+  restore_programs_in_path 'git' 'uname'
   @go.remove_test_go_rootdir
 }
 
@@ -38,29 +49,45 @@ teardown() {
     '_GO_PLATFORM_VERSION_ID="666"'
 }
 
-@test "$SUITE: set _GO_PLATFORM_ID from OSTYPE" {
-  OSTYPE='foobar' run "$TEST_GO_SCRIPT"
-  assert_success '_GO_PLATFORM_ID="foobar"'
+@test "$SUITE: set _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {
+  OSTYPE='foobar' TEST_UNAME_VERSION='3.27' run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="foobar"' \
+    '_GO_PLATFORM_VERSION_ID="3.27"'
 }
 
-@test "$SUITE: set _GO_PLATFORM_ID to macos from OSTYPE" {
-  OSTYPE='darwin16' run "$TEST_GO_SCRIPT"
-  assert_success '_GO_PLATFORM_ID="macos"'
+@test "$SUITE: macos _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {
+  OSTYPE='darwin16.3.0' TEST_UNAME_VERSION='17.0.0' run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="macos"' \
+    '_GO_PLATFORM_VERSION_ID="17.0.0"'
 }
 
-@test "$SUITE: set _GO_PLATFORM_ID to freebsd from OSTYPE" {
-  OSTYPE='freebsd11.0' run "$TEST_GO_SCRIPT"
-  assert_success '_GO_PLATFORM_ID="freebsd"'
+@test "$SUITE: freebsd _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {
+  OSTYPE='freebsd11.0' TEST_UNAME_VERSION='11.1-RELEASE-p1' \
+    run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="freebsd"' \
+    '_GO_PLATFORM_VERSION_ID="11.1-RELEASE-p1"'
 }
 
-@test "$SUITE: set _GO_PLATFORM_ID to msys from OSTYPE" {
-  stub_program_in_path 'git' 'printf "%s\n" "git version 2.13.0"'
-  OSTYPE='msys' run "$TEST_GO_SCRIPT"
-  assert_success '_GO_PLATFORM_ID="msys"'
+@test "$SUITE: msys _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {
+  OSTYPE='msys' TEST_UNAME_VERSION='2.9.0(0.318/5/3)' \
+    TEST_GIT_VERSION='2.14.2' run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="msys"' \
+    '_GO_PLATFORM_VERSION_ID="2.9.0(0.318/5/3)"'
 }
 
-@test "$SUITE: set _GO_PLATFORM_ID to msys-git from OSTYPE and git --version" {
-  stub_program_in_path 'git' 'printf "%s\n" "git version 2.13.0.windows.1"'
-  OSTYPE='msys' run "$TEST_GO_SCRIPT"
-  assert_success '_GO_PLATFORM_ID="msys-git"'
+@test "$SUITE: msys-git _GO_PLATFORM_* from OSTYPE, git --version, uname -r" {
+  OSTYPE='msys' TEST_UNAME_VERSION='2.8.0(0.310/5/3)' \
+    TEST_GIT_VERSION='git version 2.13.0.windows.1' run "$TEST_GO_SCRIPT"
+  assert_success
+  assert_lines_equal \
+    '_GO_PLATFORM_ID="msys-git"' \
+    '_GO_PLATFORM_VERSION_ID="2.8.0(0.310/5/3)"'
 }

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -13,6 +13,11 @@ setup() {
     'done'
   export __GO_ETC_OS_RELEASE="$BATS_TEST_ROOTDIR/os-release"
 
+  stub_program_in_path 'sw_vers' \
+    'if [[ "$*" == "-productVersion" ]]; then' \
+    '  printf "$TEST_MACOS_VERSION\n"' \
+    'fi'
+
   stub_program_in_path 'uname' \
     'if [[ "$*" == "-r" ]]; then' \
     '  printf "$TEST_UNAME_VERSION\n"' \
@@ -25,7 +30,7 @@ setup() {
 }
 
 teardown() {
-  restore_programs_in_path 'git' 'uname'
+  restore_programs_in_path 'git' 'uname' 'sw_vers'
   @go.remove_test_go_rootdir
 }
 
@@ -57,12 +62,13 @@ teardown() {
     '_GO_PLATFORM_VERSION_ID="3.27"'
 }
 
-@test "$SUITE: macos _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {
-  OSTYPE='darwin16.3.0' TEST_UNAME_VERSION='17.0.0' run "$TEST_GO_SCRIPT"
+@test "$SUITE: macos _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, sw_vers" {
+  OSTYPE='darwin16.3.0' TEST_UNAME_VERSION='17.0.0' \
+    TEST_MACOS_VERSION='10.13' run "$TEST_GO_SCRIPT"
   assert_success
   assert_lines_equal \
     '_GO_PLATFORM_ID="macos"' \
-    '_GO_PLATFORM_VERSION_ID="17.0.0"'
+    '_GO_PLATFORM_VERSION_ID="10.13"'
 }
 
 @test "$SUITE: freebsd _GO_PLATFORM_{ID,VERSION_ID} from OSTYPE, uname -r" {


### PR DESCRIPTION
Closes #216.

This should make it easier for people to file high-quality issues. Tweaked CONTRIBUTING.md accordingly, and fixed a stale reference to mbland/custom-links.

Also makes `lib/platform` output a bit more robust, motivated by the creating of `./go goinfo`. I'll also open an issue to make the core of `_@go.goinfo` the core of `./go vars`, which will itself become more flexible.