### PR TITLE
Fix breakage from Bats v1.0.0, bump to Bats v1.0.1

### DIFF
--- a/lib/bats-main
+++ b/lib/bats-main
@@ -50,13 +50,13 @@ export _GO_BATS_COVERAGE_DIR="${_GO_BATS_COVERAGE_DIR:-$_GO_TEST_DIR/coverage}"
 export _GO_BATS_DIR="${_GO_BATS_DIR:-$_GO_TEST_DIR/bats}"
 
 # Path to the main Bats executable
-export _GO_BATS_PATH="$_GO_BATS_DIR/libexec/bats"
+export _GO_BATS_PATH="$_GO_BATS_DIR/bin/bats"
 
 # Version of Bats to fetch if `_GO_BATS_DIR` is missing
-export _GO_BATS_VERSION="${_GO_BATS_VERSION:-optimized-20170317}"
+export _GO_BATS_VERSION="${_GO_BATS_VERSION:-v1.0.1}"
 
 # URL of the Bats git repository to clone to `_GO_BATS_DIR`
-export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/mbland/bats.git}"
+export _GO_BATS_URL="${_GO_BATS_URL:-https://github.com/bats-core/bats-core.git}"
 
 # Set this to nonempty if you wish to collect coverage using kcov by default
 export _GO_COLLECT_BATS_COVERAGE="$_GO_COLLECT_BATS_COVERAGE"

--- a/lib/bats/assertion-test-helpers
+++ b/lib/bats/assertion-test-helpers
@@ -187,7 +187,7 @@ __expect_assertion_success() {
     "#   \`failing_assertion' failed")
 
   if ! __check_expected_output "$output" "${expected_output[@]}"; then
-    printf "$ASSERTION_TEST_SCRIPT_FAILURE_MESSAGE" "${assertion%% *}" >&2
+    printf "$ASSERTION_TEST_SCRIPT_FAILURE_MESSAGE\n" "${assertion%% *}" >&2
     return '1'
   fi
 }
@@ -230,7 +230,7 @@ __expect_assertion_failure() {
     "${@/#/# }")
 
   if ! __check_expected_output "$output" "${expected_output[@]}"; then
-    printf "$ASSERTION_TEST_SCRIPT_FAILURE_MESSAGE" "${assertion%% *}" >&2
+    printf "$ASSERTION_TEST_SCRIPT_FAILURE_MESSAGE\n" "${assertion%% *}" >&2
     return '1'
   fi
 }
