### PR TITLE
Allows users to declare custom aliases

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -322,7 +322,7 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     if [[ " ${GO_ALIAS_EXPAND_CMDS[*]} " == *" $cmd "* ]]; then
       shopt -s expand_aliases
       local -a args
-      eval "$cmd ${@/ /\\\ }"
+      eval "$cmd ${@// /\\\ }"
     else
       "$cmd" "$@"
     fi

--- a/go-core.bash
+++ b/go-core.bash
@@ -320,6 +320,9 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
 
   if _@go.source_builtin 'aliases' --exists "$cmd"; then
     if [[ " ${GO_ALIAS_EXPAND_CMDS[*]} " == *" $cmd "* ]]; then
+      local -a args
+      args="${@/#/\"}"
+      args="${@/%/\"}"
       eval "$cmd" "$@"
     else
       "$cmd" "$@"

--- a/go-core.bash
+++ b/go-core.bash
@@ -319,7 +319,7 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   esac
 
   if _@go.source_builtin 'aliases' --exists "$cmd"; then
-    "$cmd" "$@"
+    eval "$cmd" "$@"
     return
   fi
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -320,9 +320,8 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
 
   if _@go.source_builtin 'aliases' --exists "$cmd"; then
     if [[ " ${GO_ALIAS_EXPAND_CMDS[*]} " == *" $cmd "* ]]; then
+      shopt -s expand_aliases
       local -a args
-      args="${@/#/\"}"
-      args="${@/%/\"}"
       eval "$cmd" "$@"
     else
       "$cmd" "$@"

--- a/go-core.bash
+++ b/go-core.bash
@@ -319,7 +319,11 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   esac
 
   if _@go.source_builtin 'aliases' --exists "$cmd"; then
-    eval "$cmd" "$@"
+    if [[ " ${GO_ALIAS_EXPAND_CMDS[*]} " == *" $cmd "* ]]; then
+      eval "$cmd" "$@"
+    else
+      "$cmd" "$@"
+    fi
     return
   fi
 

--- a/go-core.bash
+++ b/go-core.bash
@@ -322,7 +322,7 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     if [[ " ${GO_ALIAS_EXPAND_CMDS[*]} " == *" $cmd "* ]]; then
       shopt -s expand_aliases
       local -a args
-      eval "$cmd" "$@"
+      eval "$cmd ${@/ /\\\ }"
     else
       "$cmd" "$@"
     fi

--- a/libexec/aliases
+++ b/libexec/aliases
@@ -22,7 +22,13 @@
 # Note that "cd" and "pushd" are only available after you've used "{{go}} env"
 # to set up your shell environment.
 
-declare -r _GO_ALIAS_CMDS=('awk' 'cat' 'cd' 'find' 'grep' 'ls' 'pushd' 'sed')
+declare _GO_ALIAS_CMDS=('awk' 'cat' 'cd' 'find' 'grep' 'ls' 'pushd' 'sed')
+
+if [[ "${GO_ALIAS_CMDS_EXTRA[*]}" != '' ]]; then
+  _GO_ALIAS_CMDS+=( "${GO_ALIAS_CMDS_EXTRA[@]}" )
+fi
+
+readonly _GO_ALIAS_CMDS
 
 _@go.aliases() {
   local c

--- a/libexec/aliases
+++ b/libexec/aliases
@@ -28,6 +28,10 @@ if [[ "${GO_ALIAS_CMDS_EXTRA[*]}" != '' ]]; then
   _GO_ALIAS_CMDS+=( "${GO_ALIAS_CMDS_EXTRA[@]}" )
 fi
 
+if [[ "${GO_ALIAS_EXPAND_CMDS[*]}" != '' ]]; then
+  _GO_ALIAS_CMDS+=( "${GO_ALIAS_EXPAND_CMDS[@]}" )
+fi
+
 readonly _GO_ALIAS_CMDS
 
 _@go.aliases() {

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -6,7 +6,6 @@ create_aliases_test_command_script() {
   @go.create_test_go_script \
     'declare -a GO_ALIAS_CMDS_EXTRA=("nvim")' \
     'declare -a GO_ALIAS_EXPAND_CMDS=("test_echo")' \
-    'shopt -s expand_aliases' \
     'alias test_echo="echo -n test_string_19098e09818fad"' \
     "@go \$@"
 }

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -5,10 +5,13 @@ load environment
 create_aliases_test_command_script() {
   @go.create_test_go_script \
     'declare -a GO_ALIAS_CMDS_EXTRA=("nvim")' \
-    "@go $@"
+    'declare -a GO_ALIAS_EXPAND_CMDS=("test_echo")' \
+    'shopt -s expand_aliases' \
+    'alias test_echo="echo -n test_string_19098e09818fad"' \
+    "@go \$@"
 }
 
-@test "$SUITE: with no arguments, list all aliases" {
+@test "$SUITE: with no arguments, list all predefined aliases" {
   run ./go aliases
   assert_success
   assert_line_equals 0 'awk'  # first alias
@@ -16,11 +19,19 @@ create_aliases_test_command_script() {
 }
 
 @test "$SUITE: list custom aliases if defined" {
-  create_aliases_test_command_script 'aliases'
-  run "$TEST_GO_SCRIPT" aliases
+  create_aliases_test_command_script
+  run "$TEST_GO_SCRIPT" 'aliases'
   assert_success
   assert_line_equals 0 'awk'  # first alias
-  assert_line_equals -1 'nvim'  # last alias
+  assert_line_equals -2 'nvim'  # second to last alias
+  assert_line_equals -1 'test_echo'  # last alias
+}
+
+@test "$SUITE: run expanded aliases if defined" {
+  create_aliases_test_command_script 'aliases'
+  run "$TEST_GO_SCRIPT" 'test_echo'
+  assert_success
+  assert_line_equals 0 'test_string_19098e09818fad'
 }
 
 @test "$SUITE: tab completions" {
@@ -112,7 +123,7 @@ create_aliases_test_command_script() {
 @test "$SUITE: leave help generic for cd, pushd when using env function" {
   # Setting _GO_CMD will trick the script into thinking the shell function is
   # running it.
-  
+
   _GO_CMD='test-go' run ./go aliases --help cd
   [ "$status" -eq '0' ]
 

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -2,11 +2,25 @@
 
 load environment
 
+create_aliases_test_command_script() {
+  @go.create_test_go_script \
+    'declare -a GO_ALIAS_CMDS_EXTRA=("nvim")' \
+    "@go $@"
+}
+
 @test "$SUITE: with no arguments, list all aliases" {
   run ./go aliases
   assert_success
   assert_line_equals 0 'awk'  # first alias
   assert_line_equals -1 'sed'  # last alias
+}
+
+@test "$SUITE: list custom aliases if defined" {
+  create_aliases_test_command_script 'aliases'
+  run "$TEST_GO_SCRIPT" aliases
+  assert_success
+  assert_line_equals 0 'awk'  # first alias
+  assert_line_equals -1 'nvim'  # last alias
 }
 
 @test "$SUITE: tab completions" {


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

This PR adds a `GO_ALIAS_CMDS_EXTRA` array that the user can define to add their own aliases. My use case was that I grew tired of typing `go vim` and failing all the time (instead of `go run vim`).

I also added the ability for "go-script" aliases to be expanded if they are bash aliases.