### PR TITLE
Optionally hijacks -h/--help options

### DIFF
--- a/go-core.bash
+++ b/go-core.bash
@@ -289,6 +289,9 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
   if [[ "$_GO_HELP_HIJACK" == 'true' ]] \
     && [[ " $* " == *' -h '* || " $* " == *' --help '* || " $* " == *' -help '* ]]; then
     cmd='help'
+    if [[ "${1-}" == @(-h|-help|--help) && "$#" -gt 0 ]]; then
+      shift
+    fi
   else
     local cmd="${1-}"
     if [[ "$#" -gt 0 ]]; then
@@ -301,13 +304,13 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
       _@go.source_builtin 'help' 1>&2
       return 1
       ;;
+    -h | -help | --help)
+      cmd='help'
+      ;;
     -*)
       @go.printf "Unknown flag: $cmd\n\n"
       _@go.source_builtin 'help' 1>&2
       return 1
-      ;;
-    -h | -help | --help)
-      cmd='help'
       ;;
     edit)
       if [[ -z "$EDITOR" ]]; then

--- a/go-core.bash
+++ b/go-core.bash
@@ -26,8 +26,7 @@
 #           https://mike-bland.com/
 #           https://github.com/mbland
 
-if [[ "${BASH_VERSINFO[0]}" -lt '3' ||
-    ( "${BASH_VERSINFO[0]}" -eq '3' && "${BASH_VERSINFO[1]}" -lt '2' ) ]]; then
+if [[ "${BASH_VERSINFO[0]}" -lt '3' || ("${BASH_VERSINFO[0]}" -eq '3' && "${BASH_VERSINFO[1]}" -lt '2') ]]; then
   printf "This module requires bash version 3.2 or greater:\n  %s %s\n" \
     "$BASH" "$BASH_VERSION"
   exit 1
@@ -222,8 +221,8 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
     skip_callers=0
   fi
 
-  for ((i=$skip_callers + 1; i != ${#FUNCNAME[@]}; ++i)); do
-    printf '  %s:%s %s\n' "${BASH_SOURCE[$i]}" "${BASH_LINENO[$((i-1))]}" \
+  for ((i = $skip_callers + 1; i != ${#FUNCNAME[@]}; ++i)); do
+    printf '  %s:%s %s\n' "${BASH_SOURCE[$i]}" "${BASH_LINENO[$((i - 1))]}" \
       "${FUNCNAME[$i]}"
   done
   return "$result"
@@ -283,39 +282,50 @@ declare _GO_INJECT_MODULE_PATH="$_GO_INJECT_MODULE_PATH"
 #   $1: name of the command to invoke
 #   $2..$#: arguments to the specified command
 @go() {
-  local cmd="$1"
-  shift
+  # Flag to enable/disable hijacking of the '-h' or '--help' options and print
+  # the help for the command given.
+  declare _GO_HELP_HIJACK="${_GO_HELP_HIJACK:-false}"
+
+  if [[ "$_GO_HELP_HIJACK" == 'true' ]] \
+    && [[ " $* " == *' -h '* || " $* " == *' --help '* || " $* " == *' -help '* ]]; then
+    cmd='help'
+  else
+    local cmd="${1-}"
+    if [[ "$#" -gt 0 ]]; then
+      shift
+    fi
+  fi
 
   case "$cmd" in
-  '')
-    _@go.source_builtin 'help' 1>&2
-    return 1
-    ;;
-  -h|-help|--help)
-    cmd='help'
-    ;;
-  -*)
-    @go.printf "Unknown flag: $cmd\n\n"
-    _@go.source_builtin 'help' 1>&2
-    return 1
-    ;;
-  edit)
-    if [[ -z "$EDITOR" ]]; then
-      echo "Cannot edit $@: \$EDITOR not defined."
+    '')
+      _@go.source_builtin 'help' 1>&2
       return 1
-    fi
-    "$EDITOR" "$@"
-    return
-    ;;
-  run)
-    "$@"
-    return
-    ;;
-  cd|pushd|unenv)
-    @go.printf "$cmd is only available after using \"$_GO_CMD env\" %s\n" \
-      "to set up your shell environment." >&2
-    return 1
-    ;;
+      ;;
+    -*)
+      @go.printf "Unknown flag: $cmd\n\n"
+      _@go.source_builtin 'help' 1>&2
+      return 1
+      ;;
+    -h | -help | --help)
+      cmd='help'
+      ;;
+    edit)
+      if [[ -z "$EDITOR" ]]; then
+        echo "Cannot edit $@: \$EDITOR not defined."
+        return 1
+      fi
+      "$EDITOR" "$@"
+      return
+      ;;
+    run)
+      "$@"
+      return
+      ;;
+    cd | pushd | unenv)
+      @go.printf "$cmd is only available after using \"$_GO_CMD env\" %s\n" \
+        "to set up your shell environment." >&2
+      return 1
+      ;;
   esac
 
   if _@go.source_builtin 'aliases' --exists "$cmd"; then
