### PR TITLE
lib/kcov-ubuntu: Use kcov v35 to fix test coverage

### DIFF
--- a/lib/kcov-ubuntu
+++ b/lib/kcov-ubuntu
@@ -20,7 +20,7 @@ __KCOV_DEV_PACKAGES=(
 )
 readonly __KCOV_DEV_PACKAGES
 readonly __KCOV_URL='https://github.com/SimonKagstrom/kcov'
-readonly __KCOV_VERSION='master'
+readonly __KCOV_VERSION='v35'
 
 # Downloads and compiles kcov if necessary, then runs tests under kcov
 #
@@ -63,7 +63,8 @@ run_kcov() {
     return 1
   fi
 
-  local kcov_flags=("--include-pattern=$include_pattern"
+  local kcov_flags=('--bash-dont-parse-binary-dir'
+    "--include-pattern=$include_pattern"
     "--exclude-pattern=$exclude_pattern")
   local send_to_coveralls='false'
 

--- a/tests/kcov.bats
+++ b/tests/kcov.bats
@@ -16,6 +16,7 @@ RUN_KCOV_ARGV=(
 KCOV_PATH="$KCOV_DIR/src/kcov"
 KCOV_ARGV_START=(
   "$KCOV_PATH"
+  '--bash-dont-parse-binary-dir'
   "--include-pattern=$KCOV_INCLUDE_PATTERNS"
   "--exclude-pattern=$KCOV_EXCLUDE_PATTERNS"
 )


### PR DESCRIPTION
I noticed during the build for #227 that test coverage dropped precipitously for no apparent reason:

https://coveralls.io/builds/14508796

The coverage dropped because SimonKagstrom/kcov@0dd22bd added the ability for kcov to automatically discover all scripts residing in the same directory of the script under test. In this case, it unfortunately discovered all the scripts in ./git and tests/kcov, as well as various *.md and *.yml files that happened to have "bash" in the first line regardless of the presence of a #!.

The interim fix for this was to add the `--bash-dont-parse-binary-dir` flag and to update the tests accordingly.

Also, since a bit of time elapsed since I returned to the problem, I realized the latest tip of kcov's master branch exhibited the hanging bug I helped squash in SimonKagstrom/kcov#211. The bug was reintroduced in SimonKagstrom/kcov@ad17136, which tried to fix a bug reported in SimonKagstrom/kcov#248 whereby kcov would hang on output that didn't contain newlines.

SimonKagstrom/kcov#249 attempted to resolve the bug, but didn't quite work and was abandoned. I may take a stab at fixing it one day, but in the meanwhile, kcov v35 with --bash-dont-parse-binary-dir works to get this project's test coverage back in shape.