### PR TITLE
Allows custom plugins to pop up during completion with standalone projects

### DIFF
--- a/lib/internal/complete
+++ b/lib/internal/complete
@@ -6,7 +6,11 @@ _@go.complete_top_level_commands() {
     _@go.source_builtin 'commands'
   else
     printf 'help\n'
-    _@go.source_builtin 'commands' "$_GO_SCRIPTS_DIR"
+
+    local plugins_paths
+    printf -v plugins_paths '%s:' "${_GO_PLUGINS_PATHS[@]}"
+    plugins_paths="${plugins_paths%:}"
+    _@go.source_builtin 'commands' "$_GO_SCRIPTS_DIR:$plugins_paths"
   fi
 }
 

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -45,13 +45,13 @@ teardown() {
   assert_failure ''
 }
 
-@test "$SUITE: _GO_STANDALONE only completes 'help' and project scripts" {
+@test "$SUITE: _GO_STANDALONE only completes 'help' and custom scripts/plugins" {
   @go.create_test_command_script 'foo'
   @go.create_test_command_script 'bar'
   @go.create_test_command_script 'plugins/baz/bin/baz'
 
   _GO_STANDALONE='true' run "$TEST_GO_SCRIPT" complete 0
-  assert_success 'help' 'bar' 'foo'
+  assert_success 'help' 'bar' 'baz' 'foo'
 }
 
 @test "$SUITE: cd and pushd complete directories" {


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

When setting `_GO_STANDALONE`, custom plugins are not returned with tab completion. This is counter-intuitive IMHO. Plugins are super convenient to organize code and share it among projects. There is no reason really for such custom code to not be returned as suggested commands to the user, since the purpose of that custom code is 99.9% to be used by the user.