@@ -360,7 +370,7 @@ _@go.run_command_script() {
   shift
 
   local interpreter
-  read -r interpreter < "$cmd_path"
+  read -r interpreter <"$cmd_path"
 
   if [[ "${interpreter:0:2}" != '#!' ]]; then
     @go.printf \
@@ -422,8 +432,8 @@ elif [[ -z "$COLUMNS" ]]; then
   # On Travis, $TERM is set to 'dumb', but `tput cols` still fails.
   if command -v tput >/dev/null && tput cols >/dev/null 2>&1; then
     COLUMNS="$(tput cols)"
-  elif command -v mode.com >/dev/null &&
-    [[ "$(mode.com 'con')" =~ Columns:\ +([0-9]+) ]]; then
+  elif command -v mode.com >/dev/null \
+    && [[ "$(mode.com 'con')" =~ Columns:\ +([0-9]+) ]]; then
     COLUMNS="${BASH_REMATCH[1]}"
   fi
   export COLUMNS="${COLUMNS:-80}"

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -11,6 +11,29 @@ teardown() {
   @go.remove_test_go_rootdir
 }
 
+@test "$SUITE: do not hijack -h/--help by default" {
+  @go.create_test_command_script 'foo' '# Does foo stuff' 'echo foo'
+  run "$TEST_GO_SCRIPT" foo -h
+
+  assert_success
+  assert_output_matches 'foo'
+}
+
+@test "$SUITE: hijack -h/--help when _GO_HELP_HIJACK is enabled" {
+  @go.create_test_command_script 'foo' '# Does foo stuff' 'echo foo'
+
+  export _GO_HELP_HIJACK=true
+  run "$TEST_GO_SCRIPT" foo -h
+
+  assert_success
+  assert_output_matches 'Does foo stuff'
+
+  run "$TEST_GO_SCRIPT" foo --help
+
+  assert_success
+  assert_output_matches 'Does foo stuff'
+}
+
 @test "$SUITE: tab completion" {
   local subcommands=('plugh' 'quux' 'xyzzy')
   @go.create_parent_and_subcommands foo "${subcommands[@]}"

--- a/tests/vars.bats
+++ b/tests/vars.bats
@@ -44,6 +44,7 @@ quotify_expected() {
     "declare -rx _GO_CORE_URL=\"$_GO_CORE_URL\""
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
     "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
+    'declare -- _GO_HELP_HIJACK="false"'
     'declare -a _GO_IMPORTED_MODULES=()'
     'declare -a _GO_IMPORTED_MODULE_CALLERS=()'
     'declare -a _GO_IMPORTED_MODULE_FILES=()'
@@ -118,6 +119,7 @@ quotify_expected() {
     "declare -rx _GO_CORE_URL=\"$_GO_CORE_URL\""
     "declare -rx _GO_CORE_VERSION=\"$_GO_CORE_VERSION\""
     "declare -x _GO_COVERALLS_URL=\"$_GO_COVERALLS_URL\""
+    'declare -- _GO_HELP_HIJACK="false"'
     "declare -a _GO_IMPORTED_MODULES=(${expected_modules[*]})"
     "declare -a _GO_IMPORTED_MODULE_CALLERS=(${expected_module_callers[*]})"
     "declare -a _GO_IMPORTED_MODULE_FILES=(${expected_module_files[*]})"


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

Generally, it is a good practice to have `-h`, `--help` or `-help` print the help for a command. Right now, it is required that every new command that the users create to implement this. This PR adds a flag to enable `go-core.bash` to hijack these options and print the command help whenever they are present.