### PR TITLE
Allows users to set their own tab completions pattern

### DIFF
--- a/libexec/complete
+++ b/libexec/complete
@@ -36,6 +36,9 @@
 # scripts, your script must contain a `# Tab completions` comment and respond to
 # the `--complete` command line interface described above.
 #
+# - You can change the `# Tab completions` hint to a different pattern using the
+# GO_TAB_COMPLETIONS_PATTERN variable.
+#
 # - The argument list must/will always contain at least one element, even if
 # it is the empty string, which represents the user completing an argument
 # without typing anything first. Take this into account when implementing
@@ -51,7 +54,14 @@ _@go.complete_command() {
   local __go_complete_word_index
   local __go_cmd_path
   local __go_argv
-  local tab_completions_pattern='# [Tt]ab [Cc]ompletions['$'\n\r'']'
+  local tab_completions_pattern
+
+  local default_pattern='# [Tt]ab [Cc]ompletions['$'\n\r'']'
+  if [[ "${GO_TAB_COMPLETIONS_PATTERN-__undefined__}" == '__undefined__' ]]; then
+    tab_completions_pattern="$default_pattern"
+  else
+    tab_completions_pattern="$GO_TAB_COMPLETIONS_PATTERN"
+  fi
 
   . "$_GO_CORE_DIR/lib/internal/complete"
   exec 2>/dev/null

--- a/tests/complete.bats
+++ b/tests/complete.bats
@@ -140,6 +140,25 @@ teardown() {
   assert_failure ''
 }
 
+@test "$SUITE: change tab completion patter" {
+  @go.create_test_go_script \
+    'GO_TAB_COMPLETIONS_PATTERN="# New tab completions pattern"' \
+    '@go "$@"'
+
+  @go.create_test_command_script foo \
+    'if [[ "$1" == "--complete" ]]; then ' \
+    '  # New tab completions pattern' \
+    '  echo "bar" "baz" "quux"' \
+    'fi'
+
+  run "$TEST_GO_SCRIPT" complete 0 foo
+  assert_success 'foo '
+
+  local expected=('bar' 'baz' 'quux')
+  run "$TEST_GO_SCRIPT" complete 1 foo ''
+  assert_success "${expected[@]}"
+}
+
 @test "$SUITE: command script completion not detected without comment" {
   @go.create_test_command_script foo \
     'if [[ "$1" == "--complete" ]]; then ' \


### PR DESCRIPTION
- [x] I have reviewed the [contributor guidelines][contrib].
- [x] I have reviewed the [code of conduct][conduct].
- [x] Per [GitHub's Terms of Service][gh-tos], I am aware that I license my
  contribution under the same terms as [this project's license][license], and
  that I have the right to license my contribution under those terms.

[contrib]: https://github.com/mbland/go-script-bash/blob/master/CONTRIBUTING.md
[conduct]: https://github.com/mbland/go-script-bash/blob/master/CODE_OF_CONDUCT.md
[gh-tos]:  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
[license]: https://github.com/mbland/go-script-bash/blob/master/LICENSE.md

cc: @mbland

I am using docopts to have argument handling based on the help text of my scripts. This allows me to not effectively duplicate myself all over the place. I have also setup tab completion generations for all my scripts. It is redundant for me to write `# Tab completions` somewhere in each script.

This PR allows the user to define their own tab completions pattern. This way they can place the hint in the script help (eg have a line that reads `# This command supports tab completion`), set it to `''` which means that tab completions are enabled for all scripts, etc.