@@ -271,7 +271,8 @@ __run_command_and_assertion_in_subshell() {
   __assertion_output="${__assertion_output%$'\n'}"
 
   if [[ "$__assertion_output" =~ write\ error:\ Bad\ file\ descriptor$ ]]; then
-    printf "'%s' tried to write to standard output instead of standard error" \
+    printf \
+      "'%s' tried to write to standard output instead of standard error\n" \
       "${assertion%% *}" >&2
     return 1
   elif [[ -z "$__assertion_status" ]]; then

--- a/lib/bats/helpers
+++ b/lib/bats/helpers
@@ -508,7 +508,8 @@ run_bats_test_suite() {
 # Arguments:
 #   $@:  Passed directly through to `run_bats_test_suite`
 run_bats_test_suite_in_isolation() {
-  create_forwarding_script --path "$_GO_ROOTDIR/${_GO_BATS_PATH%/*}" 'bash'
+  local bats_bin="$(command -v bats)"
+  create_forwarding_script --path "${bats_bin%/*}" 'bash'
   create_forwarding_script --path '' 'rm'
   run_bats_test_suite "$@"
   restore_programs_in_path 'bash' 'rm'

--- a/tests/bats-background-process.bats
+++ b/tests/bats-background-process.bats
@@ -63,9 +63,9 @@ kill_background_test_script() {
   assert_success
   fail_if output_matches 'Did not skip'
 
-  local skip_msg='ok 1 # skip (pkill, sleep, tail not installed on the system)'
   local test_case_name='skip_if_missing_background_utilities'
-  assert_lines_equal '1..1' "$skip_msg $test_case_name"
+  local skip_msg='skip pkill, sleep, tail not installed on the system'
+  assert_lines_equal '1..1' "ok 1 $test_case_name # $skip_msg"
 }
 
 @test "$SUITE: run{,_test_script}_in_background launches background process" {

--- a/tests/bats-helpers.bats
+++ b/tests/bats-helpers.bats
@@ -167,7 +167,7 @@ __check_dirs_exist() {
   run "$BATS_TEST_ROOTDIR/test.bats"
   assert_success
   assert_lines_equal '1..1' \
-    'ok 1 # skip (foo, bar, baz not installed on the system) skip if missing'
+    'ok 1 skip if missing # skip foo, bar, baz not installed on the system'
 }
 
 @test "$SUITE: skip_if_none_present_on_system" {
@@ -193,9 +193,9 @@ __check_dirs_exist() {
     'None of foo, bar, or baz are installed on the system')
   assert_lines_equal '1..4' \
     'ok 1 should not skip if at least one present' \
-    "ok 2 # skip (${expected_messages[0]}) single program missing" \
-    "ok 3 # skip (${expected_messages[1]}) two programs missing" \
-    "ok 4 # skip (${expected_messages[2]}) three programs missing"
+    "ok 2 single program missing # skip ${expected_messages[0]}" \
+    "ok 3 two programs missing # skip ${expected_messages[1]}" \
+    "ok 4 three programs missing # skip ${expected_messages[2]}"
 }
 
 @test "$SUITE: test_join fails if result variable name is invalid" {
@@ -249,9 +249,9 @@ __check_dirs_exist() {
   TEST_FILTER='b[a-z]r' run bats "$test_file"
   assert_success
   assert_lines_equal '1..3' \
-    'ok 1 # skip foo' \
+    'ok 1 foo # skip' \
     'ok 2 bar' \
-    'ok 3 # skip baz'
+    'ok 3 baz # skip'
 }
 
 @test "$SUITE: split_bats_output_into_lines" {
@@ -473,7 +473,7 @@ __check_dirs_exist() {
     '  skip "just because"' \
     '  [[ $((2 + 2)) -eq 5 ]] || return 1' \
     '}'
-  assert_success '1..1' 'ok 1 # skip (just because) should skip'
+  assert_success '1..1' 'ok 1 should skip # skip just because'
 }
 
 @test "$SUITE: run_bats_test_suite runs a test suite with failures" {
@@ -494,7 +494,7 @@ __check_dirs_exist() {
     '  skip_if_system_missing cp rm mkdir' \
     '}'
   assert_success '1..1' \
-    'ok 1 # skip (cp, mkdir not installed on the system) should skip'
+    'ok 1 should skip # skip cp, mkdir not installed on the system'
 }
 
 @test "$SUITE: run_bats_test_suite_in_isolation can access forwarding scripts" {


### PR DESCRIPTION
https://github.com/bats-core/bats-core/releases/tag/v1.0.0, while honoring the same interface as v0.4.0, introduced a few changes that required some cleanup of our Bats utilities:

- bin/bats is no longer a symlink to libexec/bats, and the latter can no longer be invoked directly; hence _GO_BATS_PATH is now set to bin/bats.

- TAP output for skipped tests changed in bats-core/bats-core#19.

- run_bats_test_suite_in_isolation depended upon _GO_ROOTDIR and _GO_BATS_PATH, which led to bats not being able to find its libexec scripts. The bats path is now computed using `command -v bats`, which makes the library itself more portable.

- Some assertion-test-helpers output didn't end with a newline. This prevented the `while` loop used to replace `sed` in bats-core/bats-core#88 from reading the final line of output from the test. While this was fixed in bats-core/bats-core#99, updating the code to always emit newlines was still the right thing to do.

There was a bug in Bats v1.0.0 in setting `BATS_CWD` that broke the "assertion-test-helpers: failing assertion must disable shell options" test case. Specifically, stack trace paths that should've looked like:

  tests/assertion-test-helpers.bash

instead looked like:

  go-script-bash/tests/assertion-test-helpers.bash

This was fixed by bats-core/bats-core#98.