### PR TITLE
Adds 'required' option to 'prompt_for_input'

### DIFF
--- a/lib/prompt
+++ b/lib/prompt
@@ -48,20 +48,29 @@
 #   prompt      Text prompt for user input
 #   default     (Optional) Default value if response is empty
 #   fail_msg    (Optional) Failure message if empty input isn't valid
+#   persist     (Optional) Flag to repeat prompt until user supplies value
 @go.prompt_for_input() {
   @go.validate_identifier_or_die 'Input prompt response variable name' "$1"
 
-  if [[ "$2" =~ [[:space:]]$ ]]; then
-    @go.printf '%s%s%s' "${2%?}" "${3:+ [default: $3]}" "${BASH_REMATCH[0]}" >&2
-  else
-    @go.printf '%s %s' "$2" "${3:+[default: $3] }" >&2
-  fi
-  @go.read_prompt_response "$1" "$3"
+  while [[ -z "${!1-}" ]]; do
+    if [[ "$2" =~ [[:space:]]$ ]]; then
+      @go.printf '%s%s%s' "${2%?}" "${3:+ [default: $3]}" "${BASH_REMATCH[0]}" >&2
+    else
+      @go.printf '%s %s' "$2" "${3:+[default: $3] }" >&2
+    fi
 
-  if [[ -z "${!1}" && -n "$4" ]]; then
-    @go.printf '%s\n' "$4" >&2
-    return 1
-  fi
+    @go.read_prompt_response "$1" "${3-}"
+    if [[ "${5-}" != "persist" ]]; then
+      if [[ -z "${!1}" && -n "${4-}" ]]; then
+        @go.printf '%s\n' "$4" >&2
+        return 1
+      else
+        break
+      fi
+    fi
+  done
+
+  return
 }
 
 # Prompts the user for a line of input, then validates it isn't dangerous

--- a/lib/prompt
+++ b/lib/prompt
@@ -48,10 +48,11 @@
 #   prompt      Text prompt for user input
 #   default     (Optional) Default value if response is empty
 #   fail_msg    (Optional) Failure message if empty input isn't valid
-#   persist     (Optional) Flag to repeat prompt until user supplies value
+#   required     (Optional) Flag to repeat prompt until user supplies value
 @go.prompt_for_input() {
   @go.validate_identifier_or_die 'Input prompt response variable name' "$1"
 
+  unset "$1"
   while [[ -z "${!1-}" ]]; do
     if [[ "$2" =~ [[:space:]]$ ]]; then
       @go.printf '%s%s%s' "${2%?}" "${3:+ [default: $3]}" "${BASH_REMATCH[0]}" >&2
@@ -60,7 +61,7 @@
     fi
 
     @go.read_prompt_response "$1" "${3-}"
-    if [[ "${5-}" != "persist" ]]; then
+    if [[ "${5-}" != "required" ]]; then
       if [[ -z "${!1}" && -n "${4-}" ]]; then
         @go.printf '%s\n' "$4" >&2
         return 1

--- a/tests/prompt/prompt-for-input.bats
+++ b/tests/prompt/prompt-for-input.bats
@@ -8,9 +8,10 @@ setup() {
     'declare prompt="$1"' \
     'declare default="$2"' \
     'declare fail_msg="$3"' \
+    'declare required="$4"' \
     'declare response="initial value"' \
     'declare result' \
-    '@go.prompt_for_input "response" "$prompt" "$default" "$fail_msg"' \
+    '@go.prompt_for_input "response" "$prompt" "$default" "$fail_msg" "$required"' \
     'result="$?"' \
     'printf -- "%s\n" "$response"' \
     'exit "$result"'
@@ -61,4 +62,11 @@ teardown() {
   run "$TEST_GO_SCRIPT" $'What is your quest?\n' '' 'Auuuuuuuugh!' <<<''
   assert_failure 'What is your quest?' \
     'Auuuuuuuugh!'
+}
+
+@test "$SUITE: re-prompts if input is required" {
+  run "$TEST_GO_SCRIPT" $'What is your quest?\n' '' '' 'required' <<< $'\n''None'
+  assert_success 'What is your quest?' \
+    'What is your quest?' \
+    'None'
 }


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

This PR adds an extra argument to `@go.prompt_for_input`. If the function is called with this argument, eg `@go.prompt_for_input 'variable' 'prompt' '' '' 'required'` and the user supplies no value, ie presses only enter, the prompt will reappear until the user actually supplies something. If instead of `required` another value is supplied, the behavior is the already existing one. 

The rational behind this PR is that as it stands now, using `@go.prompt_for_input` in a loop to force the user to actually submit sth, is exactly identical to using `read` directly. It saves nothing. With this PR, it only takes one line and you are sure that the user will provide some input. Moreover, `@go.prompt_for_yes_or_no` already loops until the user supplies something. This PR makes the two functions more "feature compatible".