### PR TITLE
[WIP] Adds partial support for the unofficial bash strict mode

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -65,9 +65,10 @@ fi
 declare -r -x _GO_CORE_DIR="$PWD"
 
 # Set _GO_STANDALONE if your script is a standalone program.
-#
+declare -x _GO_STANDALONE="${_GO_STANDALONE-}"
+
 # See the "Standalone mode" section of README.md for more information.
-if [[ "${_GO_STANDALONE:-null}" == "null" ]]; then
+if [[ -n "$_GO_STANDALONE" ]]; then
   cd "$_GO_ROOTDIR" || exit 1
 else
   cd "$__go_orig_dir" || exit 1

--- a/go-core.bash
+++ b/go-core.bash
@@ -287,8 +287,7 @@ COLUMNS="${COLUMNS-}"
 #   $1: name of the command to invoke
 #   $2..$#: arguments to the specified command
 @go() {
-  local cmd="$1"
-  shift
+  local cmd="${1-}"
 
   case "$cmd" in
   '')

--- a/go-core.bash
+++ b/go-core.bash
@@ -208,7 +208,7 @@ COLUMNS="${COLUMNS-}"
 # Arguments:
 #   skip_callers:  The number of callers to skip over when printing the stack
 @go.print_stack_trace() {
-  local skip_callers="$1"
+  local skip_callers="${1-}"
   local result=0
   local i
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -367,7 +367,11 @@ _@go.run_command_script() {
   shift
 
   local interpreter
-  read -r interpreter < "$cmd_path"
+  interpreter=''
+
+  if [[ -s "$cmd_path" ]]; then
+    read -r interpreter < "$cmd_path"
+  fi
 
   if [[ "${interpreter:0:2}" != '#!' ]]; then
     @go.printf \

--- a/go-core.bash
+++ b/go-core.bash
@@ -289,6 +289,10 @@ COLUMNS="${COLUMNS-}"
 @go() {
   local cmd="${1-}"
 
+  if [[ $# > 0 ]]; then
+    shift
+  fi
+
   case "$cmd" in
   '')
     _@go.source_builtin 'help' 1>&2

--- a/go-core.bash
+++ b/go-core.bash
@@ -68,7 +68,7 @@ declare -r -x _GO_CORE_DIR="$PWD"
 declare -x _GO_STANDALONE="${_GO_STANDALONE-}"
 
 # See the "Standalone mode" section of README.md for more information.
-if [[ -n "$_GO_STANDALONE" ]]; then
+if [[ -z "$_GO_STANDALONE" ]]; then
   cd "$_GO_ROOTDIR" || exit 1
 else
   cd "$__go_orig_dir" || exit 1

--- a/go-core.bash
+++ b/go-core.bash
@@ -67,7 +67,7 @@ declare -r -x _GO_CORE_DIR="$PWD"
 # Set _GO_STANDALONE if your script is a standalone program.
 #
 # See the "Standalone mode" section of README.md for more information.
-if [[ -z "$_GO_STANDALONE" ]]; then
+if [[ "${_GO_STANDALONE:-null}" == "null" ]]; then
   cd "$_GO_ROOTDIR" || exit 1
 else
   cd "$__go_orig_dir" || exit 1
@@ -120,7 +120,7 @@ declare -r -x _GO_TEST_DIR="${_GO_TEST_DIR:-tests}"
 declare -r -x _GO_SCRIPT="$_GO_ROOTDIR/${0##*/}"
 
 # The name of either the ./go script itself or the shell function invoking it.
-declare -r -x _GO_CMD="${_GO_CMD:=$0}"
+declare -r -x _GO_CMD="${_GO_CMD:-$0}"
 
 # The array of command line arguments comprising the ./go command name after
 # _GO_CMD.
@@ -151,11 +151,14 @@ declare _GO_SEARCH_PATHS=()
 # Should be an absolute path. Use this for stubbing out scripts during testing
 # or debugging, or for experimenting with new implementations of existing
 # scripts.
-declare _GO_INJECT_SEARCH_PATH="$_GO_INJECT_SEARCH_PATH"
+declare _GO_INJECT_SEARCH_PATH="${_GO_INJECT_SEARCH_PATH-}"
 
 # Directory to search for module scripts first.
 # Similar to _GO_INJECT_SEARCH_PATHS above, but for `. "$_GO_USE_MODULES"`.
-declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
+declare _GO_INJECT_MODULE_PATH="${_GO_INJECT_MODULE_PATH-}"
+
+# Read from the environment and used in output formatting
+COLUMNS="${COLUMNS-}"
 
 # Invokes printf builtin, then folds output to $COLUMNS width
 #

--- a/lib/bats-main
+++ b/lib/bats-main
@@ -117,22 +117,22 @@ fi
 #   $1:   One of the flags defined above, or the first test glob pattern
 #   ...:  Remaining test glob patterns
 @go.bats_main() {
-  if [[ "$1" == '--complete' ]]; then
+  if [[ "${1:-}" == '--complete' ]]; then
     shift
     @go.bats_tab_completion "$@"
     return
   fi
   @go.bats_clone
 
-  if [[ "$1" == '--coverage' && -z "$__GO_COVERAGE_RUN" ]]; then
+  if [[ "${1:-}" == '--coverage' && -z "$__GO_COVERAGE_RUN" ]]; then
     shift
     export __GO_COVERAGE_RUN='true'
     @go.bats_coverage "$@"
-  elif [[ "$1" == '--edit' ]]; then
+  elif [[ "${1:-}" == '--edit' ]]; then
     shift
     local tests=($(@go 'glob' "${_GO_BATS_GLOB_ARGS[@]}" "$@"))
     @go 'edit' "${tests[@]}"
-  elif [[ "$1" == '--list' ]]; then
+  elif [[ "${1:-}" == '--list' ]]; then
     shift
     @go 'glob' '--trim' "${_GO_BATS_GLOB_ARGS[@]}" "$@"
   elif [[ -z "$__GO_COVERAGE_RUN" && -n "$_GO_COLLECT_BATS_COVERAGE" ]]; then

--- a/lib/complete
+++ b/lib/complete
@@ -33,6 +33,7 @@
   fi
   unset "compreply[$compgen_exit_index]"
 
+  add_slashes='false'
   if [[ "$1" =~ ^-[df]$ ]]; then
     add_slashes='true'
   fi
@@ -40,7 +41,7 @@
   for reply_item in "${compreply[@]}"; do
     # Since we're not using -o filenames, we must add slashes to dir names.
     # Since we're using -o nospace, we must add a space to a single match.
-    if [[ -n "$add_slashes" && -d "$reply_item" ]]; then
+    if [[ "$add_slashes" == 'true' && -d "$reply_item" ]]; then
       printf -- '%s/\n' "$reply_item"
     elif [[ "${#compreply[@]}" -eq '1' && ! $reply_item =~ [\ /]$ ]]; then
       printf -- '%s \n' "$reply_item"

--- a/lib/complete
+++ b/lib/complete
@@ -70,10 +70,10 @@
   local completion_item_reference
   local i
 
-  for arg in "${!argv_array_reference}"; do
-    for ((i=0; i != num_completions; ++i)); do
+  for arg in "${!argv_array_reference-}"; do
+    for ((i=0; i < num_completions; ++i)); do
       completion_item_reference="$completions_reference[$i]"
-      if [[ "${!completion_item_reference}" == "$arg" ]]; then
+      if [[ "${!completion_item_reference-}" == "$arg" ]]; then
         unset "$completions_reference[$i]"
       fi
     done

--- a/lib/complete
+++ b/lib/complete
@@ -24,7 +24,7 @@
 
   while IFS= read -r reply_item; do
     compreply+=("$reply_item")
-  done < <(trap 'echo "$?"' EXIT; compgen "$@"; exit "$?")
+  done < <(trap "" ERR; trap 'echo "$?"' EXIT; compgen "$@"; exit "$?")
 
   compgen_exit_index="$((${#compreply[@]} - 1))"
 

--- a/lib/internal/path
+++ b/lib/internal/path
@@ -25,7 +25,7 @@ _@go.set_command_path_and_argv() {
 
   local cmd_args=("$@")
   local cmd_name="${cmd_args[0]}"
-  local cmd_path
+  local cmd_path=''
   local try_path
 
   unset 'cmd_args[0]'

--- a/lib/internal/set-search-paths
+++ b/lib/internal/set-search-paths
@@ -26,7 +26,7 @@ _@go.set_search_paths() {
   # A plugin's own local plugin paths will appear before inherited ones. If
   # there is a version incompatibility issue with other installed plugins, this
   # allows a plugin's preferred version to take precedence.
-  @go.search_plugins '_@go.set_search_paths_add_plugin_paths'
+  @go.search_plugins '_@go.set_search_paths_add_plugin_paths' || : 
   _GO_SEARCH_PATHS+=("${_GO_PLUGINS_PATHS[@]}")
 }
 

--- a/lib/platform
+++ b/lib/platform
@@ -3,7 +3,7 @@
 # Sets the `_GO_PLATFORM_*` family of environment variables
 #
 # This module doesn't export any functions, only the `_GO_PLATFORM_*`
-# environment variables if `/etc/os-release` if present, or just
+# environment variables if `/etc/os-release` is present, or just
 # `_GO_PLATFORM_ID` otherwise, which is set to:
 #
 #   - 'macos' if the Bash variable `$OSTYPE` matches 'darwin'
@@ -64,7 +64,7 @@ _@go.platform_ostype() {
 }
 
 _@go.platform() {
-  if [[ -n "$_GO_PLATFORM_ID" ]]; then
+  if [[ -n "${_GO_PLATFORM_ID-}" ]]; then
     return
   elif ! _@go.platform_os_release; then
     _@go.platform_ostype

--- a/lib/prompt
+++ b/lib/prompt
@@ -110,7 +110,7 @@
 #   Zero on 'y' or 'yes' (case- and space- insensitive), nonzero otherwise
 @go.prompt_for_yes_or_no() {
   local prompt="$1"
-  local default="$2"
+  local default="${2-}"
   local response
 
   case "$default" in

--- a/libexec/aliases
+++ b/libexec/aliases
@@ -34,7 +34,7 @@ _@go.aliases() {
     return
   elif [[ "$1" == '--complete' ]]; then
     # Tab completions
-    local word_index="$2"
+    local word_index="${2-0}"
     if [[ "$word_index" -eq 0 ]]; then
       echo "--exists"
     fi

--- a/libexec/commands
+++ b/libexec/commands
@@ -70,7 +70,7 @@ _@go.commands_parse_search_paths() {
 }
 
 _@go.commands_parse_argv() {
-  case "$1" in
+  case "${1-}" in
   --paths|--summaries)
     __go_commands_action="${1#--}"
     shift
@@ -132,7 +132,7 @@ _@go.commands_tab_completions() {
 
 _@go.commands() {
   # Tab completions
-  if [[ "$1" == '--complete' ]]; then
+  if [[ "${1-}" == '--complete' ]]; then
     shift
     _@go.commands_tab_completions "$@"
     return

--- a/libexec/commands
+++ b/libexec/commands
@@ -105,20 +105,22 @@ _@go.commands_parse_argv() {
 }
 
 _@go.commands_tab_completions() {
-  local word_index="$1"
-  shift
+  local word_index="${1-0}"
+  if [[ "$#" > 1 ]]; then
+    shift
+  fi
 
   if [[ "$word_index" -eq '0' ]]; then
     echo '--paths' '--summaries'
-    if [[ "${1:0:1}" == '-' || "$#" -gt 1 ]]; then
+    if [[ "$#" -gt 0 && ("${1:0:1}" == '-' || "$#" -gt 1) ]]; then
       return
     fi
   fi
 
-  if [[ "${1:0:1}" == '-' ]]; then
+  if [[ "$#" -gt 0 && "${1:0:1}" == '-' ]]; then
     shift
     ((--word_index))
-  elif [[ "$1" =~ : || -d "$1" ]]; then
+  elif [[ "${1-}" =~ : || -d "${1-}" ]]; then
     return 1
   fi
 

--- a/libexec/complete
+++ b/libexec/complete
@@ -64,11 +64,14 @@ _@go.complete_command() {
 }
 
 _@go.complete_args() {
-  local word_index="$1"
-  shift
+  local word_index="${1-0}"
+  if [[ "$#" -gt 0 ]]; then
+    shift
+  fi
   local args=("$@")
-  local cmd_name="${args[0]}"
-  local word="${args[$word_index]}"
+  local cmd_name="${args[0]-}"
+  local word="${args[$word_index]-}"
+  local ec=0
 
   . "$_GO_CORE_DIR/lib/internal/complete"
 

--- a/libexec/env
+++ b/libexec/env
@@ -21,7 +21,7 @@ _@go.has_spaces() {
 
 _@go.env() {
   # Tab completions
-  if [[ "$1" == '--complete' ]]; then
+  if [[ "${1-}" == '--complete' ]]; then
     local word_index="$2"
     if [[ "$word_index" -eq '0' ]]; then
       echo '-'
@@ -29,7 +29,7 @@ _@go.env() {
     return
   fi
 
-  local go_func="$1"
+  local go_func="${1-}"
   local default_name="${_GO_SCRIPT##*/}"
   local shell="${SHELL##*/}"
   local shell_impl="$_GO_CORE_DIR/lib/internal/env/$shell"

--- a/libexec/env
+++ b/libexec/env
@@ -87,7 +87,13 @@ END_OF_HELP
     return 1
   fi
 
-  read -r -d '' env_script < "$shell_impl"
+  read -r -d '' env_script < "$shell_impl" && exit_code=0 || exit_code=$?
+  if [[ "$exit_code" -gt 1 ]]; then
+    # Due to encountering EOL, 'read' will return with '1'. To support 'set -e'
+    # we only return the exit code if an actual error has occured ($? -gt 1).
+    return $exit_code
+  fi
+
   env_script="${env_script//_go_func/$go_func}"
   env_script="${env_script//\$_GO_ROOTDIR/$_GO_ROOTDIR}"
   echo "${env_script//\$_GO_SCRIPT/$_GO_SCRIPT}"

--- a/libexec/env
+++ b/libexec/env
@@ -70,12 +70,19 @@ _@go.env() {
       return 1
     fi
 
-    read -r -d '' help_msg <<END_OF_HELP
+    read -r -d '' help_msg <<END_OF_HELP && exit_code=0 || exit_code=$?
 # Define the "$default_name" function by running the following command.
 # Replace '-' to use a different name instead of "$default_name".
 
 ${eval_cmd//%s/$0}
 END_OF_HELP
+
+    if [[ "$exit_code" -gt 1 ]]; then
+      # Due to encountering EOL, 'read' will return with '1'. To support 'set -e'
+      # we only return the exit code if an actual error has occured ($? -gt 1).
+      return $exit_code
+    fi
+
     @go.printf "$help_msg\n"
     return
   elif [[ "$go_func" == '-' ]]; then
@@ -89,8 +96,6 @@ END_OF_HELP
 
   read -r -d '' env_script < "$shell_impl" && exit_code=0 || exit_code=$?
   if [[ "$exit_code" -gt 1 ]]; then
-    # Due to encountering EOL, 'read' will return with '1'. To support 'set -e'
-    # we only return the exit code if an actual error has occured ($? -gt 1).
     return $exit_code
   fi
 

--- a/libexec/get.d/file
+++ b/libexec/get.d/file
@@ -173,7 +173,7 @@ _@go.get_file() {
   local filename
   local dl_cmd=()
 
-  case "$1" in
+  case "${1-}" in
   --complete)
     # Tab completions
     _@go.get_file_tab_completions "${@:2}"

--- a/libexec/help
+++ b/libexec/help
@@ -129,16 +129,14 @@ _@go.help_message_for_command() {
 }
 
 _@go.help() {
-  if [[ "$1" == '--complete' ]]; then
+  if [[ "$#" -eq '0' ]]; then
+    _@go.usage
+  elif [[ "$1" == '--complete' ]]; then
     # Tab completions
     shift
     . "$_GO_CORE_DIR/lib/internal/complete"
     _@go.complete_command_path "$@"
     return
-  fi
-
-  if [[ "$#" -eq '0' ]]; then
-    _@go.usage
   else
     _@go.help_message_for_command "$@"
   fi

--- a/libexec/modules
+++ b/libexec/modules
@@ -55,7 +55,7 @@ _@go.modules_import_use_modules_functions() {
 _@go.modules_import_use_modules_functions
 
 _@go.modules_help() {
-  local __go_module_name="$1"
+  local __go_module_name="${1-}"
   local __go_module_file
 
   if [[ "$#" -eq '0' ]]; then

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -56,6 +56,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
+    "declare -x _GO_STANDALONE=\"\""
     "declare -rx _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
@@ -130,6 +131,7 @@ quotify_expected() {
     "declare -rx _GO_SCRIPT=\"$TEST_GO_SCRIPT\""
     "declare -- _GO_SCRIPTS_DIR=\"$TEST_GO_SCRIPTS_DIR\""
     "declare -a _GO_SEARCH_PATHS=(${search_paths[*]})"
+    "declare -x _GO_STANDALONE=\"$_GO_STANDALONE\""
     "declare -rx _GO_TEST_DIR=\"$_GO_TEST_DIR\""
     "declare -rx _GO_USE_MODULES=\"$_GO_CORE_DIR/lib/internal/use\"")
 
@@ -171,6 +173,7 @@ quotify_expected() {
     "_GO_KCOV_DIR: $_GO_KCOV_DIR" \
     "_GO_ROOTDIR: $TEST_GO_ROOTDIR" \
     "_GO_SCRIPT: $TEST_GO_SCRIPT" \
+    "_GO_STANDALONE: $_GO_STANDALONE" \
     "_GO_TEST_DIR: $_GO_TEST_DIR" \
     "_GO_USE_MODULES: $_GO_USE_MODULES"
 }


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

I run my scripts with `set -euo pipefail` at the very top. I run into some unbound variables when doing so. Maybe I'll run into more as I move into using this framework. I think it is good to have default values/explicit null to make assumptions in the code clearer. 

On the part where I changed `:=` to `:-`, I did so to avoid running the same value assignment twice.

This PR is regardless of #220, but it could prove handy if #220 starts getting implemented. This PR is meant to support those users that do want the strict mode in their scripts.