### PR TITLE
Allows _GO_SCRIPTS_DIR to be equal to _GO_ROOTDIR

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -413,6 +413,15 @@ _@go.set_scripts_dir() {
       "directory" >&2
     return 1
   fi
+
+  # If '_GO_SCRIPTS_DIR' was set to '_GO_ROOTDIR', 'scripts_dir' would end up
+  # with a trailing space. This would cause issues later in the code where path
+  # comparison would fail as paths would result in double slashes before
+  # command script paths.
+  if [[ "${scripts_dir: -1}" == '/' ]]; then
+    scripts_dir="${scripts_dir%/}"
+  fi
+
   _GO_SCRIPTS_DIR="$scripts_dir"
 }
 

--- a/lib/internal/commands
+++ b/lib/internal/commands
@@ -51,8 +51,13 @@ _@go.find_commands() {
   for scripts_dir in "$@"; do
     scripts=()
 
+    # Together with the existence of a potential script, we are also excluding
+    # the './go' itself. This is relevant for the case a user has set
+    # '_GO_SCRIPTS_DIR' to '_GO_ROOTDIR'. In that case, the './go' script would
+    # end up being considered a command script.
     for script in "$scripts_dir"/*; do
-      if [[ -f "$script" && -x "$script" ]]; then
+      if [[ -f "$script" && -x "$script" &&
+        "$script" != "$_GO_ROOTDIR/$_GO_CMD" ]]; then
         scripts+=("$script")
       fi
     done


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

What the title says. This adds flexibility to the structure of projects using `go-script-bash`. 

I had encountered a need to set `_GO_ROOTDIR` to `_GO_SCRIPTS_DIR` while working on [bash-headstart](https://github.com/tterranigma/bash-headstart).