### PR TITLE
Uses a help tokens array to replace tokens in help text

### DIFF
--- a/libexec/help
+++ b/libexec/help
@@ -116,14 +116,22 @@ _@go.help_message_for_command() {
 
   local filter_pattern='# [Hh]elp [Ff]ilter['$'\n\r'']'
 
-  if [[ "$(< "$__go_cmd_path")" =~ $filter_pattern ]]; then
+  if [[ "$(<"$__go_cmd_path")" =~ $filter_pattern ]]; then
     __go_cmd_desc="$(_@go.run_command_script "$__go_cmd_path" --help-filter \
       "$__go_cmd_desc")"
   fi
 
+  if [[ "$(declare -p _GO_HELP_TOKENS 2>/dev/null || :)" =~ declare\ -A ]]; then
+    for token in "${!_GO_HELP_TOKENS[@]}"; do
+      __go_cmd_desc="${__go_cmd_desc//{{$token\}\}/${_GO_HELP_TOKENS[$token]}}"
+    done
+  fi
+
   if [[ -d "${__go_cmd_path}.d" ]]; then
-    __go_cmd_desc+="$(printf '\nSubcommands:\n\n'; \
-      _@go.source_builtin 'commands' --summaries "${__go_cmd_path}.d")"
+    __go_cmd_desc+="$(
+      printf '\nSubcommands:\n\n'
+      _@go.source_builtin 'commands' --summaries "${__go_cmd_path}.d"
+    )"
   fi
   @go.printf "$_GO_CMD $cmd_name - $__go_cmd_desc\n"
 }

--- a/libexec/help
+++ b/libexec/help
@@ -53,6 +53,17 @@
 # values, to keep the text in sync automatically. It's good practice to parse
 # tokens within `{{` and `}}` as is common with templating engines, but it's not
 # enforced.
+#
+# An alternative way to perform token replacement (for Bash version >= 4) is to
+# use the _GO_HELP_TOKENS associative array. The index of an item is the token
+# to be searched and replaced and the value of the item is the replacement
+# value. For instance:
+#
+#   declare -A _GO_HELP_TOKENS=([project_dir]=~/Projects/my-project)
+#
+# will replace 'project_dir' in the help text with '~/Projects/my-project'. By
+# default, this array is empty and you will have to declare it and add tokens to
+# it.
 
 _@go.usage() {
   local cmd_paths=("$_GO_SCRIPTS_DIR")

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -168,6 +168,36 @@ teardown() {
   assert_success "${expected[@]}"
 }
 
+@test "$SUITE: replace help tokens using _GO_HELP_TOKENS" {
+  if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    skip
+  fi
+
+  local cmd_script=(
+    '#'
+    '# Does foo stuff'
+    '#'
+    '# Usage: {{go}} {{cmd}} <{{FOO_VALID_ARGS}}>'
+    ''
+    'declare -r FOO_VALID_ARGS=("bar" "baz" "quux")'
+    ''
+  )
+  @go.create_test_command_script 'foo' "${cmd_script[@]}"
+
+  @go.create_test_go_script \
+    "declare -gA _GO_HELP_TOKENS=(['FOO_VALID_ARGS']='bar|baz|quux')" \
+    '@go "$@"'
+
+
+  run "$TEST_GO_SCRIPT" help foo
+
+  local expected=(
+    "$TEST_GO_SCRIPT foo - Does foo stuff"
+    ''
+    "Usage: $TEST_GO_SCRIPT foo <bar|baz|quux>")
+  assert_success "${expected[@]}"
+}
+
 @test "$SUITE: add subcommand summaries" {
   local cmd_template=$'# Does {{CMD}} stuff\n'
   cmd_template+=$'#\n'


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

The `--help-filter` option and the `# Help filter` comment is too much for the user for sth that they may need to implement in every command script they write. Also, it limits a bit some use cases, for instance using [docopts](https://github.com/docopt/docopts) together with go-script-bash. 

This PR adds a new associative array `_GO_HELP_TOKENS`. Each item in the array is a token=>replacement pair and go-script-bash automatically performs any replacements when generating the help text. This is complementary to the `--help-filter` method, which is compatible with old bash versions.